### PR TITLE
virttest.qemu_monitor: Verify hmp cmd in qmp as well

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -979,6 +979,7 @@ class QMPMonitor(Monitor):
             self.protocol = "qmp"
             self._greeting = None
             self._events = []
+            self._supported_hmp_cmds = []
 
             # Make sure json is available
             try:
@@ -1004,6 +1005,7 @@ class QMPMonitor(Monitor):
             self.cmd("qmp_capabilities")
 
             self._get_supported_cmds()
+            self._get_supported_hmp_cmds()
 
         except MonitorError, e:
             self._close_sock()
@@ -1107,6 +1109,43 @@ class QMPMonitor(Monitor):
 
         if not self._supported_cmds:
             logging.warn("Could not get supported monitor cmds list")
+
+
+    def _get_supported_hmp_cmds(self):
+        """
+        Get supported human monitor cmds list.
+        """
+        cmds = self.human_monitor_cmd("help", debug=False)
+        if cmds:
+            cmd_list = re.findall(r"(?:^\w+\|(\w+)\s)|(?:^(\w+?)\s)", cmds, re.M)
+            self._supported_hmp_cmds = [(i + j) for i, j in cmd_list if i or j]
+
+        if not self._supported_cmds:
+            logging.warn("Could not get supported monitor cmds list")
+
+
+    def _has_hmp_command(self, cmd):
+        """
+        Check wheter monitor support hmp 'cmd'.
+
+        @param cmd: command string which will be checked.
+
+        @return: True if cmd is supported, False if not supported.
+        """
+        if cmd and cmd in self._supported_hmp_cmds:
+            return True
+        return False
+
+
+    def verify_supported_hmp_cmd(self, cmd):
+        """
+        Verify whether cmd is supported by hmp monitor.
+        If not, raise a MonitorNotSupportedCmdError Exception.
+
+        @param cmd: The cmd string need to verify.
+        """
+        if not self._has_hmp_command(cmd):
+            raise MonitorNotSupportedCmdError(self.name, cmd)
 
 
     def _log_response(self, cmd, resp, debug=True):
@@ -1417,6 +1456,8 @@ class QMPMonitor(Monitor):
             if not self._has_command(command):
                 if "=" in cmdline:
                     command = cmdline.split()[0]
+                    self.verify_supported_hmp_cmd(command)
+
                     cmdargs = " ".join(cmdline.split()[1:]).split(",")
                     for arg in cmdargs:
                         command += " " + arg.split("=")[-1]
@@ -1459,11 +1500,11 @@ class QMPMonitor(Monitor):
         Request info about something and return the response.
         """
         cmd = "query-%s" % what
-        if self._has_command(cmd):
-            return self.cmd("query-%s" % what)
-        else:
+        if not self._has_command(cmd):
             cmd = "info %s" % what
             return self.human_monitor_cmd(cmd)
+
+        return self.cmd(cmd)
 
 
     def query(self, what):
@@ -1482,12 +1523,14 @@ class QMPMonitor(Monitor):
 
         @return: The response to the command
         """
-        if self._has_command("screendump"):
-            args = {"filename": filename}
-            return self.cmd(cmd="screendump", args=args, debug=debug)
-        else:
-            cmdline = "screendump %s" % filename
+        cmd = "screendump"
+        if not self._has_command(cmd):
+            self.verify_supported_hmp_cmd(cmd)
+            cmdline = "%s %s" % (cmd, filename)
             return self.human_monitor_cmd(cmdline, debug=debug)
+
+        args = {"filename": filename}
+        return self.cmd(cmd=cmd, args=args, debug=debug)
 
 
     def sendkey(self, keystr, hold_time=1):


### PR DESCRIPTION
Some QMP's interface will fallback to HMP if there is no
match QMP command, this patch checks HMP before calling
HMP cmd in QMP, to avoid some unexpected failure.

Signed-off-by: Qingtang Zhou qzhou@redhat.com
