### PR TITLE
tests.multi_disk: fix vm params and root_dir

### DIFF
--- a/kvm/tests/multi_disk.py
+++ b/kvm/tests/multi_disk.py
@@ -181,7 +181,7 @@ def run_multi_disk(test, params, env):
             env_process.preprocess_image(test, image_params, image_name)
 
     vm = env.get_vm(params["main_vm"])
-    vm.create(timeout=max(10, stg_image_num))
+    vm.create(timeout=max(10, stg_image_num), params=params)
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
 
     images = params.get("images").split()
@@ -201,7 +201,7 @@ def run_multi_disk(test, params, env):
     (tmp1, tmp2) = disks.parse_info_block(vm.monitor.info('block'))
     err += tmp1 + tmp2
     err += disks.generate_params()
-    err += disks.check_disk_params(params, vm.root_dir)
+    err += disks.check_disk_params(params)
     (tmp1, tmp2, _, _) = disks.check_guests_proc_scsi(
                                     session.cmd_output('cat /proc/scsi/scsi'))
     err += tmp1 + tmp2

--- a/virttest/kvm_qtree.py
+++ b/virttest/kvm_qtree.py
@@ -5,7 +5,7 @@ Utility classes and functions to handle KVM Qtree parsing and verification.
 @copyright: 2012 Red Hat Inc.
 """
 import logging, os, re
-import storage
+import storage, data_dir
 
 
 OFFSET_PER_LEVEL = 2
@@ -456,12 +456,10 @@ class QtreeDisksContainer(object):
             missing += 1
         return (additional, missing, qtree_not_scsi, proc_not_scsi)
 
-    def check_disk_params(self, params, root_dir=''):
+    def check_disk_params(self, params):
         """
         Check gathered info from qtree/block with params
         @param params: autotest params
-        @param root_dir: root_dir of images. If all images use absolute path
-                         it's safe to omit this param.
         @return: number of errors
         """
         err = 0
@@ -475,7 +473,8 @@ class QtreeDisksContainer(object):
             current = None
             image_params = params.object_params(name)
             image_name = os.path.realpath(
-                        storage.get_image_filename(image_params, root_dir))
+                        storage.get_image_filename(image_params,
+                                                   data_dir.get_data_dir()))
             for (qname, disk) in disks.iteritems():
                 if disk.get('image_name') == image_name:
                     current = disk


### PR DESCRIPTION
1) vm.create() have to force new params.
2) use data_dir instead of vm.root_dir for image absolute path

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
