### PR TITLE
qemu: sync eject_media test case to upstream

### DIFF
--- a/qemu/tests/cfg/eject_media.cfg
+++ b/qemu/tests/cfg/eject_media.cfg
@@ -1,0 +1,10 @@
+- eject_media:
+    no RHEL.3.9
+    type = eject_media
+    monitor_type = qmp
+    pre_command += "dd if=/dev/urandom of=/tmp/orig bs=10M count=1 && dd if=/dev/urandom of=/tmp/new bs=10M count=1 && mkisofs -o /tmp/orig.iso /tmp/orig && mkisofs -o /tmp/new.iso /tmp/new;"
+    umount_before_eject = yes
+    umount_cmd = "for cd in `awk '{if($0 ~ /iso9660/) print $1}' /proc/mounts`;do fuser -k $cd; umount -d $cd;done"
+    post_command += "rm -rf /tmp/orig.iso /tmp/new.iso /tmp/orig /tmp/new;"
+    new_img_name = /tmp/new.iso
+    cdrom_cd1 = /tmp/orig.iso

--- a/qemu/tests/eject_media.py
+++ b/qemu/tests/eject_media.py
@@ -1,0 +1,102 @@
+import logging, time, commands
+from autotest.client.shared import error
+from virttest import utils_misc
+
+
+@error.context_aware
+def run_eject_media(test, params, env):
+    """
+    change a removable media:
+    1) Boot VM with QMP/human monitor enabled.
+    2) Connect to QMP/human monitor server.
+    3) Eject original cdrom.
+    4) Eject original cdrom for second time.
+    5) Insert new image to cdrom.
+    6) Eject device after add new image by change command.
+    7) Insert original cdrom to cdrom.
+    8) Try to eject non-removable device.
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environmen.
+    """
+
+    if not utils_misc.qemu_has_option("qmp"):
+        logging.warn("qemu does not support qmp. Human monitor will be used.")
+    qmp_used = False
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
+    logging.info("Wait until device is ready")
+    time.sleep(10)
+    blocks_info = vm.monitor.info("block")
+    if isinstance(blocks_info, dict):
+        qmp_used = True
+
+    orig_img_name = params.get("cdrom_cd1")
+    p_dict = {"file": orig_img_name}
+    device_name = vm.get_block(p_dict)
+    if device_name is None:
+        msg = "Fail to get device using image %s" % orig_img_name
+        raise error.TestFail(msg)
+    error.context("Eject original device.")
+    eject_cmd = "eject device=%s" % device_name
+    vm.monitor.send_args_cmd(eject_cmd)
+    logging.info("Wait until device is ejected")
+    time.sleep(10)
+    blocks_info = vm.monitor.info("block")
+    if orig_img_name in str(blocks_info):
+        raise error.TestFail("Fail to eject cdrom %s. " % orig_img_name)
+
+    error.context("Eject original device for second time")
+    vm.monitor.send_args_cmd(eject_cmd)
+
+    new_img_name = params.get("new_img_name")
+    error.context("Insert new image to device.")
+    change_cmd = "change device=%s,target=%s" % (device_name, new_img_name)
+    vm.monitor.send_args_cmd(change_cmd)
+    logging.info("Wait until device changed")
+    time.sleep(10)
+    blocks_info = vm.monitor.info("block")
+    if new_img_name not in str(blocks_info):
+        raise error.TestFail("Fail to chang cdrom to %s." % new_img_name)
+    if qmp_used:
+        eject_cmd = "eject device=%s, force=True" % device_name
+    else:
+        eject_cmd = "eject device=%s" % device_name
+    error.context("Eject device after add new image by change command")
+    vm.monitor.send_args_cmd(eject_cmd)
+    logging.info("Wait until new image is ejected")
+    time.sleep(10)
+
+    blocks_info = vm.monitor.info("block")
+    if new_img_name in str(blocks_info):
+        raise error.TestFail("Fail to eject cdrom %s." % orig_img_name)
+
+    error.context("Insert %s to device %s" % (orig_img_name, device_name))
+    change_cmd = "change device=%s,target=%s" % (device_name, orig_img_name)
+    vm.monitor.send_args_cmd(change_cmd)
+    logging.info("Wait until device changed")
+    time.sleep(10)
+    blocks_info = vm.monitor.info("block")
+    if orig_img_name not in str(blocks_info):
+        raise error.TestFail("Fail to change cdrom to %s." % orig_img_name)
+
+    error.context("Try to eject non-removable device")
+    p_dict = {"removable": False}
+    device_name = vm.get_block(p_dict)
+    if device_name is None:
+        raise error.TestFail("Could not find non-removable device")
+    eject_cmd = "eject device=%s," % device_name
+    try:
+        output = vm.monitor.send_args_cmd(eject_cmd)
+    except Exception, e:
+        logging.debug("Catch exception message: %s" % e)
+    logging.info("Wait until device is ejected")
+    time.sleep(10)
+    blocks_info = vm.monitor.info("block")
+    if device_name not in str(blocks_info):
+        raise error.TestFail("Could remove non-removable device!")
+
+    session.close()


### PR DESCRIPTION
Signed-off-by: Feng Yang fyang@redhat.com

Date:   Thu Mar 10 16:01:13 2011 +0800

```
KVM Test: Add eject_media new test script.

Signed-off-by: Feng Yang <fyang@redhat.com>
Acked-by: Amos Kong <akong@redhat.com>
Acked-by: Qingtang Zhou <qzhou@redhat.com>
```

Date:   Tue May 31 11:07:29 2011 +0000

```
KVM-test: Wait the cdrom init in RHEL5 host in eject test

In RHEL5 host 4.9 guests need some time to init cdrom device. If
this process not finished the device will be locked automatically.
And this will cause test report failed because of locked device
can not be eject. So add sleep in every step of this test to make
sure the init and eject operate finished before we check info.
Also modify the removable device check pattern to suitable for
both RHEL5 and RHEL6 host.

Signed-off-by: Yiqiao Pu <ypu@redhat.com>
Acked-by: Feng Yang <fyang@redhat.com>
Acked-by: Qingtang Zhou <qzhou@redhat.com>
```

Date:   Thu Dec 22 14:20:08 2011 +0000

```
KVM Test: Update eject_media test script.

Make it works with qmp changes in rhel6.
Make it works for both rhel6 and rhel5.
Use error.context in script.
Update test script description.
Put get_block to virt_test_utils.py

Changes from v1:
Call get_block and check_block_locked from kvm_vm.py
Changes from v2:
Typo fix chang -> change
Do not import virt_test_utils, do not need it now.

Signed-off-by: Feng Yang <fyang@redhat.com>
```

Date:   Thu Sep 13 11:31:20 2012 +0800

```
KVM Test: Change utils_misc.has_option to utils_misc.qemu_has_option

utils_misc.has_option have been renamed to utils_misc.qemu_has_option

We need update script use new interface.

Signed-off-by: Feng Yang <fyang@redhat.com>
```
