### PR TITLE
virt: Verify whether guest image is bootable

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -128,6 +128,10 @@ image_size = 10G
 image_raw_device = no
 # Name of image, or path to device node if using image_raw_device
 image_name = image
+# Verify whether guest boot from Hard disk.
+image_verify_bootable = yes
+# Pattern for verifying whether boot up from Hard disk.
+image_unbootable_pattern = "Hard Disk.*not a bootable disk"
 
 # Host-side caching to use. This option is passed directly to qemu(-kvm) so
 # any valid qemu cache option is valid here. A quick reference for the

--- a/tests/cfg/pxe.cfg
+++ b/tests/cfg/pxe.cfg
@@ -12,3 +12,4 @@
     network = bridge
     restart_vm = yes
     pxe_timeout = 60
+    image_verify_bootable = no

--- a/tests/cfg/unattended_install.cfg
+++ b/tests/cfg/unattended_install.cfg
@@ -17,6 +17,7 @@
     inactivity_treshold = 1800
     # Set migrate_background to yes to run migration in parallel
     # migrate_background = yes
+    image_verify_bootable = no
 
     # Way of delivering ks file into the guest
     variants:


### PR DESCRIPTION
This patch adds a function in vm.verify_alive method,
to check if the image is bootable. If image can't bootup,
autotest will raise an ImageUnbootableError exception.

There are 2 parameters for this function:
- image_verify_bootable: Turn on/off this checking function.
- image_unbootable_pattern: Pattern for bootable checking.

Signed-off-by: Qingtang Zhou qzhou@redhat.com
