### PR TITLE
virt: Unattended_install bugfix

### DIFF
--- a/tests/unattended_install.py
+++ b/tests/unattended_install.py
@@ -399,12 +399,9 @@ class UnattendedInstallConfig(object):
         utils.run("cp %s %s" % (self.unattended_file, dest_fname),
                   verbose=DEBUG)
 
-        if self.params.get("vm_type") == "libvirt":
-            utils.run("find . | fakeroot cpio -H newc --create > ../%s.img" %
-                      base_initrd.rstrip(".gz"), verbose=DEBUG)
-        else:
-            utils.run("find . | fakeroot cpio -H newc --create | gzip -9 > ../%s" %
-                      base_initrd, verbose=DEBUG)
+        # For libvirt initrd.gz will be renamed to initrd.img in setup_cdrom()
+        utils.run("find . | fakeroot cpio -H newc --create | gzip -9 > ../%s" %
+	          base_initrd, verbose=DEBUG)
 
         os.chdir(self.image_path)
         utils.run("rm -rf initrd_remaster", verbose=DEBUG)


### PR DESCRIPTION
- setup_cdrom() was overwriting output initrd from preseed_initrd()
- Added comment making reason for initrd.img name clear

Signed-off-by: Chris Evich cevich@redhat.com
