### PR TITLE
virt: Adds support for cancel migration in multi-host tests.

### DIFF
--- a/kvm/tests/migration_multi_host.py
+++ b/kvm/tests/migration_multi_host.py
@@ -1,4 +1,6 @@
-from virttest import utils_test
+import logging, os
+from autotest.client.shared import error
+from virttest import utils_test, remote, virt_vm, utils_misc
 
 
 def run_migration_multi_host(test, params, env):
@@ -15,13 +17,77 @@ def run_migration_multi_host(test, params, env):
     class TestMultihostMigration(utils_test.MultihostMigration):
         def __init__(self, test, params, env):
             super(TestMultihostMigration, self).__init__(test, params, env)
+            self.srchost = self.params.get("hosts")[0]
+            self.dsthost = self.params.get("hosts")[1]
+            self.vms = params.get("vms").split()
+
+
+        def migration_scenario(self, worker=None):
+            self.migrate_wait(self.vms, self.srchost, self.dsthost,
+                              start_work=worker)
+
+
+    class TestMultihostMigrationCancel(TestMultihostMigration):
+        def __init__(self, test, params, env):
+            super(TestMultihostMigrationCancel, self).__init__(test, params,
+                                                               env)
+            self.install_path = params.get("cpuflags_install_path", "/tmp")
+            self.vm_mem = int(params.get("mem", "512"))
+            self.srchost = self.params.get("hosts")[0]
+            self.dsthost = self.params.get("hosts")[1]
+            self.vms = params.get("vms").split()
+            self.id = {'src': self.srchost,
+                       'dst': self.dsthost,
+                       "type": "cancel_migration"}
+
+        def check_guest(self):
+            broken_vms = []
+            for vm in self.vms:
+                try:
+                    vm = env.get_vm(vm)
+                    session = vm.wait_for_login(timeout=self.login_timeout)
+                    session.sendline("killall -9 cpuflags-test")
+                except (remote.LoginError, virt_vm.VMError):
+                    broken_vms.append(vm)
+            if broken_vms:
+                raise error.TestError("VMs %s should work on src"
+                                      " host after canceling of"
+                                      " migration." % (broken_vms))
+            # Try migration again without cancel.
 
         def migration_scenario(self):
-            srchost = self.params.get("hosts")[0]
-            dsthost = self.params.get("hosts")[1]
-            vms = params.get("vms").split()
+            def worker(mig_data):
+                vm = mig_data.vms[0]
+                session = vm.wait_for_login(timeout=self.login_timeout)
 
-            self.migrate_wait(vms, srchost, dsthost)
+                utils_misc.install_cpuflags_util_on_vm(test, vm,
+                                                       self.install_path,
+                                                   extra_flags="-msse3 -msse2")
 
-    mig = TestMultihostMigration(test, params, env)
+                cmd = ("%s/cpuflags-test --stressmem %d %%" %
+                           (os.path.join(self.install_path, "test_cpu_flags"),
+                            self.vm_mem / 2))
+                logging.debug("Sending command: %s" % (cmd))
+                session.sendline(cmd)
+
+            super_cls = super(TestMultihostMigrationCancel, self)
+            super_cls.migration_scenario(worker)
+
+            if params.get("hostid") == self.master_id():
+                self.check_guest()
+
+            self._hosts_barrier(self.hosts, self.id,
+                                'wait_for_cancel', self.login_timeout)
+
+            params["cancel_delay"] = None
+            super(TestMultihostMigrationCancel, self).migration_scenario()
+
+
+    mig = None
+    cancel_delay = params.get("cancel_delay", None)
+    if cancel_delay is None:
+        mig = TestMultihostMigration(test, params, env)
+    else:
+        mig = TestMultihostMigrationCancel(test, params, env)
+
     mig.run()

--- a/kvm/tests/migration_multi_host_fd.py
+++ b/kvm/tests/migration_multi_host_fd.py
@@ -1,6 +1,8 @@
 import logging, socket, time, errno, os, fcntl
