### PR TITLE
qemu.cfg.virtio_console: Remove the only Linux

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -1,5 +1,4 @@
 - virtio_console: install setup image_copy unattended_install.cdrom
-    only Linux
     type = virtio_console
     # Console cleanup is not 100%, consider using kill_vm_on_error
     kill_vm_on_error = yes


### PR DESCRIPTION
only Linux was removed couple of versions back. Each linux-only
variant of virtio_console sets this itself.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
