### PR TITLE
Add test for virsh net-destroy v3

### DIFF
--- a/libvirt/tests/cfg/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_net_destroy.cfg
@@ -1,0 +1,34 @@
+- virsh_net_destroy:
+    type = virsh_net_destroy
+    vms = ""
+    main_vm = ""
+    kill_vm = "no"
+    kill_unresponsive_vms = "no"
+    encode_video_files = "no"
+    skip_image_processing = "yes"
+    take_regular_screendumps = "no"
+    net_destroy_network = "default"
+    net_destroy_net_ref = "name"
+    net_destroy_extra = ""
+    net_destroy_status = "active"
+    variants:
+        - normal_test:
+            status_error = "no"
+            variants:
+                - default_option:
+                - uuid_option:
+                    net_destroy_net_ref = "uuid"
+        - error_test:
+            status_error = "yes"
+            variants:
+                - no_option:
+                    net_destroy_net_ref = ""
+                - no_net_extra_option:
+                    net_destroy_net_ref = ""
+                    net_destroy_extra = "xyz"
+                - extra_option1:
+                    net_destroy_extra = "xyz"
+                - extra_option2:
+                    net_destroy_extra = "--xyz"
+                - inactive_status_option:
+                    net_destroy_status = "inactive"

--- a/libvirt/tests/virsh_net_destroy.py
+++ b/libvirt/tests/virsh_net_destroy.py
@@ -1,0 +1,74 @@
+import re
+from autotest.client.shared import error
+from virttest import virsh
+
+def run_virsh_net_destroy(test, params, env):
+    """
+    Test command: virsh net-destroy.
+
+    The command can forcefully stop a given network.
+    1.Make sure the network exists.
+    2.Prepare network status.
+    3.Perform virsh net-destroy operation.
+    4.Check if the network has been destroied.
+    5.Recover network environment.
+    6.Confirm the test result.
+    """
+
+    net_ref = params.get("net_destroy_net_ref")
+    extra = params.get("net_destroy_extra", "")
+    network_name = params.get("net_destroy_network", "default")
+    network_status = params.get("net_destroy_status", "active")
+    status_error = params.get("status_error", "no")
+
+    # Confirm the network exists.
+    output_all = virsh.net_list("--all").stdout.strip()
+    if not re.search(network_name, output_all):
+        raise error.TestNAError("Make sure the network exists!!")
+
+    # Run test case
+    if net_ref == "uuid":
+       net_ref  = virsh.net_uuid(network_name).stdout.strip()
+    elif net_ref == "name":
+       net_ref = network_name
+
+    # Get status of network and prepare network status.
+    network_current_status = "active"
+    try:
+        if not virsh.net_state_dict()[network_name]['active']:
+            network_current_status = "inactive"
+            if network_status == "active":
+                virsh.net_start(network_name)
+        else:
+            if network_status == "inactive":
+                virsh.net_destroy(network_name)
+    except error.CmdError:
+        raise error.TestError("Prepare network status failed!")
+
+    status = virsh.net_destroy(net_ref, extra,
+                                ignore_status=True).exit_status
+
+    # Confirm the network has been destroied.
+    if virsh.net_state_dict()[network_name]['active']:
+        status = 1
+
+    # Recover network status
+    try:
+        if (network_current_status == "active" and
+            not virsh.net_state_dict()[network_name]['active']):
+            virsh.net_start(network_name)
+        if (network_current_status == "inactive" and
+            virsh.net_state_dict()[network_name]['active']):
+            virsh.net_destroy(network_name)
+    except error.CmdError:
+        raise error.TestError("Recover network status failed!")
+
+    # Check status_error
+    if status_error == "yes":
+        if status == 0:
+            raise error.TestFail("Run successfully with wrong command!")
+    elif status_error == "no":
+        if status != 0:
+            raise error.TestFail("Run failed with right command")
+    else:
+        raise error.TestError("The status_error must be 'yes' or 'no'!")


### PR DESCRIPTION
I resend a pull request about virsh net-destroy with my net_destroy branch.

Li Yang (1):
  libvirt: Add test module for virsh net-destroy

 libvirt/tests/cfg/virsh_net_destroy.cfg |   34 ++++++++++++++
 libvirt/tests/virsh_net_destroy.py      |   74 +++++++++++++++++++++++++++++++
 2 files changed, 108 insertions(+), 0 deletions(-)
 create mode 100644 libvirt/tests/cfg/virsh_net_destroy.cfg
 create mode 100644 libvirt/tests/virsh_net_destroy.py
