### PR TITLE
libvirt: Add test module for virsh update-device v4

### DIFF
--- a/libvirt/tests/cfg/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_update_device.cfg
@@ -1,0 +1,52 @@
+- virsh_update_device:
+    type = virsh_update_device
+    kill_vm = "yes"
+    take_regular_screendumps = "no"
+    updatedevice_vm_ref = "name"
+    updatedevice_extra = ""
+    variants:
+        - normal_test:
+            status_error = "no"
+            variants:
+                - id_option:
+                    updatedevice_vm_ref = "id"
+                    variants:
+                        - no_option:
+                        - force_option:
+                            updatedevice_flag = "--force"
+                            updatedevice_twice = "yes"
+                        - persistent_option:
+                            updatedevice_flag = "--persistent"
+                        - config_option:
+                            updatedevice_flag = "--config"
+                        - force_diff_iso_option:
+                            updatedevice_twice = "yes"
+                            updatedevice_diff_iso = "yes"
+                - name_option:
+                - pause_option:
+                    paused_after_start_vm = "yes"
+                - uuid_option:
+                    updatedevice_vm_ref = "uuid"
+                - diff_option:
+                    updatedevice_diff_file = "yes"
+                - name_persistent_option:
+                    updatedevice_flag = "--persistent"
+                - config_option:
+                    updatedevice_flag = "--config"
+        - error_test:
+            status_error = "yes"
+            variants:
+                - no_option:
+                    updatedevice_vm_ref = ""
+                - hex_id_option:
+                    updatedevice_vm_ref = "hex_id"
+                - invalid_id_option:
+                    updatedevice_vm_ref = "updatedevice_invalid_id"
+                    updatedevice_invalid_id = "9999"
+                - invalid_uuid_option:
+                    updatedevice_vm_ref = "updatedevice_invalid_uuid"
+                    updatedevice_invalid_uuid = "99999999-9999-9999-9999-999999999999"
+                - extra_option:
+                    updatedevice_extra = xyz
+                - shut_off_option:
+                    start_vm = "no"

