### PR TITLE
virttest.qemu_vm: set global_image_bootindex to 1 when using -kernel

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1220,6 +1220,8 @@ class VM(virt_vm.BaseVM):
         vdisk = 0
         scsi_disk = 0
         global_image_bootindex = 0
+        if params.get("kernel"):
+            global_image_bootindex = 1
 
         qemu_binary = utils_misc.get_qemu_binary(params)
 


### PR DESCRIPTION
As -kernel option should take the bootindex 0, so we should make
global_image_bootindex for images bootindex count start from 1.

Signed-off-by: Yiqiao Pu ypu@redhat.com
