### PR TITLE
qemu.tests: new test-case for qemu drive_mirror feature

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -54,3 +54,22 @@ variants:
                     - 3:
                         host_kernel_ver_str += ".3"
                         requires_kernel = [">= 2.6.32-279", "<  2.6.32-280"]
+            - 7:
+                # RHEL-7 pointer
+                host_kernel_ver_str += ".7"
+                netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\n"
+                drive_mirror:
+                    block_mirror_cmd = "drive-mirror"
+                    block_reopen_cmd = "block-job-complete"
+                    check_event = yes
+                ksm_base:
+                    status_query_cmd = "cat /sys/kernel/mm/ksm/run"
+                    setup_cmd = "echo 1 > /sys/kernel/mm/ksm/run"
+                    query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
+                virtio_net:
+                    vhost = "vhost=on"
+                variants:
+                    - 0:
+                        host_kernel_ver_str += ".0"
+                        requires_kernel = [">= 3.2.1-0.8"]
+                        machine_type = "pc"

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -1,0 +1,96 @@
+- drive_mirror:
+    no Host_RHEL.5
+    no Host_RHEL.6.1
+    no Host_RHEL.6.2
+    only qcow2
+    type = drive_mirror
+    monitor_type = qmp
+    monitors = qmpmonitor1
+    main_monitor = qmpmonitor1
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    block_mirror_cmd = "__com.redhat_drive-mirror"
+    block_reopen_cmd = "__com.redhat_drive-reopen"
+    wait_timeout = 3600
+    # wait_timeout: wait xx seconds for block mirror job go into steady status, aka offset equal image length
+    source_images = "image1"
+    # source_images: set which image will be mirroring to target, now only a image at one time;
+    full_copy_image1 = "full"
+    #for full image or top most
+    default_speed_image1 = 0
+    # default speed unit is B/s, for 10MB/s please set speed to '10M'
+    target_format_image1 = "qcow2"
+    create_mode_image1 = "absolute-paths"
+    target_image_image1 = "/tmp/target1"
+    check_event = no
+    variants:
+        - simple:
+            type = drive_mirror_simple
+            repeat_times = 3
+            cancel_timeout = 3
+            variants:
+                - cancel:
+                    before_steady = "cancel"
+                - set_speed:
+                    max_speed_image1 = 10M
+                    before_steady = "set_speed"
+                - reset_speed:
+                    default_speed_image1 = 10M
+                    max_speed_image1 = 1M
+                    before_steady = "set_speed"
+                - query:
+                    before_steady = "query_status"
+                    default_speed_image1 = 3M
+                    max_speed_image1 = 10M
+        - with_stress:
+            type = drive_mirror_stress
+            reopen_timeout = 360
+            variants:
+                - heavyload:
+                    tmp_dir = "/tmp"
+                    download_link = http://weather.ou.edu/~apw/projects/stress/stress-1.0.4.tar.gz
+                    md5sum = a607afa695a511765b40993a64c6e2f4
+                    install_cmd = "tar -xzvf %s/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install "
+                    config_cmd = ""
+                    app_check_cmd = "stress --help"
+                    start_cmd = "stress --cpu 4 --io 4 --vm 2 --vm-bytes 256M --quiet &"
+                    check_cmd = 'pidof -s stress'
+                    stop_cmd = "killall -g stress"
+                    variants:
+                        - stress:
+                            before_start = "load_stress"
+                            when_steady = "reopen"
+                            after_reopen = "reboot verify_alive"
+                        - stop:
+                            before_start = "load_stress"
+                            before_steady = "stop"
+                            when_steady = "reopen resume"
+                            after_reopen = "reboot verify_alive"
+                        - check_steady:
+                            before_start = "load_stress"
+                            when_steady = "verify_steady"
+                            #seconds to verify offset not decrease when guest in steady status
+                            hold_on_timeout = 300
+                            after_reopen = "reboot verify_alive"
+                - dd:
+                    app_check_cmd = "dd --help"
+                    start_cmd = "(dd if=/dev/urandom of=/tmp/tmp.img bs=4k count=500000 oflag=direct &)"
+                    check_cmd = "pidof dd"
+                    stop_cmd = "killall -g dd;rm -f /tmp/tmp.img"
+                    before_start = "load_stress"
+                    when_steady = "reopen"
+                    after_reopen = "reboot verify_alive"
+        - reboot:
+            type = drive_mirror_reboot
+            when_steady = "reopen stop_reset"
+            after_reopen = "reboot verify_alive"
+        - powerdown:
+            type = drive_mirror_powerdown
+            app_check_cmd = "uname"
+            start_cmd = 'sh -c "wget -c https://www.kernel.org/pub/linux/kernel/v2.6/longterm/v2.6.35/linux-2.6.35.14.tar.gz -O /mnt/Linux.tgz && '
+            start_cmd += 'tar -xzvf /mnt/Linux.tgz  -C /mnt && cd /mnt/linux-2.6.35.14 && make defconfig && make && make modules"'
+            check_cmd = 'pidof -s make'
+            stop_cmd = 'pkill sh;rm -rf /mnt/linux-2.6.35.14'
+            before_start = "load_stress"
+            when_steady = "powerdown"
+            after_reopen ="verify_alive"