--- a/libvirt/tests/virsh_update_device.py
+++ b/libvirt/tests/virsh_update_device.py
@@ -1,0 +1,167 @@
+import re, os, difflib
+from autotest.client.shared import error
+from virttest import virsh, libvirt_xml
+from xml.dom.minidom import parseString
+
+def run_virsh_update_device(test, params, env):
+    """
+    Test command: virsh update-device.
+
+    Update device from an XML <file>.
+    1.Prepare test environment.Make sure a cdrom exists in VM.
+      If not, please attach one cdrom manually.
+    2.Perform virsh update-device operation.
+    3.Recover test environment.
+    4.Confirm the test result.
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    if vm.is_alive() and params.get("start_vm") == "no":
+        vm.destroy()
+
+    def create_attach_xml(update_xmlfile, source_iso):
+        """
+        Create a xml file to update a device.
+
+        @param: update_xmlfile : Temp xml saves device infomation.
+        @param: source_iso : disk's source file.
+        """
+        try:
+            f = open(source_iso, 'wb')
+            f.seek((1024 * 1024) - 1)
+            f.write(str(0))
+            f.close()
+        except IOError:
+            raise  error.TestFail("Create source_iso failed!")
+
+        content = """
+<disk device='cdrom' type='file'>
+<driver name='file'/>
+<source file='%s'/>
+<target bus='ide' dev='hdc'/>
+<readonly/>
+</disk>
+""" % source_iso
+        xmlfile = open(update_xmlfile, 'w')
+        xmlfile.write(content)
+        xmlfile.close()
+
+    def check_attach(source_file, output):
+        """
+        Check attached device and disk exist or not.
+
+        @param: source_file : disk's source file.
+        @param: output :VM's xml infomation .
+        """
+        dom = parseString(output)
+        source = dom.getElementsByTagName("source")
+        output2 = ""
+        for n in source:
+            output2 += n.getAttribute("file")
+        target = dom.getElementsByTagName("target")
+        output3 = ""
+        for n in target:
+            output3 += n.getAttribute("dev")
+        dom.unlink
+
+        source_iso = "%s"  % source_file
+        if not re.search(source_iso, output2):
+            raise  error.TestFail("didn't see 'attached disk")
+        if not re.search('hdc', output3):
+            raise  error.TestFail("didn't see 'attached device")
+
+
+    domid = vm.get_id()
+    domuuid = vm.get_uuid()
+
+    # Prepare tmp directory and files.
+    tmp_iso = os.path.join(test.virtdir, "tmp.iso")
+    tmp2_iso = os.path.join(test.virtdir, "tmp2.iso")
+    update_xmlfile = os.path.join(test.tmpdir, "xml_file")
+
+    # Get all parameters for configuration.
+    flag = params.get("updatedevice_flag", "")
+    twice = "yes" == params.get("updatedevice_twice", "no")
+    diff_iso = params.get("updatedevice_diff_iso", "no")
+    vm_ref = params.get("updatedevice_vm_ref", "")
+    status_error = params.get("status_error", "no")
+    extra = params.get("updatedevice_extra", "")
+
+    create_attach_xml(update_xmlfile, tmp_iso)
+    vm_xml = os.path.join(test.tmpdir, "vm_xml")
+    virsh.dumpxml(vm_name, vm_xml)
+    vmxml_before = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+
+    if vm_ref == "id":
+        vm_ref = domid
+        if twice:
+            virsh.update_device(domainarg=domid, filearg=update_xmlfile,
+                                ignore_status=True)
+        if diff_iso == "yes":
+            os.remove(update_xmlfile)
+            create_attach_xml(update_xmlfile, tmp2_iso)
+    elif vm_ref == "uuid":
+        vm_ref = domuuid
+    elif vm_ref == "hex_id":
+        vm_ref = hex(int(domid))
+    elif vm_ref.find("updatedevice_invalid") != -1:
+        vm_ref = params.get(vm_ref)
+    elif vm_ref == "name":
+        vm_ref = "%s %s" % (vm_name, extra)
+
+    status = virsh.update_device(domainarg=vm_ref, filearg=update_xmlfile,
+                    flagstr=flag, ignore_status=True, debug=True).exit_status
+
+    output = "%s" % libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    if params.has_key("updatedevice_diff_file"):
+        vm_xml_after = os.path.join(test.tmpdir, "vm_xml_after")
+        virsh.dumpxml(vm_name, vm_xml_after)
+    vm.destroy()
+    output_shut = "%s" % libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+
+    # Recover environment
+    vm.undefine()
+    vmxml_before.define()
+    if os.path.exists(tmp_iso):
+        os.remove(tmp_iso)
+    if os.path.exists(tmp2_iso):
+        os.remove(tmp2_iso)
+
+    # Check status_error
+    flag_list = flag.split("--")
+    for item in flag_list:
+        option = item.strip()
+        if option == "":
+            continue
+        if virsh.has_command_help_match("update-device", option) == None:
+            status_error = "yes"
+            break
+    if status_error == "yes":
+        if status == 0:
+            raise error.TestFail("Run successfully with wrong command!")
+    elif status_error == "no":
+        if status != 0:
+            raise error.TestFail("Run failed with right command")
+        else:
+            if flag == "--persistent" or flag == "--config":
+                if not re.search(tmp_iso, output_shut):
+                    raise error.TestFail("virsh update-device function invalid"
+                                         "didn't see 'attached device' in XML")
+            else:
+                if params.has_key("updatedevice_diff_file"):
+                    context_before = file(vm_xml, 'r').read().splitlines()
+                    context_after = file(vm_xml_after, 'r').read().splitlines()
+                    output_diff = difflib.Differ().compare(context_before,
+                                                           context_after)
+                    if not re.search(tmp_iso, "\n".join(list(output_diff))):
+                        raise  error.TestFail("virsh update-device function "
+                        "invalid; can't see 'attached device'in before/after")
+                else:
+                    if re.search(tmp_iso, output_shut):
+                        raise  error.TestFail("virsh attach-device without "
+                        "--persistent/--config function invalid;can see "
+                        "'attached device'in XML")
+            if diff_iso == "yes":
+                check_attach(tmp2_iso, output)
+            if  vm_ref == "name":
+                check_attach(tmp_iso, output)


### PR DESCRIPTION
I resend a patch about "virsh update-device" with commit message, and fixed up some issues.
Li Yang (1):
  libvirt: Add test module for virsh update-device

 libvirt/tests/cfg/virsh_update_device.cfg |   52 +++++++++
 libvirt/tests/virsh_update_device.py      |  177 +++++++++++++++++++++++++++++
 2 files changed, 229 insertions(+), 0 deletions(-)
 create mode 100644 libvirt/tests/cfg/virsh_update_device.cfg
 create mode 100644 libvirt/tests/virsh_update_device.py
