### PR TITLE
qemu.tests: Add a kvm subtest format_disk.

### DIFF
--- a/qemu/tests/cfg/format_disk.cfg
+++ b/qemu/tests/cfg/format_disk.cfg
@@ -1,0 +1,19 @@
+- format_disk:
+    virt_test_type = qemu
+    type = format_disk
+    images += " disk1"
+    boot_drive_disk1 = yes
+    image_name_disk1 = images/storage
+    image_size_disk1 = 10G
+    force_create_image_disk1 = yes
+    writefile_cmd = echo
+    kill_vm = yes
+    cmd_timeout = 1200
+    # The following parameters will be overriden in guest-os config files.
+    create_partition_cmd = ""
+    format_cmd = cd /dev && for i in `ls | egrep [shv]db`;do yes |mkfs.ext3 $i; done
+    list_disk_cmd = ""
+    set_online_cmd = ""
+    mount_cmd =  cd /dev && ls | egrep [shv]db | xargs -I dev mount -t ext3 dev /media
+    testfile_name = /media/txt.txt
+    readfile_cmd = cat

--- a/qemu/tests/format_disk.py
+++ b/qemu/tests/format_disk.py
@@ -1,0 +1,90 @@
+import logging, re
+from autotest.client.shared import error
+from virttest import utils_misc
+
+@error.context_aware
+def run_format_disk(test, params, env):
+    """
+    Format guest disk:
+    1) Boot guest with second disk
+    2) Login to the guest
+    3) Get disk list in guest
+    4) Create partition on disk
+    5) Format the disk
+    6) Mount the disk
+    7) Read in the file to see whether content has changed
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    error.context("Login to the guest", logging.info)
+    session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
+    cmd_timeout = int(params.get("cmd_timeout", 360))
+
+    # Create a partition on disk
+    create_partition_cmd = params.get("create_partition_cmd")
+    if create_partition_cmd:
+        has_dispart = re.findall("diskpart", create_partition_cmd, re.I)
+        if (params.get("os_type") == 'windows' and has_dispart):
+            error.context("Get disk list in guest")
+            list_disk_cmd = params.get("list_disk_cmd")
+            s, o = session.cmd_status_output(list_disk_cmd,
+                                                     timeout=cmd_timeout)
+            for i in re.findall("Disk*.(\d+)\s+Offline",o):
+                error.context("Set disk '%s' to online status" % i,
+                              logging.info)
+                set_online_cmd = params.get("set_online_cmd") % i
+                s, o = session.cmd_status_output(set_online_cmd,
+                                                     timeout=cmd_timeout)
+                if s !=0:
+                    raise error.TestFail("Can not set disk online %s" % o)
+
+        error.context("Create partition on disk", logging.info)
+        s, o = session.cmd_status_output(create_partition_cmd,
+                                                 timeout=cmd_timeout)
+        if s != 0:
+            raise error.TestFail("Failed to create partition with error: %s" % o)
+        logging.info("Output of command of create partition on disk: %s" % o)
+
+    format_cmd = params.get("format_cmd")
+    if format_cmd:
+        error.context("Format the disk with cmd '%s'" % format_cmd,
+                      logging.info)
+        s, o = session.cmd_status_output(format_cmd,
+                                                 timeout=cmd_timeout)
+        if s != 0:
+            raise error.TestFail("Failed to format with error: %s" % o)
+        logging.info("Output of format disk command: %s" % o)
+
+    mount_cmd = params.get("mount_cmd")
+    if mount_cmd:
+        error.context("Mount the disk with cmd '%s'" % mount_cmd, logging.info)
+        s, o = session.cmd_status_output(mount_cmd, timeout=cmd_timeout)
+        if s != 0:
+            raise error.TestFail("Failed to mount with error: %s" % o)
+        logging.info("Output of mount disk command: %s" % o)
+
+    error.context("Write some random string to test file", logging.info)
+    testfile_name = params.get("testfile_name")
+    ranstr = utils_misc.generate_random_string(100)
+
+    writefile_cmd = params.get("writefile_cmd")
+    wfilecmd = writefile_cmd + " " + ranstr + " >" + testfile_name
+    s, o = session.cmd_status_output(wfilecmd, timeout=cmd_timeout)
+    if s != 0:
+        raise error.TestFail("Write to file error: %s" % o)
+
+    error.context("Read in the file to see whether content has changed",
+                  logging.info)
+    readfile_cmd = params.get("readfile_cmd")
+    rfilecmd = readfile_cmd + " " + testfile_name
+    s, o = session.cmd_status_output(rfilecmd, timeout=cmd_timeout)
+    if s != 0:
+        raise error.TestFail("Read file error: %s" % o)
+    if o.strip() != ranstr:
+        raise error.TestFail("The content writen to file has changed")
+    session.close()

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -126,6 +126,25 @@
         pci_test_cmd += " diskpart /s dt"
         block_virtio, blk_virtio_blk:
             match_string = "VirtIO SCSI Disk Device"
+    format_disk:
+        create_partition_cmd = "echo select disk 1 > cmd &&"
+        create_partition_cmd += " echo create partition primary >> cmd &&"
+        create_partition_cmd += " echo select partition 1 >> cmd &&"
+        create_partition_cmd += " echo assign letter=I >> cmd &&"
+        create_partition_cmd += " echo exit >> cmd &&"
+        create_partition_cmd += " diskpart /s cmd"
+        format_cmd = "format I: /FS:NTFS /V:local /Q /y"
+        list_disk_cmd = "echo list disk >  cmd &&"
+        list_disk_cmd += " echo exit >>  cmd &&"
+        list_disk_cmd += " diskpart /s cmd"
+        set_online_cmd = " echo select disk %s > cmd &&"
+        set_online_cmd += " echo online disk >> cmd &&"
+        set_online_cmd += " echo att disk clear readonly >> cmd &&"
+        set_online_cmd += " echo exit >> cmd &&"
+        set_online_cmd += " diskpart /s cmd"
+        testfile_name = I:\\txt.txt
+        readfile_cmd = type
+        mount_cmd =
     physical_resources_check:
         catch_uuid_cmd =
         cpu_vendor_id_chk_cmd = "wmic cpu get Manufacturer | more +1"


### PR DESCRIPTION
This test will simply create a file system on disk, mount it and write
a file with some content to the disk. Check whether the write could be
succeeded.

Signed-off-by: sshang sshang@redhat.com

Checking guest os type with 'guest_name' parameter may not
always work for all guests, and not supported by upstream.
Thus update all these places to using 'os_type'.

Signed-off-by: Qingtang Zhou qzhou@redhat.com

In the format disk test, the status of the harddisk is different in different
env in Windows guest. Should check if the disk plused is offline and writeable.

Signed-off-by: Yiqiao Pu ypu@redhat.com

This patch try to fix all the tab and trailing space problems.

Signed-off-by: Jason Wang jasowang@redhat.com

Make command timeout of format_disk.py scirpt longer and configurable

Signed-off-by: Feng Yang fyang@redhat.com
