### PR TITLE
Sync Qemu killer report test case to upstream.

### DIFF
--- a/qemu/tests/cfg/qemu_killer_report.cfg
+++ b/qemu/tests/cfg/qemu_killer_report.cfg
@@ -1,4 +1,4 @@
 - qemu_killer_report:
     type = qemu_killer_report
     virt_test_type = qemu
-    qemu_error_re = signal 15 from pid ([0-9]*)
+    qemu_error_re = "signal 15 from pid ([0-9]+)"


### PR DESCRIPTION
This request sync qemu_killer_report test case to upstream.  And also make some update on the code in patch "qemu: Use wait_for replace hardcode sleep time"

Will backport this patch when it applied by upstream to our internal tree.  Better do not merge these two patches to one.

Thanks.
