### PR TITLE
Allow virsh.define()&undefine() to raise error.

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -185,7 +185,12 @@ class VM(virt_vm.BaseVM):
         """
         Undefine the VM.
         """
-        return virsh.undefine(self.name, uri=self.connect_uri)
+        try:
+            virsh.undefine(self.name, uri=self.connect_uri)
+        except error.CmdError, detail:
+            logging.error("Undefine VM %s failed:\n%s", name, detail)
+            return False
+        return True
 
 
     def define(self, xml_file):
@@ -195,7 +200,12 @@ class VM(virt_vm.BaseVM):
         if not os.path.exists(xml_file):
             logging.error("File %s not found." % xml_file)
             return False
-        return virsh.define(xml_file, uri=self.connect_uri)
+        try:
+            virsh.define(xml_file, uri=self.connect_uri)
+        except error.CmdError, detail:
+            logging.error("Define VM from %s failed:\n%s", xml_file, detail)
+            return False
+        return True
 
 
     def state(self):

--- a/virttest/libvirt_xml.py
+++ b/virttest/libvirt_xml.py
@@ -305,7 +305,7 @@ class VMXML(VMXMLBase):
 
     def undefine(self):
         """Undefine this VM with libvirt retaining XML in instance"""
-        # Allow any exceptions to propigate up
+        # Use remove_domain to confirm vm is down before undefine
         self.__virsh__.remove_domain(self.vm_name)
 
 

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -785,13 +785,9 @@ def define(xml_path, **dargs):
     @return: True operation was successful
     """
     dargs['ignore_status'] = False
-    try:
-        command("define --file %s" % xml_path, **dargs)
-        logging.debug("defined VM %s", name)
-        return True
-    except error.CmdError:
-        logging.error("Define %s failed.", xml_path)
-        return False
+    cmd = "define --file %s" % xml_path
+    logging.debug("Define VM from %s", xml_path)
+    return command(cmd, **dargs)
 
 
 def undefine(name, **dargs):
@@ -803,13 +799,9 @@ def undefine(name, **dargs):
     @return: True operation was successful
     """
     dargs['ignore_status'] = False
-    try:
-        command("undefine %s" % (name), **dargs)
-        logging.debug("undefined VM %s", name)
-        return True
-    except error.CmdError, detail:
-        logging.error("undefine VM %s failed:\n%s", name, detail)
-        return False
+    cmd = "undefine %s" % name
+    logging.debug("Undefine VM %s", name)
+    return command(cmd, **dargs)
 
 
 def remove_domain(name, **dargs):
@@ -823,7 +815,11 @@ def remove_domain(name, **dargs):
     if domain_exists(name, **dargs):
         if is_alive(name, **dargs):
             destroy(name, **dargs)
-        undefine(name, **dargs)
+        try:
+            undefine(name, **dargs)
+        except error.CmdError, detail:
+            logging.error("Undefine VM %s failed:\n%s", name, detail)
+            return False
     return True
 
 


### PR DESCRIPTION
Old virsh.define()&undefine() will only return True&False.
It's not flexible if we need to test error_test.

Now it returns the result struct for more use.
That means we should catch error.CmdError out of it.
