### PR TITLE
qemu.test: Add cpuinfo_query test

### DIFF
--- a/qemu/tests/cfg/cpuinfo_query.cfg
+++ b/qemu/tests/cfg/cpuinfo_query.cfg
@@ -1,0 +1,19 @@
+- cpuinfo_query:
+    type = cpuinfo_query
+    vms = ''
+    variants:
+        - qcpu_id:
+            no Host_RHEL.5
+            query_cmd = " -cpu ?cpuid"
+            cpu_info = "f_edx,f_ecx,extf_edx,extf_ecx"
+        - qmachine_type:
+            query_cmd = " -M ?"
+            cpu_info = "pc,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
+        - qcpu_dump:
+            no Host_RHEL.5
+            query_cmd = " -cpu ?dump"
+            cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"
+        - qcpu_model:
+            no Host_RHEL.5
+            query_cmd = " -cpu ?model"
+            cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"

--- a/qemu/tests/cpuinfo_query.py
+++ b/qemu/tests/cpuinfo_query.py
@@ -1,0 +1,32 @@
+import logging, os
+from autotest.client.shared import error, utils
+from virttest import utils_misc
+
+@error.context_aware
+def run_cpuinfo_query(test, params, env):
+    """
+    cpuinfo query test:
+    1). run query cmd. e.g -cpu ?cpuid
+    2). check the expected info is inclued in the cmd output.
+    3). raise error if defined info is missing.
+    """
+    qemu_binary = utils_misc.get_path(os.path.join(test.bindir,
+                                      params.get("vm_type")),
+                                      params.get("qemu_binary", "qemu"))
+    error.context("run query cmd")
+    qcmd = params.get("query_cmd")
+    if qcmd is None:
+        raise error.TestError("query cmd is missing,"
+                              "pls check query_cmd in config file")
+    cmd = qemu_binary + qcmd
+    output = utils.system_output(cmd)
+
+    error.context("check if expected info is included in output of %s " % cmd)
+    cpuinfos = params.get("cpu_info", "Conroe").split(",")
+    missing = []
+    for cpuinfo in cpuinfos:
+        if not cpuinfo in output:
+            missing.append(cpuinfo)
+    if missing:
+        raise error.TestFail("%s is missing in the output\n %s" %
+                            (", ".join(missing), output))


### PR DESCRIPTION
1). cpuid query
2). cpu model query
3). cpu dump file quey
4). supported machine type query

Change from v1:
1). cpuid, model, dump query is not supported in rhel5, add the limitation
2). rhel5 machine type is diff from rhel6

Change from v2:
add rhel6.3 machine type configuration

Change from v3:
add default value to cpuinfos
add query_cmd notification

Change from v4:
update utils.cmd to utils.system_output

Signed-off-by: Suqin Huang shuang@redhat.com
