### PR TITLE
qemu.tests : Add new test boot_order_check

### DIFF
--- a/qemu/tests/boot_order_check.py
+++ b/qemu/tests/boot_order_check.py
@@ -1,0 +1,83 @@
+import logging, re
+from autotest.client import utils
+from virttest import utils_misc
+from autotest.client.shared import error
+
+
+@error.context_aware
+def run_boot_order_check(test, params, env):
+    """
+    KVM Autotest set boot order for multiple NIC and block devices
+    1) Boot the vm with deciding bootorder for multiple block and NIC devices
+    2) Check the guest boot order, should try to boot guest os
+       from the device whose bootindex=1, if this fails, it
+       should try device whose bootindex=2, and so on, till
+       the guest os succeeds to boot or fails to boot
+
+    @param test: kvm test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment
+    """
+    error.context("Boot vm by passing boot order decided", logging.info)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    vm.pause()
+
+    # Disable nic device, boot fail from nic device except user model
+    if params['nettype'] != 'user':
+        for nic in vm.virtnet:
+            utils.system("ifconfig %s down" % nic.ifname)
+
+    vm.resume()
+
+    timeout = int(params.get("login_timeout", 240))
+    bootorder_type = params.get("bootorder_type")
+    backspace_char = params.get("backspace_char")
+    boot_fail_infos = params.get("boot_fail_infos")
+    bootorder = params.get("bootorder")
+    nic_addr_filter = params.get("nic_addr_filter")
+    output = None
+    list_nic_addr = []
+
+    # As device id in the last line of info pci output
+    # We need reverse the pci infomation to get the pci addr which is in the
+    # front row.
+    pci_info = vm.monitor.info("pci")
+    pci_list = str(pci_info).split("\n")
+    pci_list.reverse()
+    pci_info = " ".join(pci_list)
+    for nic in vm.virtnet:
+        nic_addr = re.findall(nic_addr_filter % nic.device_id, pci_info)
+        bootindex = "0%x" % int(params['bootindex_%s' % nic.nic_name])
+        list_nic_addr.append((nic_addr, bootindex[-2]))
+
+    list_nic_addr.sort(cmp = lambda x,y: cmp(x[1], y[1]))
+
+    boot_fail_infos = boot_fail_infos % (list_nic_addr[0][0],
+                                         list_nic_addr[1][0],
+                                         list_nic_addr[2][0])
+
+    error.context("Check the guest boot result", logging.info)
+    if bootorder_type == "type2":
+        session_serial = vm.wait_for_serial_login(timeout=timeout)
+        output = vm.serial_console.get_output()
+        session_serial.close()
+    else:
+        f = lambda: re.search("No bootable device.",
+                              vm.serial_console.get_output())
+        utils_misc.wait_for(f, timeout, 1)
+
+        output = vm.serial_console.get_output()
+
+    # find and replace some ascii characters to non-ascii char,
+    # like as: '\b' (backspace)
+    if backspace_char:
+        data = re.sub(r".%s" % backspace_char, "", output)
+    else:
+        data = output
+    result = re.findall(boot_fail_infos, data, re.S|re.M|re.I)
+
+    if not result:
+        raise error.TestFail("Got a wrong boot order, "
+                             "Excepted order: '%s'" % bootorder)

--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -1,0 +1,80 @@
+- boot_order_check:
+    virt_test_type = qemu
+    only Linux
+    type = boot_order_check
+    kill_vm = yes
+    boot_menu = on
+    enable_sga = yes
+    # we have QEMU machine with three NICs (virtio, e1000, rtl8139)
+    # and two disks (default, IDE). firmware should try to boot from the bootindex=1
+    # first. If this fails, it should try the bootindex=2 next, and so on.
+    nics = 'nic1 nic2 nic3'
+    nic_model_nic1 = virtio
+    nic_model_nic2 = e1000
+    nic_model_nic3 = rtl8139
+    device_id_nic1 = 'idNic1'
+    device_id_nic2 = 'idNic2'
+    device_id_nic3 = 'idNic3'
+    images += ' stg2'
+    image_name_stg2 = images/storage2
+    image_format_stg2 = qcow2
+    drive_format_stg2 = "ide"
+    image_size_stg2 = 2G
+    force_create_image_stg2 = yes
+    remove_image_stg2 = yes
+    # Char: '\b' (backspace)
+    backspace_char = '\x08'
+    nic_addr_filter = "%s.*?Bus\s+\d+,\s+device\s+(\d+)"
+    variants:
+        - bootorder0:
+            # Some firmware has limitations on which devices can be considered for
+            # booting. For instance, the PC BIOS boot specification allows only one
+            # disk to be bootable. If boot from disk fails for some reason, the BIOS
+            # won't retry booting from other disk. It still can try to boot from
+            # floppy or net, though.
+            bootorder_type = "type0"
+            bootorder = 'stg2 -> nic2 -> nic1 -> nic3'
+            bootindex_image1 = 2
+            bootindex_stg2 = 1
+            bootindex_nic1 = 4
+            bootindex_nic2 = 3
+            bootindex_nic3 = 5
+            boot_fail_infos = "Booting from Hard Disk.*"
+            boot_fail_infos += "Boot failed: not a bootable disk.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out"
+        - bootorder1:
+            bootorder_type = "type1"
+            bootorder = 'nic1 -> stg2 -> nic2 -> nic3'
+            bootindex_image1 = 4
+            bootindex_stg2 = 2
+            bootindex_nic1 = 1
+            bootindex_nic2 = 3
+            bootindex_nic3 = 5
+            boot_fail_infos = "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "Booting from Hard Disk.*"
+            boot_fail_infos += "Boot failed: not a bootable disk.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out"
+        - bootorder2:
+            bootorder_type = "type2"
+            bootorder = 'nic1 -> nic2 -> nic3 -> image1'
+            bootindex_image1 = 4
+            bootindex_stg2 = 5
+            bootindex_nic1 = 1
+            bootindex_nic2 = 2
+            bootindex_nic3 = 3
+            boot_fail_infos = "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "Booting from Hard Disk"


### PR DESCRIPTION
add new case boot_order_check

changes from v1:
1) update time.sleep to wait_for()
2) add some comments
3) modify replace ascii char(backspace)

changes from v2:
1) fix check whether guest is booted

changes from v3:
1) move boot_fail_infos to the cfg files
2) update the check branch

changes from v4:
1) update the TestFail info

changes from v5:
1) check the boot order by boot_fail_infos

changes from v6:
1) get the nic_addr from 'info pci'

chages from v7:
1) add func to get nic_addr from nic_device_id

Signed-off-by: Shuping Cui scui@redhat.com
Acked-by: Feng Yang fyang@redhat.com