--- a/qemu/tests/drive_mirror.py
+++ b/qemu/tests/drive_mirror.py
@@ -1,0 +1,130 @@
+import logging, time
+from autotest.client.shared import error
+from virttest import utils_misc
+from qemu.tests import block_copy
+
+class DriveMirror(block_copy.BlockCopy):
+    """
+    base class for block mirror tests;
+    """
+
+    def __init__(self, test, params, env, tag):
+        super(DriveMirror, self).__init__(test, params, env, tag)
+
+    def parser_test_args(self):
+        """
+        paraser test args and set default value;
+        """
+        params = super(DriveMirror, self).parser_test_args()
+        params["create_mode"] = params.get("create_mode", "absolute-path")
+        params["target_format"] = params.get("target_format", "qcow2")
+        params["reopen_timeout"] = int(params.get("reopen_timeout", 60))
+        params["full_copy"] = params.get("full_copy", "").lower()
+        params["check_event"] = params.get("check_event", "no").lower()
+        cmd = params.get("block_mirror_cmd", "__com.redhat.drive-mirror")
+        if cmd.startswith("__com.redhat"):
+            params["full_copy"] = (params["full_copy"] == "full")
+        return params
+
+    @error.context_aware
+    def start(self):
+        """
+        start block device mirroring job;
+        """
+        params = self.parser_test_args()
+        target_image = params.get("target_image")
+        default_speed = params.get("default_speed")
+        full_copy = params.get("full_copy")
+        create_mode = params.get("create_mode")
+        target_format = params.get("target_format")
+
+        error.context("start to mirror block device", logging.info)
+        self.vm.block_mirror(self.device, target_image, default_speed,
+                             full_copy, target_format, create_mode)
+        time.sleep(0.5)
+        started = self.get_status()
+        if not started:
+            raise error.TestFail("No active mirror job found")
+        self.trash.append(target_image)
+
+    @error.context_aware
+    def reopen(self):
+        """
+        reopen target image, then check if image file of the device is
+        target images;
+        """
+
+        params = self.parser_test_args()
+        target_image = params.get("target_image")
+        target_format = params.get("target_format")
+        reopen_timeout = params.get("reopen_timeout")
+
+        def is_opened():
+            device = self.vm.get_block({"file": target_image})
+            ret = (device == self.device)
+            if self.vm.monitor.protocol == "qmp":
+                ret &= bool(self.vm.monitor.get_event("BLOCK_JOB_COMPLETED"))
+            return  ret
+
+        error.context("reopen new target image", logging.info)
+        if self.vm.monitor.protocol == "qmp":
+            self.vm.monitor.clear_events()
+        self.vm.block_reopen(self.device, target_image, target_format)
+        opened = utils_misc.wait_for(is_opened, timeout=reopen_timeout)
+        if not opened:
+            msg = "Wait open new image timeout(%ss)" % reopen_timeout
+            raise error.TestFail(msg)
+
+    def is_steady(self):
+        """
+        check block device mirroring job is steady status or not;
+        """
+        params = self.parser_test_args()
+        info = self.get_status()
+        ret = (info["len"] == info["offset"])
+        if self.vm.monitor.protocol == "qmp":
+            check_event = params.get("check_event")
+            if check_event == "yes":
+                ret &= bool(self.vm.monitor.get_event("BLOCK_JOB_READY"))
+        return ret
+
+    def wait_for_steady(self):
+        """
+        check block device mirroring status, utils timeout; if still not go
+        into steady status, raise TestFail exception;
+        """
+        params = self.parser_test_args()
+        timeout = params.get("wait_timeout")
+        steady =utils_misc.wait_for(self.is_steady,
+                                     step=2.0, timeout=timeout)
+        if not steady:
+            raise error.TestFail("wait job goin ready status"
+                                 "timeout in %ss" % timeout)
+
+    def action_before_start(self):
+        """
+        run steps before job in steady status;
+        """
+        return self.do_steps("before_start")
+
+    def action_before_steady(self):
+        """
+        run steps before job in steady status;
+        """
+        return self.do_steps("before_steady")
+
+    def action_when_steady(self):
+        """
+        run steps when job in steady status;
+        """
+        self.wait_for_steady()
+        return self.do_steps("when_steady")
+
+    def action_after_reopen(self):
+        """
+        run steps after reopened new target image;
+        """
+        return self.do_steps("after_reopen")
+
+def run_drive_mirror(test, params, env):
+    pass

