### PR TITLE
remove the unnecessary double quote on uri when migrate using qmp monitor

### DIFF
--- a/virttest/kvm_monitor.py
+++ b/virttest/kvm_monitor.py
@@ -1178,6 +1178,7 @@ class QMPMonitor(Monitor):
         args = {"uri": uri,
                 "blk": full_copy,
                 "inc": incremental_copy}
+        args['uri'] = re.sub('"', "", args['uri'])
         try:
             return self.cmd("migrate", args)
         except QMPCmdError, e:


### PR DESCRIPTION
remove the unnecessary double quote on uri when migrate using qmp monitor

otherwise, the migration would fail.
Tested on my localhost using F18(both hmp && qmp)
before patch:
{"execute": "migrate", "arguments": {"uri": "\"exec:nc localhost 5200\"", "blk": false, "inc": false}, "id": "fUOKXSd2"}
after patch:
{"execute": "migrate", "arguments": {"uri": "exec:nc localhost 5200", "blk": false, "inc": false}, "id": "fUOKXSd2"}

Signed-off-by: Xiaoqing Wei xwei@redhat.com
