### PR TITLE
virt: Adds new type of multi_host migration

### DIFF
--- a/kvm/tests/migration_multi_host.py
+++ b/kvm/tests/migration_multi_host.py
@@ -19,6 +19,8 @@ def run_migration_multi_host(test, params, env):
     base_class = utils_test.MultihostMigration
     if mig_protocol == "fd":
         base_class = utils_test.MultihostMigrationFd
+    if mig_protocol == "exec":
+        base_class = utils_test.MultihostMigrationExec
 
     class TestMultihostMigration(base_class):
         def __init__(self, test, params, env):

--- a/kvm/tests/migration_multi_host_cancel.py
+++ b/kvm/tests/migration_multi_host_cancel.py
@@ -21,6 +21,8 @@ def run_migration_multi_host_cancel(test, params, env):
     base_class = utils_test.MultihostMigration
     if mig_protocol == "fd":
         base_class = utils_test.MultihostMigrationFd
+    if mig_protocol == "exec":
+        base_class = utils_test.MultihostMigrationExec
 
 
     class TestMultihostMigrationCancel(base_class):
@@ -63,9 +65,9 @@ def run_migration_multi_host_cancel(test, params, env):
                                                        self.install_path,
                                                    extra_flags="-msse3 -msse2")
 
-                cmd = ("%s/cpuflags-test --stressmem %d %%" %
+                cmd = ("%s/cpuflags-test --stressmem %d,%d %%" %
                            (os.path.join(self.install_path, "test_cpu_flags"),
-                            self.vm_mem / 2))
+                            self.vm_mem * 10, self.vm_mem / 2))
                 logging.debug("Sending command: %s" % (cmd))
                 session.sendline(cmd)
 

--- a/kvm/tests/migration_multi_host_ping_pong.py
+++ b/kvm/tests/migration_multi_host_ping_pong.py
@@ -32,6 +32,8 @@ def run_migration_multi_host_ping_pong(test, params, env):
     base_class = utils_test.MultihostMigration
     if mig_protocol == "fd":
         base_class = utils_test.MultihostMigrationFd
+    if mig_protocol == "exec":
+        base_class = utils_test.MultihostMigrationExec
 
     class TestMultihostMigration(base_class):
         def __init__(self, test, params, env):
@@ -159,7 +161,7 @@ def run_migration_multi_host_ping_pong(test, params, env):
                                                        self.install_path,
                                                    extra_flags="-msse3 -msse2")
 
