### PR TITLE
run_pylint tweak

### DIFF
--- a/tools/run_pylint.py
+++ b/tools/run_pylint.py
@@ -83,7 +83,7 @@ def get_pylint_opts():
         else:
             opts = disable_old
 
-    opts += ['--reports=no', '--include-ids=y']
+    opts += ['--reports=no', '--include-ids=y', '--good-names=i,j,k,Run,_,vm']
     return opts
 
 


### PR DESCRIPTION
While looking at the new documentation I realized why don't we add vm into good-names by default.
