### PR TITLE
virtio_console: Mark 2 tests only for virtserialport

### DIFF
--- a/shared/cfg/subtests.cfg.sample
+++ b/shared/cfg/subtests.cfg.sample
@@ -2533,15 +2533,21 @@ variants:
                                 only Linux
                                 virtio_console_test = lseek
                             - rw_host_offline:
+                                # console is always connected to underneath virtserialport.
+                                only virtserialport
                                 virtio_console_test = rw_host_offline
                             - rw_host_offline_big_data:
                                 only Linux
+                                # console is always connected to underneath virtserialport.
+                                only virtserialport
                                 virtio_console_test = rw_host_offline_big_data
                             - rw_blocking_mode:
                                 only Linux
                                 virtio_console_test = rw_blocking_mode
                             - rw_nonblocking_mode:
                                 only Linux
+                                # console uses blocking mode to connect to underneath virtserialport.
+                                only virtserialport
                                 virtio_console_test = rw_nonblocking_mode
                             - basic_loopback:
                                 virtio_console_test = basic_loopback


### PR DESCRIPTION
virtconsole uses virtserialport and creates console on top of it.
It creates an additional layer between the port and the user
and as the result it handles certain things differently, like
Non-blocking mode and not-connected-host are situations, which are
not handled and there is currently no plan of when and how it will
be handled as console is always connected to virtserialport and
console always uses blocking mode to talk to virtserialport.
That's why it doesn't make sense to run tests and pretend it
should act as virtserialport.

Regards,
Lukáš Doktor