-                cmd = ("nohup %s/cpuflags-test --stressmem %d 32"
+                cmd = ("nohup %s/cpuflags-test --stressmem %d,32"
                        " > %s &" %
                            (os.path.join(self.install_path, "test_cpu_flags"),
                             self.stress_memory,

--- a/kvm/tests/migration_multi_host_with_file_transfer.py
+++ b/kvm/tests/migration_multi_host_with_file_transfer.py
@@ -49,6 +49,8 @@ def run_migration_multi_host_with_file_transfer(test, params, env):
     base_class = utils_test.MultihostMigration
     if mig_protocol == "fd":
         base_class = utils_test.MultihostMigrationFd
+    if mig_protocol == "exec":
+        base_class = utils_test.MultihostMigrationExec
 
     guest_root = params.get("guest_root", "root")
     guest_pass = params.get("password", "123456")

--- a/kvm/tests/migration_multi_host_with_speed_measurement.py
+++ b/kvm/tests/migration_multi_host_with_speed_measurement.py
@@ -29,6 +29,8 @@ def run_migration_multi_host_with_speed_measurement(test, params, env):
     base_class = utils_test.MultihostMigration
     if mig_protocol == "fd":
         base_class = utils_test.MultihostMigrationFd
+    if mig_protocol == "exec":
+        base_class = utils_test.MultihostMigrationExec
 
     install_path = params.get("cpuflags_install_path", "/tmp")
 
@@ -123,8 +125,9 @@ def run_migration_multi_host_with_speed_measurement(test, params, env):
                 utils_misc.install_cpuflags_util_on_vm(test, vm, install_path,
                                                     extra_flags="-msse3 -msse2")
 
-                cmd = ("%s/cpuflags-test --stressmem %d" %
-                    (os.path.join(install_path, "test_cpu_flags"), vm_mem / 2))
+                cmd = ("%s/cpuflags-test --stressmem %d,%d" %
+                    (os.path.join(install_path, "test_cpu_flags"),
+                     vm_mem * 4, vm_mem / 2))
                 logging.debug("Sending command: %s" % (cmd))
                 session.sendline(cmd)
 

--- a/kvm/tests/migration_with_speed_measurement.py
+++ b/kvm/tests/migration_with_speed_measurement.py
@@ -83,8 +83,9 @@ def run_migration_with_speed_measurement(test, params, env):
 
         vm.monitor.migrate_set_speed(mig_speed)
 
-        cmd = ("%s/cpuflags-test --stressmem %d" %
-                (os.path.join(install_path, "test_cpu_flags"), vm_mem / 2))
+        cmd = ("%s/cpuflags-test --stressmem %d,%d" %
+                (os.path.join(install_path, "test_cpu_flags"),
+                 vm_mem * 4, vm_mem / 2))
         logging.debug("Sending command: %s" % (cmd))
         session.sendline(cmd)
 

--- a/shared/cfg/subtests.cfg.sample
+++ b/shared/cfg/subtests.cfg.sample
@@ -1396,6 +1396,8 @@ variants:
                         mig_protocol = "tcp"
                     -fd:
                         mig_protocol = "fd"
+                    -exec:
+                        mig_protocol = "exec"
 
                 variants:
                     #Time when start migration
@@ -1412,16 +1414,24 @@ variants:
                                 start_migration_timeout = 6
 
                 variants:
+                    -mig_online:
+                        mig_offline = no
+                    -mig_offline:
+                        mig_offline = yes
+
+                variants:
                     # Migration properties
                     - @default:
                         type = migration_multi_host
                     - cancel_with_delay:
                         type = migration_multi_host_cancel
                         only after_login_vm
+                        only mig_online
                         cancel_delay = 10
                     - measure_speed:
                         only Linux
                         only after_login_vm
+                        only mig_online
                         not_wait_for_migration = yes
                         mig_speed = 1G
                         type = migration_multi_host_with_speed_measurement
@@ -1429,6 +1439,7 @@ variants:
                         only Linux
                         only after_login_vm
                         type = migration_multi_host_with_file_transfer
+                        only mig_online
                         comm_port = 13234
                         #path where file is stored on guest.
                         guest_path = "/tmp/file"
@@ -1442,6 +1453,7 @@ variants:
                     - downtime:
                         only after_login_vm
                         sub_type = downtime
+                        only mig_online
                         # downtime in seconds.
                         max_downtime = 10
                         not_wait_for_migration = yes
@@ -1449,6 +1461,7 @@ variants:
                     - speed:
                         only after_login_vm
                         sub_type = speed
+                        only mig_online
                         # speed in Mb
                         min_migration_speed = 10M
                         max_migration_speed = 500M
@@ -1464,6 +1477,7 @@ variants:
                         # amount of memory shouldn't be too high otherwise
                         # migration will never end
                         only after_login_vm
+                        only mig_online
                         type = migration_multi_host_ping_pong
                         # stress_memory should be less than troughput of
                         # migration
@@ -1480,6 +1494,11 @@ variants:
                                 stress_type = disk
                             - all:
                                 stress_type = all
+                    - host_mig_offline:
+                        only exec
+                        only mig_offline
+                        host_mig_offline = yes
+                        type = migration_multi_host
 
             - cpuflags_multi_host:
                 type = cpuflags

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -107,7 +107,8 @@ def preprocess_vm(test, params, env, name):
             # Start the VM (or restart it if it's already up)
             vm.create(name, params, test.bindir,
                       migration_mode=params.get("migration_mode"),
-                      migration_fd=params.get("migration_fd"))
+                      migration_fd=params.get("migration_fd"),
+                      migration_exec_cmd=params.get("migration_exec_cmd_dst"))
             # Update mac and IP info for assigned device
             # NeedFix: Can we find another way to get guest ip?
             if params.get("mac_changeable") == "yes":

--- a/virttest/kvm_vm.py
+++ b/virttest/kvm_vm.py
@@ -2339,7 +2339,8 @@ class VM(virt_vm.BaseVM):
                 cancel_delay=None, offline=False, stable_check=False,
                 clean=True, save_path="/tmp", dest_host="localhost",
                 remote_port=None, not_wait_for_migration=False,
-                fd_src=None, fd_dst=None,):
+                fd_src=None, fd_dst=None, migration_exec_cmd_src=None,
+                migration_exec_cmd_dst=None):
         """
         Migrate the VM.
 
@@ -2366,6 +2367,12 @@ class VM(virt_vm.BaseVM):
                      VM write data. Descriptor is closed during the migration.
         @param fd_d: File descriptor for migration from which destination
                      VM read data.
+        @param migration_exec_cmd_src: Command to embed in '-incoming "exec: "'
+                (e.g. 'exec:gzip -c > filename') if migration_mode is 'exec'
+                default to listening on a random TCP port
+        @param migration_exec_cmd_dst: Command to embed in '-incoming "exec: "'
+                (e.g. 'gzip -c -d filename') if migration_mode is 'exec'
+                default to listening on a random TCP port
         """
         if protocol not in self.MIGRATION_PROTOS:
             raise virt_vm.VMMigrateProtoUnsupportedError
