### PR TITLE
qemu.test: Add check_unhalt_vcpu test case

### DIFF
--- a/qemu/tests/cfg/check_unhalt_vcpu.cfg
+++ b/qemu/tests/cfg/check_unhalt_vcpu.cfg
@@ -1,0 +1,14 @@
+- check_unhalt_vcpu:
+    testcase = 'check_unhalt_vcpu'
+    type = check_unhalt_vcpu
+    images += " unbootable"
+    boot_drive = no
+    boot_drive_unbootable = yes
+    image_boot_unbootable = yes
+    image_name_unbootable = images/unbootable
+    image_size_unbootable = 10M
+    image_format_unbootable = qcow2
+    force_create_image_unbootable = yes
+    kill_vm = yes
+    remove_image_unbootable = yes
+    cpu_get_usage_cmd = PID=%s; top -n1 -b -p $PID | awk "{ if(\$1==$PID) {print \$9} }"

--- a/qemu/tests/check_unhalt_vcpu.py
+++ b/qemu/tests/check_unhalt_vcpu.py
@@ -1,0 +1,35 @@
+import logging, time
+from autotest.client.shared import error
+from autotest.client import utils
+
+def run_check_unhalt_vcpu(test, params, env):
+    """
+    Check unhalt vcpu of guest.
+    1) Use qemu-img create any image which can not boot.
+    2) Start vm with the image created by step 1
+    3) Use ps get qemu-kvm process %cpu, if greater than 90%, report fial.
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    pid = vm.get_pid()
+    if not pid:
+        raise error.TestError("Can't get pid of qemu")
+
+    sleep_time = params.get("sleep_time", 60)
+    time.sleep(sleep_time)
+
+    cpu_get_usage_cmd = params["cpu_get_usage_cmd"]
+    cpu_get_usage_cmd = cpu_get_usage_cmd % pid
+    cpu_usage = utils.system_output(cpu_get_usage_cmd)
+
+    try:
+        cpu_usage = float(cpu_usage)
+    except ValueError, detail:
+        raise error.TestError("Could not get correct cpu usage value with cmd"
+                          " '%s', detail: '%s'" % (cpu_get_usage_cmd, detail))
+
+    if cpu_usage >= 90:
+        raise error.TestFail("Guest have unhalt vcpu.")
+
+    logging.info("Guest vcpu work normally")


### PR DESCRIPTION
```
Kvm-test: Move files to right place and small bug fix

Signed-off-by: Yiqiao Pu <ypu@redhat.com>

KVM-Test: Increase sleep time in check_unhalt_vcpu

cpu usage is 100% at first in check_unhalt_vcpu testing,
but it decrease after several second,
10s is too short, increase the sleep time

Signed-off-by: Suqin Huang <shuang@redhat.com>

KVM-test: fix of get qemu pid

After mgoldish's change, vm.get_pid() rightly returns qemu's pid. No need us
'pgrep -P $shell_pid'.

Signed-off-by: Amos Kong <akong@redhat.com>

KVM: Check unhalt vcpu of guest.

(1) Use qemu-img create any image which can not boot.
(2) Start vm with the image created by step 1
(3) Use ps get qemu-kvm process %cpu, if greater than 90%, report fial.

Signed-off-by: sshang <sshang@redhat.com>
```
