### PR TITLE
virttest.qemu_vm: fix guest's network can't work if tap dev already exis...

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1717,6 +1717,8 @@ class VM(virt_vm.BaseVM):
                         logging.debug("Copying mac for nic %s from VM %s"
                                        % (nic.nic_name, mac_source.name))
                         nic.mac = mac_source.get_mac_address(nic.nic_name)
+                    if nic.ifname in utils_net.get_net_if():
+                        self.virtnet.generate_ifname(nic.nic_name)
                     if nic.nettype in ['bridge', 'network', 'macvtap']:
                         self._nic_tap_add_helper(nic)
                     elif nic.nettype == 'user':


### PR DESCRIPTION
Autotest can't handle the situation which tap device has been in bridge
before it's assigned into bridge by autotest itself. thus guest's network
can't work. This patch fix this error