@@ -2436,7 +2443,8 @@ class VM(virt_vm.BaseVM):
                 extra_params = clone.params.get("extra_params", "") + " -S"
                 clone.params["extra_params"] = extra_params
             clone.create(migration_mode=protocol, mac_source=self,
-                         migration_fd=fd_dst)
+                         migration_fd=fd_dst,
+                         migration_exec_cmd=migration_exec_cmd_dst)
             if fd_dst:
                 os.close(fd_dst)
             error.context()
@@ -2507,11 +2515,14 @@ class VM(virt_vm.BaseVM):
             elif protocol == "unix":
                 uri = "unix:%s" % clone.migration_file
             elif protocol == "exec":
-                uri = '"exec:nc localhost %s"' % clone.migration_port
+                if local:
+                    uri = '"exec:nc localhost %s"' % clone.migration_port
+                else:
+                    uri = '"exec:%s"' % (migration_exec_cmd_src)
             elif protocol == "fd":
                 uri = "fd:%s" % mig_fd_name
 
-            if offline:
+            if offline == True:
                 self.monitor.cmd("stop")
 
             logging.info("Migrating to %s", uri)

--- a/virttest/utils_test.py
+++ b/virttest/utils_test.py
@@ -501,8 +501,8 @@ class MultihostMigration(object):
         raise NotImplementedError
 
 
-    def post_migration(self, vm, cancel_delay, dsthost, vm_ports,
-                             not_wait_for_migration, fd):
+    def post_migration(self, vm, cancel_delay, mig_offline, dsthost, vm_ports,
+                             not_wait_for_migration, fd, mig_data):
         pass
 
 
