### PR TITLE
multi_disk: Fix incorrect params

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -17,6 +17,8 @@
         - max_disk:
             only virtio_blk
             # TODO: confirm this works with libvirt
+            usbs = ''
+            usb_devices = ''
             stg_image_num = 23
             stg_image_size = 1G
             stg_image_boot = no

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -95,7 +95,7 @@ def run_multi_disk(test, params, env):
     # Compatibility
     stg_params += _add_param("image_size", params.get("stg_image_size"))
     stg_params += _add_param("image_format", params.get("stg_image_format"))
-    stg_params += _add_param("image_boot", params.get("stg_image_boot"))
+    stg_params += _add_param("image_boot", params.get("stg_image_boot", "no"))
     stg_params += _add_param("drive_format", params.get("stg_drive_format"))
     if params.get("stg_assign_index") != "no":
         # Assume 0 and 1 are already occupied (hd0 and cdrom)


### PR DESCRIPTION
- max_disk must not have any usbs, otherwise there are not enough
  slots in PCI
- default image_boot = yes which generates in multi_disk test
  multiple disks with index = 1 and test failure. By forcing default
  value stg_image_boot = 'no' we can keep the default value (and index
  of image1) and let the other disk to have their own indexes.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