--- a/qemu/tests/drive_mirror_powerdown.py
+++ b/qemu/tests/drive_mirror_powerdown.py
@@ -1,0 +1,75 @@
+import logging
+from virttest import storage, data_dir
+from autotest.client.shared import error, utils
+from qemu.tests import drive_mirror_stress
+
+class DriveMirrorPowerdown(drive_mirror_stress.DriveMirrorStress):
+
+    def __init__(self, test, params, env, tag):
+        super(DriveMirrorPowerdown, self).__init__(test, params, env, tag)
+        params = self.params.object_params(self.tag)
+        image_file = storage.get_image_filename(params,
+                data_dir.get_data_dir())
+        self.params["image_file"] = image_file
+
+    @error.context_aware
+    def powerdown(self):
+        """
+        power down guest via quit qemu;
+        """
+        params = self.parser_test_args()
+        error.context("powerdown vm", logging.info)
+        self.vm.destroy()
+        error.context("backup base image", logging.info)
+        image_file = params.get("image_file")
+        cmd = "mv %s %s-bak" % (image_file, image_file)
+        utils.system(cmd)
+        return
+
+    @error.context_aware
+    def powerup(self):
+        """
+        bootup guest with target image, same as reopen new image;
+        steps are:
+        1). backup base image, move target image as base image
+        2). bootup guest with target image;
+        """
+        params = self.parser_test_args()
+        image_file = params.get("image_file")
+        target_image = params.get("target_image")
+        cmd = "yes|mv %s %s" % (target_image, image_file)
+        error.context("copy target image")
+        utils.system(cmd)
+        error.context("powerup vm with target image", logging.info)
+        self.vm.create()
+
+    def clean(self):
+        params = self.parser_test_args()
+        image_file = params.get("image_file")
+        super(DriveMirrorPowerdown, self).clean()
+        cmd = "yes|mv %s-bak %s" % (image_file, image_file)
+        utils.system(cmd)
+
+def run_drive_mirror_powerdown(test, params, env):
+    """
+    drive_mirror_powerdown test:
+    1). boot guest, do kernel build
+    3). mirror disk to target image
+    4). wait go into steady status, then quit qemu
+    5). bootup guest with target image
+    6). check guest can response correctly
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    tag = params.get("source_images", "image1")
+    powerdown_test = DriveMirrorPowerdown(test, params, env, tag)
+    try:
+        powerdown_test.action_before_start()
+        powerdown_test.start()
+        powerdown_test.action_when_steady()
+        powerdown_test.powerup()
+        powerdown_test.action_after_reopen()
+    finally:
+        powerdown_test.clean()

--- a/qemu/tests/drive_mirror_reboot.py
+++ b/qemu/tests/drive_mirror_reboot.py
@@ -1,0 +1,56 @@
+import time, random, logging
+from autotest.client.shared import error, utils
+from qemu.tests import drive_mirror
+
+class DriveMirrorReboot(drive_mirror.DriveMirror):
+
+    STOP = False
+
+    def __init__(self, test, params, env, tag):
+        super(DriveMirrorReboot, self).__init__(test, params, env, tag)
+
+    @error.context_aware
+    def start_reset(self):
+        """
+        Reset guest with system_reset in loop;
+        """
+        reboot_method = self.params.get("reboot_method", "system_reset")
+        error.context("reset/restart guest in loop", logging.info)
+        while not self.STOP:
+            self.reboot(method=reboot_method)
+            random_sleep =random.randint(3, 20)
+            time.sleep(random_sleep)
+        return None
+
+    @error.context_aware
+    def stop_reset(self):
+        """
+        stop reset guest loop;
+        """
+        error.context("stop reset/restart guest loop", logging.info)
+        self.STOP = True
+
+
+def run_drive_mirror_reboot(test, params, env):
+    """
+    drive_mirror_reboot test:
+    1). boot guest, do system_reset in loop
+    2). start mirroring, wait go into steady status
+    3). reopen new image and stop system_reset, then reboot guest
+    4). check guest alive
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    tag = params.get("source_images", "image1")
+    reboot_test = DriveMirrorReboot(test, params, env, tag)
+    try:
+        bg = utils.InterruptedThread(reboot_test.start_reset)
+        bg.start()
+        reboot_test.start()
+        reboot_test.action_when_steady()
+        bg.join()
+        reboot_test.action_after_reopen()
+    finally:
+        reboot_test.clean()

