### PR TITLE
shared.cfg: Show guest disk/nic/cpu/image config by default

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -2,7 +2,7 @@
 #
 # NICs
 variants:
-    - @rtl8139:
+    - rtl8139:
         nic_model = rtl8139
         no ethtool
         jumbo:
@@ -36,7 +36,7 @@ variants:
             # Device selection for the NDISTest server machine
             dp_regex_servermsgdev = VirtIO Ethernet Adapter$
             dp_regex_serversupportdev = VirtIO Ethernet Adapter #2$
-    -xennet:
+    - xennet:
         # placeholder
     - spapr-vlan:
         nic_model = spapr-vlan
@@ -48,7 +48,7 @@ variants:
         # If people want to specify something different.
 
 variants:
-    - @up:
+    - up:
         no autotest.npb autotest.tsc
     - smp2:
         smp = 2
@@ -57,7 +57,7 @@ variants:
         timedrift.with_load: used_cpus = 100
 
 variants:
-    - @ide:
+    - ide:
         drive_format=ide
     - scsi:
         drive_format=scsi
@@ -98,7 +98,7 @@ variants:
         # placeholder
 
 variants:
-    - @qcow2:
+    - qcow2:
         image_format = qcow2
         check_image = yes
     - vmdk:


### PR DESCRIPTION
Normally, these configs are important to a test job, thus show
them all in test's name.

Signed-off-by: Qingtang Zhou qzhou@redhat.com
