### PR TITLE
tests.cfg: Add a config block for simple ping test

### DIFF
--- a/tests/cfg/ping.cfg
+++ b/tests/cfg/ping.cfg
@@ -4,6 +4,7 @@
     counts = 100
     flood_minutes = 10
     variants:
+        - default_ping:
         - multi_nics:
             nics += ' nic2'
         - ext_host:


### PR DESCRIPTION
The ping test contains 2 subtest now, this patch adds one
more subtest for a simple single-nic-card ping test.

Signed-off-by: Qingtang Zhou qzhou@redhat.com
