### PR TITLE
tools.checkpatch: Make checkpatch work under submodule directory

### DIFF
--- a/tools/check_patch.py
+++ b/tools/check_patch.py
@@ -65,7 +65,7 @@ class VCS(object):
     def guess_vcs_name(self):
         if os.path.isdir(".svn"):
             return "SVN"
-        elif os.path.isdir(".git"):
+        elif os.path.exists(".git"):
             return "git"
         else:
             logging.error("Could not figure version control system. Are you "
@@ -366,8 +366,7 @@ class FileChecker(object):
         self.check_exceptions = ['client/tests/virt/kvm/tests/stepmaker.py']
 
         if self.is_python:
-            logging.debug("Checking file %s",
-                          self.path.replace("./", "autotest/"))
+            logging.debug("Checking file %s", self.path)
         if self.is_python and not self.path.endswith(".py"):
             self.bkp_path = "%s-cp.py" % self.path
             shutil.copyfile(self.path, self.bkp_path)


### PR DESCRIPTION
I had a problem to run checkpatch under virttest submodule as .git is only a file with the link to the actual .git directory. git and other tools seems to work properly.

To notify the user, that not whole autotest is tested I removed the `replace('./', 'autotest')`.

I tested this on pull request 98, 99 and with '-f' successfully.
