### PR TITLE
virttest-virsh: Set auto_close before raise Error in init of VirshSession.

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -168,6 +168,7 @@ class VirshSession(aexpect.ShellSession):
         if self.cmd_status('list', timeout=60) != 0:
             logging.debug("Persistent virsh session is not responding, "
                           "libvirtd may be dead.")
+            self.auto_close = True
             raise aexpect.ShellStatusError(virsh_exec, 'list')
 
 


### PR DESCRIPTION
If we failed to init VirshSession and catch a error. There will be a virsh process out of control, beacause default auto_close of VirshSession if False.
