### PR TITLE
KVM Test: Add new test boot from device

### DIFF
--- a/qemu/tests/boot_from_device.py
+++ b/qemu/tests/boot_from_device.py
@@ -1,0 +1,153 @@
+import logging, re, os
+from autotest.client import utils
+from virttest import utils_misc, data_dir
+from autotest.client.shared import error, iscsi
+
+
+@error.context_aware
+def run_boot_from_device(test, params, env):
+    """
+    KVM boot from device:
+    1) Start guest from device(hd/usb/scsi-hd)
+    2) Check the boot result
+    3) Log into the guest if it's up
+    4) Shutdown the guest if it's up
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+
+    def create_cdroms():
+        """
+        Create 'test' cdrom with one file on it
+        """
+
+        logging.info("creating test cdrom")
+        cdrom_test = params.get("cdrom_test")
+        cdrom_test = utils_misc.get_path(data_dir.get_data_dir(), cdrom_test)
+        utils.run("dd if=/dev/urandom of=test bs=10M count=1")
+        utils.run("mkisofs -o %s test" % cdrom_test)
+        utils.run("rm -f test")
+
+
+    def cleanup_cdroms():
+        """
+        Removes created cdrom
+        """
+
+        logging.info("cleaning up temp cdrom images")
+        cdrom_test = utils_misc.get_path(data_dir.get_data_dir(), params.get("cdrom_test"))
+        os.remove(cdrom_test)
+
+
+    def preprocess_remote_storage():
+        """
+        Prepare remote ISCSI storage for block image, and login session for
+        iscsi device.
+        """
+
+        device_name = None
+
+        iscsidevice = iscsi.Iscsi(params)
+        iscsidevice.login()
+        device_name = iscsidevice.get_device_name()
+        if not device_name:
+            iscsidevice.logout()
+            raise error.TestError("Fail to get iscsi device name")
+
+
+    def postprocess_remote_storage():
+        """
+        Logout from target.
+        """
+
+        iscsidevice = iscsi.Iscsi(params)
+        iscsidevice.logout()
+
+
+    def cleanup(dev_name):
+        if dev_name == "scsi-cd":
+            cleanup_cdroms()
+        elif dev_name == "iscsi-dev":
+            postprocess_remote_storage()
+
+
+    def check_boot_result(boot_fail_info, device_name):
+        """
+        Check boot result, and logout from iscsi device if boot from iscsi.
+        """
+
+        logging.info("Wait for display and check boot info.")
+        infos = boot_fail_info.split(';')
+        f = lambda: re.search(infos[0], vm.serial_console.get_output())
+        utils_misc.wait_for(f, timeout, 1)
+
+        logging.info("Try to boot from '%s'" % device_name)
+        try:
+            if dev_name == "hard-drive" or (dev_name == "scsi-hd" and not
+                                            params.get("image_name_stg")):
+                error.context("Log into the guest to verify it's up",
+                               logging.info)
+                session = vm.wait_for_login(timeout=timeout)
+                session.close()
+                vm.destroy()
+                return
+
+            output = vm.serial_console.get_output()
+
+            for i in infos:
+                if not re.search(i, output):
+                    raise error.TestFail("Could not boot from"
+                                         " '%s'" % device_name)
+        finally:
+            cleanup(device_name)
+
+
+    dev_name = params.get("dev_name")
+    if dev_name == "scsi-cd":
+        create_cdroms()
+        vm = env.get_vm(params["main_vm"])
+        vm.create()
+    elif dev_name == "iscsi-dev":
+        preprocess_remote_storage()
+        vm = env.get_vm(params["main_vm"])
+        vm.create()
+    else:
+        vm = env.get_vm(params["main_vm"])
+        vm.verify_alive()
+
+    timeout = int(params.get("login_timeout", 360))
+    boot_menu_key = params.get("boot_menu_key", 'f12')
+    boot_menu_hint = params.get("boot_menu_hint")
+    boot_fail_info = params.get("boot_fail_info")
+    boot_device = params.get("boot_device")
+
+    if boot_device:
+        f = lambda: re.search(boot_menu_hint, vm.serial_console.get_output())
+        if not utils_misc.wait_for(f, timeout, 1):
+            cleanup(dev_name)
+            raise error.TestFail("Could not get boot menu message. "
+                                 "Excepted Result: '%s'" % boot_menu_hint)
+
+        # Send boot menu key in monitor.
+        vm.send_key(boot_menu_key)
+
+        output = vm.serial_console.get_output()
+        boot_list = re.findall("^\d+\. (.*)\s", output, re.M)
+
+        if not boot_list:
+            cleanup(dev_name)
+            raise error.TestFail("Could not get boot entries list.")
+
+        logging.info("Got boot menu entries: '%s'", boot_list)
+        for i, v in enumerate(boot_list, start=1):
+            if re.search(boot_device, v, re.I):
+                logging.info("Start guest from boot entry '%s'" % boot_device)
+                vm.send_key(str(i))
+                break
+        else:
+            raise error.TestFail("Could not get any boot entry match "
+                                 "pattern '%s'" % boot_device)
+
+    check_boot_result(boot_fail_info, dev_name)

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -1,0 +1,79 @@
+- boot_from_device:
+    no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+    type = boot_from_device
+    boot_menu = on
+    enable_sga = yes
+    image_boot = no
+    virt_test_type = qemu
+    boot_menu_key = "f12"
+    boot_menu_hint = "Press F12 for boot menu"
+    boot_fail_info = "Booting from Hard Disk...;"
+    boot_fail_info += "Boot failed: not a bootable disk"
+    variants:
+        - boot_from_hard_drive:
+            dev_name = hard-drive
+            bootindex_image1 = 1
+        - boot_from_usb_stg:
+            dev_name = usb-storage
+            usb_devices = ""
+            usbs = usb1
+            usb_type_usb1 = usb-ehci
+            images += " stg"
+            image_name_stg = "images/usbdevice"
+            image_format_stg = "qcow2"
+            drive_format_stg = "usb2"
+            image_size_stg = 100M
+            create_image_stg = yes
+            remove_image_stg = yes
+            variants:
+                - with_new_device:
+                    bootindex_stg = 1
+                - with_specify_device:
+                    # Specify the boot device name which you want to test here.
+                    boot_device = "USB MSC Drive"
+        - boot_from_scsi_hd:
+            dev_name = scsi-hd
+            drive_format_image1 = scsi-hd
+            variants:
+                - with_local_device:
+                    bootindex_image1 = 1
+                - with_new_device:
+                    images = " stg"
+                    image_name_stg = "images/scsidevice"
+                    image_format_stg = "qcow2"
+                    drive_format_stg = scsi-hd
+                    image_size_stg = 1G
+                    create_image_stg = yes
+                    remove_image_stg = yes
+                    bootindex_stg = 1
+                - with_specify_device:
+                    boot_device = "virtio-scsi Drive"
+        - boot_from_scsi_cdrom:
+            start_vm = no
+            dev_name = scsi-cd
+            cdroms = "test"
+            cdrom_test = /tmp/test.iso
+            cd_format = scsi-cd
+            boot_fail_info = "Booting from DVD/CD...;"
+            boot_fail_info += "Boot failed: Could not read from CDROM"
+            variants:
+                - with_local_iso:
+                    bootindex_test = 1
+                - with_specify_device:
+                    boot_device = "DVD/CD"
+        - boot_from_iscsi_device:
+            start_vm = no
+            dev_name = iscsi-dev
+            portal_ip = 10.66.90.100
+            initiator = "iqn.2010-07.com.redhat:kvmautotest"
+            target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-puyiqiao"
+            images = "stg"
+            image_name_stg = "/dev/sdb"
+            image_format_stg = ""
+            drive_format_stg = scsi-block
+            variants:
+                - with_remote_stg:
+                    bootindex_stg = 1
+                - with_specify_device:
+                    boot_device = "virtio-scsi Drive"
+


### PR DESCRIPTION
This patch adds new test boot from device(hd/usb/scsi-hd/scsi-cd/scsi-block).

changes from v1:
1) add subtests(boot_from_hd, boot_from_scsi_hd) into the patch.
2) modified some function.

changes from v2:
1) add subtests(boot_from_scsi_cd, boot_from_scsi_block) into the patch.
2) add some function, such as: preprocess_remote_storage(), preprocess_remote_storage()

changes from v3:
1) add master_cdroms/cleanup_cdroms function.

changes from v4:
1) modified some functions.

changes from v5:
1) change some error.TestFail to error.TestError
2) add cleanup function before raising exception
3) fix some grammer error

changes from v6:
1) remove tmp cd file
2) update check result branch

changes from v7:
1) update some code style issue.

changes from v8:
1) rename master_cdroms function name
2) update code style issue
3) add check some param

changes from v9:
1) update code style

Signed-off-by: Shuping Cui scui@redhat.com
Signed-off-by: Feng Yang fyang@redhat.com

Have merge several internal patch to one.