--- a/qemu/tests/drive_mirror_simple.py
+++ b/qemu/tests/drive_mirror_simple.py
@@ -1,0 +1,44 @@
+import logging, time, random
+from autotest.client.shared import error
+from qemu.tests import drive_mirror
+
+class DriveMirrorSimple(drive_mirror.DriveMirror):
+
+    def __init__(self, test, params, env, tag):
+        super(DriveMirrorSimple, self).__init__(test, params, env, tag)
+
+    @error.context_aware
+    def query_status(self):
+        """
+        query runing block mirroring job info;
+        """
+        error.context("query job status", logging.info)
+        if not self.get_status():
+            raise error.TestFail("No active job")
+
+
+def run_drive_mirror_simple(test, params, env):
+    """
+    drive_mirror_simple test:
+    1). launch block mirroring job w/o max speed
+    2). query job status on the device before steady status(optinal)
+    3). reset max job speed before steady status(optional)
+    4). cancel active job on the device before steady status(optional)
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    tag = params.get("source_images", "image1")
+    repeats = int(params.get("repeat_times", 3))
+    simple_test = DriveMirrorSimple(test, params, env, tag)
+    try:
+        for i in range(repeats):
+            v_max,v_min = int(params.get("login_timeout", 360)) / 4, 0
+            time.sleep(random.randint(v_min, v_max))
+            simple_test.start()
+            simple_test.action_before_steady()
+            if simple_test.get_status():
+                 simple_test.cancel()
+    finally:
+        simple_test.clean()

--- a/qemu/tests/drive_mirror_stress.py
+++ b/qemu/tests/drive_mirror_stress.py
@@ -1,0 +1,124 @@
+import time, logging
+from autotest.client.shared import error
+from autotest.client import utils
+from virttest import utils_misc
+from qemu.tests import drive_mirror
+
+class DriveMirrorStress(drive_mirror.DriveMirror):
+
+    def __init__(self, test, params, env, tag):
+        super(DriveMirrorStress, self).__init__(test, params, env, tag)
+
+    @error.context_aware
+    def install_stress_app(self):
+        error.context("install stress app in guest")
+        params = self.parser_test_args()
+        session = self.get_session()
+        installed = session.cmd_status(params.get("app_check_cmd")) == 0
+        if installed:
+            return
+        link = params.get("download_link")
+        md5sum = params.get("md5sum")
+        tmp_dir = params.get("tmp_dir")
+        install_cmd = params.get("install_cmd") % tmp_dir
+        config_cmd = params.get("config_cmd")
+        pkg = utils.unmap_url_cache(self.test.tmpdir, link, md5sum)
+        self.vm.copy_files_to(pkg, tmp_dir)
+        s, o = session.cmd_status_output(install_cmd, timeout=300)
+        if s != 0:
+            raise error.TestError("Fail to install stress app(%s)"  % o)
+        s, o = session.cmd_status_output(config_cmd, timeout=300)
+        if s != 0:
+            raise error.TestError("Fail to conifg stress app(%s)"  % o)
+
+
+    @error.context_aware
+    def load_stress(self):
+        """
+        load IO/CPU/Memoery stress in guest;
+        """
+        params = self.parser_test_args()
+        self.install_stress_app()
+        cmd = params.get("start_cmd")
+        session = self.get_session()
+        error.context("lanuch stress app in guest", logging.info)
+        session.sendline(cmd)
+        logging.info("Command: %s" % cmd)
+        runing = utils_misc.wait_for(self.app_runing, first=0.5, timeout=300)
+        if not runing:
+            raise error.TestFail("stress app isn't running")
+        return None
+
+    @error.context_aware
+    def unload_stress(self):
+        """
+        stop stress app
+        """
+        def _unload_stress():
+            params = self.parser_test_args()
+            session = self.get_session()
+            cmd = params.get("stop_cmd")
+            session.sendline(cmd)
+            if not self.app_runing():
+                return True
+            return False
+
+        error.context("stop stress app in guest", logging.info)
+        utils_misc.wait_for(_unload_stress, first=2.0,
+                text="wait stress app quit", step=1.0, timeout=120)
+
+    def app_runing(self):
+        """
+        check stress app really run in background;
+        """
+        session = self.get_session()
+        params = self.parser_test_args()
+        cmd = params.get("check_cmd")
+        status = session.cmd_status(cmd, timeout=120)
+        return status == 0
+
+    @error.context_aware
+    def verify_steady(self):
+        """
+        verify offset not decreased, after block mirror job in steady status;
+        """
+        error.context("verify offset not decreased", logging.info)
+        params = self.parser_test_args()
+        timeout = int(params.get("hold_on_timeout", 600))
+        offset = self.get_status()["offset"]
+        start = time.time()
+        while time.time() < start + timeout:
+            _offset = self.get_status()["offset"]
+            if _offset < offset:
+                msg = "offset decreased, offset last: %s" % offset
+                msg += "offset now: %s" % _offset
+                raise error.TestFail(msg)
+            offset = _offset
+
+
+def run_drive_mirror_stress(test, params, env):
+    """
+    drive_mirror_stress test:
+    1). load stress in guest
+    2). mirror block device
+    3). stop vm when mirroring job really run(optional)
+    4). wait for block job in steady status
+    5). check offset not decreased(optional)
+    6). reopen new target image(optional)
+    7). quit stress app, reboot guest(optional);
+    8). verify guest can response correctly
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    tag = params.get("source_image", "image1")
+    stress_test = DriveMirrorStress(test, params, env, tag)
+    try:
+        stress_test.action_before_start()
+        stress_test.start()
+        stress_test.action_before_steady()
+        stress_test.action_when_steady()
+        stress_test.action_after_reopen()
+    finally:
+        stress_test.clean()

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -225,3 +225,34 @@
         rename_error_image = yes
     balloon_check:
         free_mem_cmd = wmic os get FreePhysicalMemory
