### PR TITLE
qemu.tests: Add case for device properties bit check

### DIFF
--- a/qemu/tests/cfg/device_bit_check.cfg
+++ b/qemu/tests/cfg/device_bit_check.cfg
@@ -1,0 +1,39 @@
+- device_bit_check:
+    virt_test_type = qemu
+    type = device_bit_check
+    start_vm = no
+    test_loop = "default;0 1;0 0"
+    Windows:
+        check_in_guest = no
+    # Parameters for this case and have default values in script.
+    # Can be set up to others for more bit check
+    # The properties bit name in command line and monitor
+    # This should be a basic parameter for this case
+    # And the following parameters should keep the same structure with this one.
+    # options = "indirect_desc event_idx"
+    # option value should add in command line for the options
+    # option_add = "off off"
+    # default value for the options when don't set them in command line
+    # default_value = "1 1"
+    # the bit offset when check the options inside guest
+    # options_offset = "28 29"
+    # dev_pattern =  "(dev: virtio-blk-pci.*?)dev:"
+    variants:
+        - block_device:
+            only virtio_blk virtio_scsi
+            virtio_blk:
+                dev_param_name = blk_extra_params
+                blk_extra_params = ""
+                pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio block device"
+                dev_type = virtio-blk-pci
+            virtio_scsi:
+                dev_param_name = scsi_extra_params_hda
+                pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Device 1004"
+                dev_type = virtio-scsi-pci
+                scsi_extra_params_hda = ""
+        - nic_device:
+            only virtio_net
+            nic_extra_params = ""
+            pci_id_pattern = "(\d+:\d+\.\d+)\s+Ethernet controller:.*?Virtio network device"
+            dev_type = virtio-net-pci
+            dev_param_name = nic_extra_params

--- a/qemu/tests/device_bit_check.py
+++ b/qemu/tests/device_bit_check.py
@@ -1,0 +1,82 @@
+import logging, re
+from autotest.client.shared import error
+from virttest import env_process
+
+
+@error.context_aware
+def run_device_bit_check(test, params, env):
+    """
+    Device bit check test:
+    We can set up some properties bits though qemu-kvm command line. This case
+    will check if those properties bits set up correctly by monitor command
+    'qtree' or inside guest by sysfs(only linux).
+    1) Boot up a guest with specific parameter
+    2) Verify the relevant bit of the device set correctly in the monitor
+       or inside guest(if it is possible)
+
+    @param test: qemu test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    default_value = params.get("default_value", "1 1").split()
+    option_add = params.get("option_add", "off off").split()
+    options = params.get("options", "indirect_desc event_idx").split()
+    options_offset = params.get("options_offset", "28 29").split()
+    test_loop = params.get("test_loop", "default").split(";")
+    timeout = float(params.get("login_timeout", 240))
+    dev_type = params.get("dev_type", "virtio-blk-pci")
+    dev_param_name = params.get("dev_param_name", "blk_extra_params")
+    dev_pattern = params.get("dev_pattern", "(dev: %s.*?)dev:" % dev_type)
+    pci_id_pattern = params.get("pci_id_pattern")
+    convert_dict = {"1": "on", "0": "off"}
+    for properties in test_loop:
+        if properties != "default":
+            properties = properties.strip().split()
+            for index, value in enumerate(properties):
+                if value != default_value[index]:
+                    params[dev_param_name] += ",%s=%s" % (options[index],
+                                                          option_add[index])
+                params[dev_param_name] = params[dev_param_name].lstrip(",")
+        else:
+            properties = default_value
+
+        error.context("Boot up guest with properites: %s value as: %s"\
+                      % (str(options), properties), logging.info)
+        vm_name = params["main_vm"]
+        params["start_vm"] = 'yes'
+        env_process.preprocess_vm(test, params, env, vm_name)
+
+        vm = env.get_vm(vm_name)
+
+        session = vm.wait_for_login(timeout=timeout)
+        qtree_info = vm.monitor.info("qtree")
+        dev_info = re.findall(dev_pattern, qtree_info, re.S)
+        if not dev_info:
+            raise error.TestError("Can't get device info from qtree result.")
+
+        for index, option in enumerate(options):
+            option_value = re.findall("%s\s+=\s+(\w+)" % option, dev_info[0])
+            if not option_value:
+                raise error.TestError("Can't get the property info from qtree"
+                                " result")
+            if option_value[0] != convert_dict[properties[index]]:
+                raise error.TestFail("Properity bit for %s is wrong." % option)
+
+            logging.info("Properity bit in qtree is right for %s." % option)
+            if params.get("check_in_guest", "yes") == "yes":
+                pci_info = session.cmd_output("lspci")
+                pci_n = re.findall(pci_id_pattern, pci_info)
+                if not pci_n:
+                    raise error.TestError("Can't get the pci id for device")
+                cmd = "cat /sys/bus/pci/devices/0000:%s/" % pci_n[0]
+                cmd += "virtio*/features"
+                bitstr = session.cmd_output(cmd)
+                bitstr = re.findall("[01]+", bitstr)[-1]
+
+                if bitstr[int(options_offset[index])] != properties[index]:
+                    raise error.TestFail("Properity bit for %s is wrong"
+                                         " inside guest." % option)
+            logging.info("Properity bit in qtree is right for %s"
+                         " in guest." % option)
+        session.close()
+        vm.destroy()


### PR DESCRIPTION
This case will check some properties bits for virtio devices set in
the command line. This script will support both block and nic devices.

Signed-off-by: Yiqiao Pu ypu@redhat.com
