### PR TITLE
virttest.remote : make remote scp support ipv6 address

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -363,7 +363,7 @@ def scp_to_remote(host, port, username, password, local_path, remote_path,
 
     command = ("scp -v -o UserKnownHostsFile=/dev/null "
                "-o PreferredAuthentications=password -r %s "
-               "-P %s %s %s@%s:%s" %
+               "-P %s %s %s@\[%s\]:%s" %
                (limit, port, local_path, username, host, remote_path))
     password_list = []
     password_list.append(password)
@@ -391,7 +391,7 @@ def scp_from_remote(host, port, username, password, remote_path, local_path,
 
     command = ("scp -v -o UserKnownHostsFile=/dev/null "
                "-o PreferredAuthentications=password -r %s "
-               "-P %s %s@%s:%s %s" %
+               "-P %s %s@\[%s\]:%s %s" %
                (limit, port, username, host, remote_path, local_path))
     password_list = []
     password_list.append(password)
@@ -421,7 +421,7 @@ def scp_between_remotes(src, dst, port, s_passwd, d_passwd, s_name, d_name,
 
     command = ("scp -v -o UserKnownHostsFile=/dev/null -o "
                "PreferredAuthentications=password -r %s -P %s"
-               " %s@%s:%s %s@%s:%s" %
+               " %s@\[%s\]:%s %s@\[%s\]:%s" %
                (limit, port, s_name, src, s_path, d_name, dst, d_path))
     password_list = []
     password_list.append(s_passwd)


### PR DESCRIPTION
This patch make remote scp related func support ipv6 address.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
