### PR TITLE
tests.cfg.dd_test: Fix the image bootindex bug

### DIFF
--- a/tests/cfg/dd_test.cfg
+++ b/tests/cfg/dd_test.cfg
@@ -8,6 +8,7 @@
     image_size_stg1 = 1M
     image_snapshot_stg1 = no
     drive_index_stg1 = 3
+    image_boot_stg1 = no
     dd_count = 1
     # last input and output disk
     dd_if_select = -1


### PR DESCRIPTION
When image_boot is set, autotest assigns index = 1
which leads to duplicated indexes.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
