### PR TITLE
Libvirt virsh domif-{set,get}link test

### DIFF
--- a/libvirt/tests/cfg/virsh_domif_setlink_getlink.cfg
+++ b/libvirt/tests/cfg/virsh_domif_setlink_getlink.cfg
@@ -3,15 +3,14 @@
     variants:
         - positive_test:
             status_error = "no"
-            libvirtd = "on"
             variants:
                 - domif_setlink:
-                    action = "setlink"
+                    if_action = "setlink"
                     variants:
                         - setlink_up:
-                            operation = "up"
+                            if_operation = "up"
                         - setlink_down:
-                            operation = "down"
+                            if_operation = "down"
             variants:
                 - running_guest:
                     start_vm = "yes"
@@ -34,8 +33,8 @@
 
         - negative_test:
             status_error = "yes"
-            action = "setlink"
-            operation = "up"
+            if_action = "setlink"
+            if_operation = "up"
             if_device = "mac"
             options = " "
             variants:

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -614,6 +614,7 @@ class VMCPUXML(VMXML):
             nets[dev] = node
         return nets
 
+    #TODO re-visit this method after the libvirt_xml.devices.interface module is implemented
 
     @staticmethod
     def get_net_dev(vm_name):

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2049,7 +2049,7 @@ def connect(connect_uri="", options="", **dargs):
     """
     return command("connect %s %s" % (connect_uri, options), **dargs)
 
-def domif_setlink(name, interface, state, options, **dargs):
+def domif_setlink(name, interface, state, options=None, **dargs):
     """
     Set network interface stats for a running domain.
 
@@ -2066,7 +2066,7 @@ def domif_setlink(name, interface, state, options, **dargs):
 
     return command(cmd, **dargs)
 
-def domif_getlink(name, interface, options, **dargs):
+def domif_getlink(name, interface, options=None, **dargs):
     """
     Get network interface stats for a running domain.
 


### PR DESCRIPTION
Tracking issue:
#240

Add virsh domif-setlink domif-getlink test

Introduce virsh domif-setlink domif-getlink  testing:

```
1. Positive testing
    1.1 Running domain and shutting off domain testing
    1.2 Setlink domain interface up and down then check
    1.3 Options "--config" testing
    1.4 Interface name and MAC address testing

2. Negative testing
    2.1 Invalid options testing
    2.2 Shutting off domain with interface name
```

Signed-off-by: whuang whuang@redhat.com
