### PR TITLE
tests.virtio_console: Add boot_nr1 test

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -197,6 +197,13 @@
                             virtio_ports = "vs1"
                             virtio_port_type_vs1 = serialport
                             virtio_port_params_vs1 = "nr=0"
+                        - boot_nr1:
+                            # This one should boot successfully
+                            virtio_console_test = open
+                            virtio_console_params = serialport
+                            virtio_ports = "vs1"
+                            virtio_port_type_vs1 = serialport
+                            virtio_port_params_vs1 = "nr=1"
                         - boot_too_much_ports:
                             extra_params = " -device virtio-serial-pci,max_ports=32"
                             start_vm = 0
@@ -210,3 +217,4 @@
         # Spread consoles across multiple virtio-serial-pcis
         - spread_2:
             virtio_port_spread = 2
+


### PR DESCRIPTION
To make sure boot_nr tests are working correctly it's necessarily to boot
(and open) the port with nr=1.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
