### PR TITLE
virttest/utils_misc:Remove aes flag for SandyBridge

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -669,7 +669,7 @@ def get_cpu_model():
                    "Haswell":
                    "fsgsbase,bmi1,hle,avx2,smep,bmi2,erms,invpcid,rtm",
                    "SandyBridge":
-                   "avx,xsave,aes,sse4_2|sse4.2,sse4.1|sse4_1,cx16,ssse3",
+                   "avx,xsave,sse4_2|sse4.2,sse4.1|sse4_1,cx16,ssse3",
                    "Westmere": "aes,sse4.2|sse4_2,sse4.1|sse4_1,cx16,ssse3",
                    "Nehalem": "sse4.2|sse4_2,sse4.1|sse4_1,cx16,ssse3",
                    "Penryn": "sse4.1|sse4_1,cx16,ssse3",
@@ -1260,7 +1260,7 @@ def get_host_cpu_models():
                    "Opteron_G2": "cx16",
                    "Opteron_G1": "",
                    "SandyBridge":
-                   "avx,xsave,aes,sse4_2|sse4.2,sse4.1|sse4_1,cx16,ssse3",
+                   "avx,xsave,sse4_2|sse4.2,sse4.1|sse4_1,cx16,ssse3",
                    "Westmere": "aes,sse4.2|sse4_2,sse4.1|sse4_1,cx16,ssse3",
                    "Nehalem": "sse4.2|sse4_2,sse4.1|sse4_1,cx16,ssse3",
                    "Penryn": "sse4.1|sse4_1,cx16,ssse3",


### PR DESCRIPTION
As flag 'aes' is not include in all SandyBridge CPUs, like
Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz in my desktop.

flags shows by "cat /proc/cpuinfo" :

fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca
cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht
tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs
bts nopl xtopology nonstop_tsc aperfmperf eagerfpu pni
pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16
xtpr pdcm pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer
 xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm
tpr_shadow vnmi flexpriority ept vpid

no flag 'aes'.

So remove aes from SandyBridge.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