+    drive_mirror.with_stress.dd:
+        tmp_dir = "C:\"
+        #if this link not available, please download from http://www.chrysocome.net/downloads/dd-0.5.zip
+        download_link = "http://www.chrysocome.net/downloads/dd.exe"
+        md5sum = 168b73cc0f3d8c92c98c5028aec770df
+        install_cmd = 'mkdir "C:\Program Files\dd" && copy /b %s\dd.exe "C:\Program Files\dd\"'
+        config_cmd = 'setx path "%path%;C:\Program Files\dd" -m'
+        app_check_cmd = "dd --list"
+        start_cmd = "dd if=/dev/random of=c:\test.img bs=4k count=25000"
+        stop_cmd = 'taskkill /F /T /IM dd.exe & del /f /s /q "c:\test.img"'
+        check_cmd = 'tasklist | findstr /I  "dd.exe"'
+    drive_mirror.with_stress.heavyload:
+        tmp_dir = "C:\"
+        download_link = "http://www.jam-software.com/heavyload/HeavyLoadSetup.exe"
+        md5sum = 5bf187bd914ac8ce7f79361d7b56bc15
+        install_cmd = 'start /wait %s\HeavyLoadSetup.exe /verysilent'
+        config_cmd = 'setx path "%path%;C:\Program Files\JAM Software\HeavyLoad" -m'
+        app_check_cmd = "heavyload"
+        start_cmd = "heavyload /CPU /MEMORY /START"
+        check_cmd = 'tasklist | findstr /I  "heavyload.exe"'
+        stop_cmd = "taskkill /T /F /IM heavyload.exe"
+    drive_mirror.powerdown:
+        tmp_dir = "C:\"
+        download_link = "http://www.jam-software.com/heavyload/HeavyLoadSetup.exe"
+        md5sum = 5bf187bd914ac8ce7f79361d7b56bc15
+        install_cmd = 'start /wait %s\HeavyLoadSetup.exe /verysilent'
+        config_cmd = 'setx path "%path%;C:\Program Files\JAM Software\HeavyLoad" -m'
+        app_check_cmd = "heavyload"
+        start_cmd = "heavyload /CPU /MEMORY /START"
+        check_cmd = 'tasklist | findstr /I  "heavyload.exe"'
+        stop_cmd = "taskkill /T /F /IM heavyload.exe"

