### PR TITLE
virttest.qemu_vm: VM.verify_alive() changes

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -173,9 +173,10 @@ class VM(virt_vm.BaseVM):
         """
         Verify if the userspace component (qemu) crashed.
         """
-        for line in self.process.get_output().splitlines():
-            if "(core dumped)" in line:
-                raise QemuSegFaultError(line)
+        if "(core dumped)" in self.process.get_output():
+            for line in self.process.get_output().splitlines():
+                if "(core dumped)" in line:
+                    raise QemuSegFaultError(line)
 
     def verify_kvm_internal_error(self):
         """


### PR DESCRIPTION
Hi guys,

the first patch adds support for catching KVM internal errors (They are easily to seen by executing `qemu_no_shutdown` https://github.com/autotest/virt-test/pull/379 test when using `reset_interval = 0`, using smp).

The second patch is only a proposal how to speed-up another similar function.

Regards,
Lukáš
