### PR TITLE
virttest.standalone_test: Fix logging parameter

### DIFF
--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -665,7 +665,7 @@ def run_tests(parser, options):
     for i, d in enumerate(parser.get_dicts()):
         shortname = get_tag(d, tag_index)
 
-        logging.info("Test %4d:  %s", (i + 1, shortname))
+        logging.info("Test %4d:  %s", i + 1, shortname)
         last_index += 1
 
     if last_index == -1:


### PR DESCRIPTION
Use variables instead of tuple in logging. (Fix of the commit c32628206d3f3445817e00db438024dcb43d47ee)

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
