### PR TITLE
virt: qemu adds missing virt_test_type.

### DIFF
--- a/qemu/tests/cfg/steps.cfg
+++ b/qemu/tests/cfg/steps.cfg
@@ -1,5 +1,6 @@
 - install:
     no JeOS
+    virt_test_type = qemu
     type = steps
     fail_if_stuck_for = 300
     stuck_detection_history = 2
@@ -11,6 +12,7 @@
 
 - setup: install
     no JeOS
+    virt_test_type = qemu
     type = steps
     fail_if_stuck_for = 300
     stuck_detection_history = 2


### PR DESCRIPTION
Signed-off-by: Jiří Župka jzupka@redhat.com
