### PR TITLE
cfg: FIX: virtio_console subtest variant must have unique name

### DIFF
--- a/shared/cfg/subtests.cfg.sample
+++ b/shared/cfg/subtests.cfg.sample
@@ -2273,7 +2273,7 @@ variants:
                                         virtio_console_test = migrate_offline
                                     - online:
                                         virtio_console_test = migrate_online
-                            - reboot:
+                            - restart:
                                 virtio_console_method = shell
                                 variants:
                                     - stressed:


### PR DESCRIPTION
The reboot variant is also test name. This leads to automatical runs
of this test when reboot test is specified. Changing this variant name
to reset should fix this issue.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