@@ -516,13 +516,14 @@ class MultihostMigration(object):
         re implement this method.
         """
         def mig_wrapper(vm, cancel_delay, dsthost, vm_ports,
-                        not_wait_for_migration):
-            vm.migrate(cancel_delay=cancel_delay, dest_host=dsthost,
-                       remote_port=vm_ports[vm.name],
+                        not_wait_for_migration, mig_offline, mig_data):
+            vm.migrate(cancel_delay=cancel_delay, offline=mig_offline,
+                       dest_host=dsthost, remote_port=vm_ports[vm.name],
                        not_wait_for_migration=not_wait_for_migration)
 
-            self.post_migration(vm, cancel_delay, dsthost, vm_ports,
-                                not_wait_for_migration, None)
+            self.post_migration(vm, cancel_delay, mig_offline, dsthost,
+                                vm_ports, not_wait_for_migration, None,
+                                mig_data)
 
         logging.info("Start migrating now...")
         cancel_delay = mig_data.params.get("cancel_delay")
@@ -531,11 +532,18 @@ class MultihostMigration(object):
         not_wait_for_migration = mig_data.params.get("not_wait_for_migration")
         if not_wait_for_migration == "yes":
             not_wait_for_migration = True
+        mig_offline = mig_data.params.get("mig_offline")
+        if mig_offline == "yes":
+            mig_offline = True
+        else:
+            mig_offline = False
+
         multi_mig = []
         for vm in mig_data.vms:
-            multi_mig.append((mig_wrapper, (vm, cancel_delay,
-                                            mig_data.dst, mig_data.vm_ports,
-                                            not_wait_for_migration)))
+            multi_mig.append((mig_wrapper, (vm, cancel_delay, mig_data.dst,
+                                            mig_data.vm_ports,
+                                            not_wait_for_migration,
+                                            mig_offline, mig_data)))
         utils_misc.parallel(multi_mig)
 
 
@@ -579,11 +587,12 @@ class MultihostMigration(object):
             for vm in mig_data.vms:
                 vm.wait_for_login(timeout=self.login_timeout)
 
-        sync = SyncData(self.master_id(), self.hostid, mig_data.hosts,
-                        mig_data.mig_id, self.sync_server)
-        mig_data.vm_ports = sync.sync(timeout=120)[mig_data.dst]
-        logging.info("Received from destination the migration port %s",
-                     str(mig_data.vm_ports))
+        if mig_data.params.get("host_mig_offline") != "yes":
+            sync = SyncData(self.master_id(), self.hostid, mig_data.hosts,
+                            mig_data.mig_id, self.sync_server)
+            mig_data.vm_ports = sync.sync(timeout=120)[mig_data.dst]
+            logging.info("Received from destination the migration port %s",
+                         str(mig_data.vm_ports))
 
 
     def _check_vms_dest(self, mig_data):
@@ -593,9 +602,10 @@ class MultihostMigration(object):
                          vm.migration_port)
             mig_data.vm_ports[vm.name] = vm.migration_port
 
-        SyncData(self.master_id(), self.hostid,
-                 mig_data.hosts, mig_data.mig_id,
-                 self.sync_server).sync(mig_data.vm_ports, timeout=120)
+        if mig_data.params.get("host_mig_offline") != "yes":
+            SyncData(self.master_id(), self.hostid,
+                     mig_data.hosts, mig_data.mig_id,
+                     self.sync_server).sync(mig_data.vm_ports, timeout=120)
 
 
     def _prepare_params(self, mig_data):
@@ -732,12 +742,15 @@ class MultihostMigration(object):
             mig_data = MigrationData(self.params, srchost, dsthost,
                                      vms_name, params_append)
             cancel_delay = self.params.get("cancel_delay", None)
+            host_offline_migration = self.params.get("host_mig_offline")
+
             try:
                 try:
                     if mig_data.is_src():
                         self.prepare_for_migration(mig_data, None)
                     elif self.hostid == dsthost:
-                        self.prepare_for_migration(mig_data, mig_mode)
+                        if host_offline_migration != "yes":
+                            self.prepare_for_migration(mig_data, mig_mode)
                     else:
                         return
 
@@ -750,7 +763,7 @@ class MultihostMigration(object):
                                                         "vm is paused.")
 
                     # Starts VM and waits timeout before migration.
-                    if self.params.get("paused_after_start_vm") == "yes":
+                    if pause == "yes":
                         for vm in mig_data.vms:
                             vm.resume()
                         wait = self.params.get("start_migration_timeout", 0)
@@ -760,6 +773,18 @@ class MultihostMigration(object):
 
                     timeout = 30
                     if cancel_delay is None:
+                        if host_offline_migration == "yes":
+                            self._hosts_barrier(self.hosts,
+                                                mig_data.mig_id,
+                                                'wait_for_offline_mig',
+                                                self.finish_timeout)
+                            if mig_data.is_dst():
+                                self.prepare_for_migration(mig_data, mig_mode)
+                            self._hosts_barrier(self.hosts,
+                                                mig_data.mig_id,
+                                                'wait2_for_offline_mig',
+                                                self.finish_timeout)
+
                         if (not mig_data.is_src()):
                             timeout = self.mig_timeout
                         self._hosts_barrier(mig_data.hosts, mig_data.mig_id,
@@ -858,15 +883,16 @@ class MultihostMigrationFd(MultihostMigration):
         For change way how machine migrates is necessary
         re implement this method.
         """
