### PR TITLE
qemu: add audio test for guest

### DIFF
--- a/qemu/tests/audio.py
+++ b/qemu/tests/audio.py
@@ -1,0 +1,25 @@
+from autotest.client.shared import error
+
+@error.context_aware
+def run_audio(test, params, env):
+    """
+    Test guest audio:
+
+    1) Boot guest with -soundhw ***
+    2) Log into guest
+    3) Write a file which contains random content to audio device, check
+       whether it succeeds.
+    """
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
+
+    random_content_size = params.get("random_content_size")
+    audio_device = params.get("audio_device")
+
+    error.context("Verifying whether /dev/dsp is present")
+    session.cmd("test -c %s" % audio_device)
+    error.context("Trying to write to the device")
+    session.cmd("dd if=/dev/urandom of=%s bs=%s count=1" %
+                (audio_device, random_content_size))

--- a/qemu/tests/cfg/audio.cfg
+++ b/qemu/tests/cfg/audio.cfg
@@ -1,0 +1,8 @@
+- audio:
+    only Linux
+    no RHEL.3.9
+    type = audio
+    soundcards = ac97
+    random_content_size = 100K
+    audio_device = /dev/dsp
+


### PR DESCRIPTION
(1) Boot guest with -soundhw [sound card].
(2) Log into guest.
(3) Write a file which contains random content
    to the audio device, check if succeeds or not.

Signed-off-by: sshang sshang@redhat.com
