### PR TITLE
virt: Repair multi-host migration framework.

### DIFF
--- a/virttest/utils_test.py
+++ b/virttest/utils_test.py
@@ -647,6 +647,7 @@ class MultihostMigration(object):
         @param mig_data: object with migration data.
         """
         for vm in mig_data.vms:
+            vm.monitor.cmd("cont")
             if not guest_active(vm):
                 raise error.TestFail("Guest not active after migration")
 


### PR DESCRIPTION
There was problem with qemu parameter -S.

Signed-off-by: Jiří Župka jzupka@redhat.com
