### PR TITLE
virttest.utils_misc:Fix return value to list for ppc64

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1163,7 +1163,7 @@ def get_host_cpu_models():
         return pattern
 
     if ARCH == 'ppc64':
-        return 'POWER7'
+        return ['POWER7']
 
     vendor_re = "vendor_id\s+:\s+(\w+)"
     cpu_flags_re = "flags\s+:\s+([\w\s]+)\n"


### PR DESCRIPTION
In get_host_cpu_models(), it will return a string if the host is
ppc64 machine, but for  x86 will return the mode list.

To avoid this gap, change the return value to a list.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
