### PR TITLE
virt: Adds file which contain patterns which should be excluded.

### DIFF
--- a/.pack_exclude
+++ b/.pack_exclude
@@ -1,0 +1,5 @@
+./.git
+./tmp/*
+./shared/data/*
+./logs/*
+*.pyc


### PR DESCRIPTION
Adds file which contain patterns which should be excluded
from tar package distributed to clients from the server.

Depends on: https://github.com/autotest/autotest/pull/618

Signed-off-by: Jiří Župka jzupka@redhat.com