-from virttest import utils_test, utils_misc
+from virttest import utils_test, utils_misc, remote, virt_vm
+from autotest.client.shared import error
 from autotest.client.shared.syncdata import SyncData
+
 
 def run_migration_multi_host_fd(test, params, env):
     """
@@ -28,8 +30,12 @@ def run_migration_multi_host_fd(test, params, env):
             re implement this method.
             """
             logging.info("Start migrating now...")
+            cancel_delay = mig_data.params.get("cancel_delay")
+            if cancel_delay is not None:
+                cancel_delay = int(cancel_delay)
             vm = mig_data.vms[0]
             vm.migrate(dest_host=mig_data.dst,
+                       cancel_delay=cancel_delay,
                        protocol="fd",
                        fd_src=mig_data.params['migration_fd'])
 
@@ -74,7 +80,7 @@ def run_migration_multi_host_fd(test, params, env):
             sock.listen(1)
             return sock
 
-        def migration_scenario(self):
+        def migration_scenario(self, worker=None):
             srchost = self.params.get("hosts")[0]
             dsthost = self.params.get("hosts")[1]
             mig_port = None
@@ -120,5 +126,68 @@ def run_migration_multi_host_fd(test, params, env):
                 finally:
                     s.close()
 
-    mig = TestMultihostMigrationFd(test, params, env)
+
+    class TestMultihostMigrationCancel(TestMultihostMigrationFd):
+        def __init__(self, test, params, env):
+            super(TestMultihostMigrationCancel, self).__init__(test, params,
+                                                               env)
+            self.install_path = params.get("cpuflags_install_path", "/tmp")
+            self.vm_mem = int(params.get("mem", "512"))
+            self.srchost = self.params.get("hosts")[0]
+            self.dsthost = self.params.get("hosts")[1]
+            self.vms = params.get("vms").split()
+            self.id = {'src': self.srchost,
+                       'dst': self.dsthost,
+                       "type": "cancel_migration"}
+
+        def check_guest(self):
+            broken_vms = []
+            for vm in self.vms:
+                try:
+                    vm = env.get_vm(vm)
+                    session = vm.wait_for_login(timeout=self.login_timeout)
+                    session.sendline("killall -9 cpuflags-test")
+                except (remote.LoginError, virt_vm.VMError):
+                    broken_vms.append(vm)
+            if broken_vms:
+                raise error.TestError("VMs %s should work on src"
+                                      " host after canceling of"
+                                      " migration." % (broken_vms))
+            # Try migration again without cancel.
+
+        def migration_scenario(self):
+            def worker(mig_data):
+                vm = mig_data.vms[0]
+                session = vm.wait_for_login(timeout=self.login_timeout)
+
+                utils_misc.install_cpuflags_util_on_vm(test, vm,
+                                                       self.install_path,
+                                                   extra_flags="-msse3 -msse2")
+
+                cmd = ("%s/cpuflags-test --stressmem %d %%" %
+                           (os.path.join(self.install_path, "test_cpu_flags"),
+                            self.vm_mem / 2))
+                logging.debug("Sending command: %s" % (cmd))
+                session.sendline(cmd)
+
+            super_cls = super(TestMultihostMigrationCancel, self)
+            super_cls.migration_scenario(worker)
+
+            if params.get("hostid") == self.master_id():
+                self.check_guest()
+
+            self._hosts_barrier(self.hosts, self.id,
+                                'wait_for_cancel', self.login_timeout)
+
+            params["cancel_delay"] = None
+            super(TestMultihostMigrationCancel, self).migration_scenario()
+
+
+    mig = None
+    cancel_delay = params.get("cancel_delay", None)
+    if cancel_delay is None:
+        mig = TestMultihostMigrationFd(test, params, env)
+    else:
+        mig = TestMultihostMigrationCancel(test, params, env)
+
     mig.run()

--- a/shared/cfg/subtests.cfg.sample
+++ b/shared/cfg/subtests.cfg.sample
@@ -973,7 +973,7 @@ variants:
                 kill_vm_on_error = yes
                 iterations = 2
                 used_mem = 1024
