### PR TITLE
virttest.bootstrap.py: Correct number_variants in get_directory_structure

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -133,7 +133,7 @@ def get_directory_structure(rootdir, guest_file):
                              (4 * (indent + number_variants - 1) * " "))
             number_variants += 1
         elif indent < previous_indent:
-            number_variants -= 1
+            number_variants = indent
         indent += number_variants
         try:
             base_folder = folders[-1]


### PR DESCRIPTION
The old method of caculate number_variants will give a wrong number if
there is more than one sub directory in a cfg directory and each sub directory
has different depth.

Signed-off-by: Yiqiao Pu ypu@redhat.com