-        def mig_wrapper(vm, cancel_delay, dsthost, vm_ports,
+        def mig_wrapper(vm, cancel_delay, mig_offline, dsthost, vm_ports,
                         not_wait_for_migration, fd):
-            vm.migrate(cancel_delay=cancel_delay, dest_host=dsthost,
+            vm.migrate(cancel_delay=cancel_delay, offline=mig_offline,
+                       dest_host=dsthost,
                        not_wait_for_migration=not_wait_for_migration,
                        protocol="fd",
                        fd_src=fd)
 
-            self.post_migration(vm, cancel_delay, dsthost, vm_ports,
-                                not_wait_for_migration, fd)
+            self.post_migration(vm, cancel_delay, mig_offline, dsthost,
+                                vm_ports, not_wait_for_migration, fd, mig_data)
 
         logging.info("Start migrating now...")
         cancel_delay = mig_data.params.get("cancel_delay")
@@ -875,11 +901,16 @@ class MultihostMigrationFd(MultihostMigration):
         not_wait_for_migration = mig_data.params.get("not_wait_for_migration")
         if not_wait_for_migration == "yes":
             not_wait_for_migration = True
+        mig_offline = mig_data.params.get("mig_offline")
+        if mig_offline == "yes":
+            mig_offline = True
+        else:
+            mig_offline = False
 
         multi_mig = []
         for vm in mig_data.vms:
             fd = vm.params.get("migration_fd")
-            multi_mig.append((mig_wrapper, (vm, cancel_delay,
+            multi_mig.append((mig_wrapper, (vm, cancel_delay, mig_offline,
                                             mig_data.dst, mig_data.vm_ports,
                                             not_wait_for_migration,
                                             fd)))
@@ -997,6 +1028,157 @@ class MultihostMigrationFd(MultihostMigration):
             finally:
                 for s in sockets:
                     s.close()
+
+
+class MultihostMigrationExec(MultihostMigration):
+    def __init__(self, test, params, env):
+        super(MultihostMigrationExec, self).__init__(test, params, env)
+
+
+    def post_migration(self, vm, cancel_delay, mig_offline, dsthost,
+                             mig_exec_cmd, not_wait_for_migration, fd,
+                             mig_data):
+        if mig_data.params.get("host_mig_offline") == "yes":
+            src_tmp = vm.params.get("migration_sfiles_path")
+            dst_tmp = vm.params.get("migration_dfiles_path")
+            username = vm.params.get("username")
+            password = vm.params.get("password")
+            remote.scp_to_remote(dsthost, "22", username, password,
+                                 src_tmp, dst_tmp)
+
+
+    def migrate_vms_src(self, mig_data):
+        """
+        Migrate vms source.
+
+        @param mig_Data: Data for migration.
+
+        For change way how machine migrates is necessary
+        re implement this method.
+        """
+        def mig_wrapper(vm, cancel_delay, mig_offline, dsthost, mig_exec_cmd,
+                        not_wait_for_migration, mig_data):
+            vm.migrate(cancel_delay=cancel_delay,
+                       offline=mig_offline,
+                       dest_host=dsthost,
+                       not_wait_for_migration=not_wait_for_migration,
+                       protocol="exec",
+                       migration_exec_cmd_src=mig_exec_cmd)
+
+            self.post_migration(vm, cancel_delay, mig_offline,
+                                dsthost, mig_exec_cmd,
+                                not_wait_for_migration, None, mig_data)
+
+        logging.info("Start migrating now...")
+        cancel_delay = mig_data.params.get("cancel_delay")
+        if cancel_delay is not None:
+            cancel_delay = int(cancel_delay)
+        not_wait_for_migration = mig_data.params.get("not_wait_for_migration")
+        if not_wait_for_migration == "yes":
+            not_wait_for_migration = True
+        mig_offline = mig_data.params.get("mig_offline")
+        if mig_offline == "yes":
+            mig_offline = True
+        else:
+            mig_offline = False
+
+        multi_mig = []
+        for vm in mig_data.vms:
+            mig_exec_cmd = vm.params.get("migration_exec_cmd_src")
+            multi_mig.append((mig_wrapper, (vm, cancel_delay,
+                                            mig_offline,
+                                            mig_data.dst,
+                                            mig_exec_cmd,
+                                            not_wait_for_migration,
+                                            mig_data)))
+        utils_misc.parallel(multi_mig)
+
+
+    def _check_vms_source(self, mig_data):
+        start_mig_tout = mig_data.params.get("start_migration_timeout", None)
+        if start_mig_tout is None:
+            for vm in mig_data.vms:
+                vm.wait_for_login(timeout=self.login_timeout)
+
+        if mig_data.params.get("host_mig_offline") != "yes":
+            self._hosts_barrier(mig_data.hosts, mig_data.mig_id,
+                                'prepare_VMS', 60)
+
+
+    def _check_vms_dest(self, mig_data):
+        if mig_data.params.get("host_mig_offline") != "yes":
+            self._hosts_barrier(mig_data.hosts, mig_data.mig_id,
+                                'prepare_VMS', 120)
+
+
+    def migrate_wait(self, vms_name, srchost, dsthost, start_work=None,
+                      check_work=None, mig_mode="exec", params_append=None):
+        vms_count = len(vms_name)
+        mig_ports = []
+
+        host_offline_migration = self.params.get("host_mig_offline")
+
+        sync = SyncData(self.master_id(), self.hostid,
+                         self.params.get("hosts"),
+                         {'src': srchost, 'dst': dsthost,
+                          'port': "ports"}, self.sync_server)
+
+        mig_params = {}
+
+        if host_offline_migration != "yes":
+            if self.params.get("hostid") == dsthost:
+                last_port = 5199
+                for _ in range(vms_count):
+                    last_port = utils_misc.find_free_port(last_port + 1, 6000)
+                    mig_ports.append(last_port)
+
+            mig_ports = sync.sync(mig_ports, timeout=120)
+            mig_ports = mig_ports[dsthost]
+            logging.debug("Migration port %s" % (mig_ports))
+            mig_cmds = {}
+            for mig_port, vm_name in zip(mig_ports, vms_name):
+                mig_dst_cmd = "nc -l %s %s" % (dsthost, mig_port)
+                mig_src_cmd = "nc %s %s" % (dsthost, mig_port)
+                mig_params["migration_exec_cmd_src_%s" % (vm_name)] = mig_src_cmd
+                mig_params["migration_exec_cmd_dst_%s" % (vm_name)] = mig_dst_cmd
+        else:
+            # Generate filenames for migration.
+            mig_fnam = {}
+            for vm_name in vms_name:
+                while True:
+                    fnam = ("mig_" + utils.generate_random_string(6) +
+                            "." + vm_name)
+                    fpath = os.path.join(self.test.tmpdir, fnam)
+                    if (not fnam in mig_fnam.values() and
+                        not os.path.exists(fnam)):
+                        mig_fnam[vm_name] = fpath
+                        break
+            mig_fs = sync.sync(mig_fnam, timeout=120)
+            mig_cmds = {}
+            # Prepare cmd and files.
+            if self.params.get("hostid") == srchost:
+                mig_src_cmd = "gzip -c > %s"
+                for vm_name in vms_name:
+                    mig_params["migration_sfiles_path_%s" % (vm_name)] = (
+                        mig_fs[srchost][vm_name])
+                    mig_params["migration_dfiles_path_%s" % (vm_name)] = (
+                        mig_fs[dsthost][vm_name])
+
+                    mig_params["migration_exec_cmd_src_%s" % (vm_name)] = (
+                        mig_src_cmd % mig_fs[srchost][vm_name])
+
+            if self.params.get("hostid") == dsthost:
+                mig_dst_cmd = "gzip -c -d %s"
+                for vm_name in vms_name:
+                    mig_params["migration_exec_cmd_dst_%s" % (vm_name)] = (
+                         mig_dst_cmd % mig_fs[dsthost][vm_name])
+
+        logging.debug("Exec commands %s", mig_cmds)
+
+        super_cls = super(MultihostMigrationExec, self)
+        super_cls.migrate_wait(vms_name, srchost, dsthost,
+                               start_work=start_work, mig_mode=mig_mode,
+                               params_append=mig_params)
 
 
 def stop_windows_service(session, service, timeout=120):


### PR DESCRIPTION
1) Migration over exec protocol
2) Adds support for host offline migration
     - Source host starts VM migrate to file or any to storage
        place.
     - Then destination host start VM and continues in offline
        migration from storage place.
    In default exec migration is guest state stored in autotest tmpdir.

Signed-off-by: Jiří Župka jzupka@redhat.com