-                mig_timeout = 4800
+                mig_timeout = 480
                 disk_prepare_timeout = 360
                 comm_port = 13234
                 regain_ip_cmd = killall dhclient; sleep 10; dhclient;
@@ -989,6 +989,27 @@ variants:
                                 type = migration_multi_host_with_speed_measurement
                     -fd:
                         type = migration_multi_host_fd
+
+                variants:
+                    # Time when start migration
+                    - after_login_vm:
+                        paused_after_start_vm = no
+                    - early_boot_vm:
+                        no measure_migration_speed
+                        login_timeout = 420
+                        paused_after_start_vm = yes
+                        variants:
+                            -timeout_0:
+                                start_migration_timeout = 0
+                            -timeout_6:
+                                start_migration_timeout = 6
+
+                variants:
+                    # Migration cancel
+                    - @no_cancel:
+                    - cancel_with_delay:
+                        no measure_migration_speed
+                        cancel_delay = 10
 
             - migration_multi_host_with_file_transfer: install setup image_copy unattended_install.cdrom
                 type = migration_multi_host_with_file_transfer

--- a/virttest/utils_test.py
+++ b/virttest/utils_test.py
@@ -510,14 +510,18 @@ class MultihostMigration(object):
         For change way how machine migrates is necessary
         re implement this method.
         """
-        def mig_wrapper(vm, dsthost, vm_ports):
-            vm.migrate(dest_host=dsthost, remote_port=vm_ports[vm.name])
+        def mig_wrapper(vm, cancel_delay, dsthost, vm_ports):
+            vm.migrate(cancel_delay=cancel_delay, dest_host=dsthost,
+                       remote_port=vm_ports[vm.name])
 
         logging.info("Start migrating now...")
+        cancel_delay = mig_data.params.get("cancel_delay")
+        if cancel_delay is not None:
+            cancel_delay = int(cancel_delay)
         multi_mig = []
         for vm in mig_data.vms:
-            multi_mig.append((mig_wrapper, (vm, mig_data.dst,
-                                            mig_data.vm_ports)))
+            multi_mig.append((mig_wrapper, (vm, cancel_delay,
+                                            mig_data.dst, mig_data.vm_ports)))
         utils_misc.parallel(multi_mig)
 
 
@@ -710,6 +714,7 @@ class MultihostMigration(object):
             error = None
             mig_data = MigrationData(self.params, srchost, dsthost,
                                      vms_name, params_append)
+            cancel_delay = self.params.get("cancel_delay", None)
             try:
                 try:
                     if mig_data.is_src():
@@ -726,21 +731,21 @@ class MultihostMigration(object):
                     self.migrate_vms(mig_data)
 
                     timeout = 30
-                    if not mig_data.is_src():
-                        timeout = self.mig_timeout
-                    self._hosts_barrier(mig_data.hosts, mig_data.mig_id,
-                                        'mig_finished', timeout)
+                    if cancel_delay is None:
+                        if (not mig_data.is_src()):
+                            timeout = self.mig_timeout
+                        self._hosts_barrier(mig_data.hosts, mig_data.mig_id,
+                                            'mig_finished', timeout)
 
-                    if mig_data.is_dst():
-                        self.check_vms(mig_data)
-                        if check_work:
-                            check_work(mig_data)
-
+                        if mig_data.is_dst():
+                            self.check_vms(mig_data)
+                            if check_work:
+                                check_work(mig_data)
                 except:
                     error = True
                     raise
             finally:
-                if not error:
+                if not error and cancel_delay is None:
                     self._hosts_barrier(self.hosts,
                                         mig_data.mig_id,
                                         'test_finihed',


### PR DESCRIPTION
1) Start migration with stressed VM.
2) Wait cancel_delay and then cancel migration.
3) Check if machine is alive on source host.
4) Stop stress of VM.
5) Migrate machine again.
6) Check if machine is alive on destination host.

Signed-off-by: Jiří Župka jzupka@redhat.com