--- a/shared/cfg/guest-os/Windows/Win2003/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2003/x86_64.cfg
@@ -35,3 +35,7 @@
             dd_data_whqlqual = Basic
         device.net:
             image_name_supportvm = win2003-64-supportvm
+    drive_mirror.with_stress.heavyload:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
+    drive_mirror.powerdown:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'

--- a/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
@@ -1,5 +1,9 @@
 - x86_64:
     vm_arch_name = x86_64
+    drive_mirror.with_stress.heavyload:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
+    drive_mirror.powerdown:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
     variants:
         -sp1:
             image_name += -sp1-64

--- a/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
@@ -26,6 +26,10 @@
             dd_data_whqlqual = Logo
         device.net:
             image_name_supportvm = win7-64-supportvm
+    drive_mirror.with_stress.heavyload:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
+    drive_mirror.powerdown:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
     variants:
         - sp0:
         - sp1:

--- a/shared/cfg/guest-os/Windows/WinVista/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/WinVista/x86_64.cfg
@@ -6,6 +6,10 @@
         dd_data_whqlos = Windows Vista Client x64
         device:
             dd_data_whqlqual = Premium
+    drive_mirror.with_stress.heavyload:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
+    drive_mirror.powerdown:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
     variants:
         - sp1:
             image_name += -sp1-64

--- a/shared/cfg/guest-os/Windows/WinXP/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP/x86_64.cfg
@@ -28,3 +28,7 @@
             image_name_supportvm = winXP-64-supportvm
     multi_disk, usb_multi_disk:
         list_volume_command = fsutil fsinfo drives
+    drive_mirror.with_stress.heavyload:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'
+    drive_mirror.powerdown:
+        config_cmd = 'setx path "%path%;C:\Program Files (x86)\JAM Software\HeavyLoad" -m'


### PR DESCRIPTION
New test case for qemu drive-mirror feature, implement support to check 
1: Cancel live mirroring
2: Query live mirroring job status
3: Set live mirroring speed limit
4: Live mirroring while guest reboot
5: Stop guest during live mirroring
6: Power down during live mirroring steady state
7: Live mirroring when guest under stress
Know Issue:
Third-parted test tools used in test (eg, stress, heavyload, dd for windows), script will download them from Internet, but this links not always available so,  it's better to download them into a internal repo to ensure test run stably;

Signed-off-by: Xu Tian xutian@redhat.com
