### PR TITLE
virttest.env_process: Kill VMs with deleted disks

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -507,6 +507,17 @@ def postprocess(test, params, env):
                 logging.warn(e)
                 vm.destroy(gracefully=False)
 
+    # Kill VMs with deleted disks
+    for vm in env.get_all_vms():
+        destroy = False
+        vm_params = params.object_params(vm.name)
+        for image in vm_params.objects('images'):
+            if params.object_params(image).get('remove_image') == 'yes':
+                destroy = True
+        if destroy and not vm.is_dead():
+            logging.debug('Image of VM %s was removed, destroing it.', vm.name)
+            vm.destroy()
+
     # Kill all aexpect tail threads
     aexpect.kill_tail_threads()
 


### PR DESCRIPTION
Hi guys,

when I hunted some problems with multiple disks I discovered, that disks I'm writing in guests are not the same on host. This is due of reused VM and recreated disks on host. My proposal is to go through params and in case that VM's disk was removed, destroy it.

What do you think about this?

_This doesn't apply much for single instances of ./run. It might be seen in two consecutive tests. When you use autotest-local it applies even for two instances of autotest-local since it detects the same VM and reuses it_
