### PR TITLE
qemu.tests: Add a subtest disable_win_update for Windows guests

### DIFF
--- a/qemu/tests/cfg/disable_win_update.cfg
+++ b/qemu/tests/cfg/disable_win_update.cfg
@@ -1,0 +1,6 @@
+- disable_win_update:
+    virt_test_type = qemu
+    only Windows
+    type = disable_win_update
+    stop_update_service_cmd = net stop WuAuServ
+    disable_update_service_cmd = sc delete WuAuServ

--- a/qemu/tests/disable_win_update.py
+++ b/qemu/tests/disable_win_update.py
@@ -1,0 +1,29 @@
+import logging
+from autotest.client.shared import error
+
+
+def run_disable_win_update(test, params, env):
+    """
+    This simply stop updates services in Windows guests.
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=float(params.get("login_timeout", 240)))
+
+    stop_update_service_cmd = params.get("stop_update_service_cmd")
+    s, o = session.get_command_status_output(stop_update_service_cmd)
+    if s != 0:
+        logging.error("Failed to stop Windows update service: %s" % o)
+    else:
+        logging.info("Stopped Windows updates services")
+
+    disable_update_service_cmd = params.get("disable_update_service_cmd")
+    s, o = session.get_command_status_output(disable_update_service_cmd)
+    if s != 0:
+        logging.error("Turn off updates service failed: %s" % o)
+    else:
+        logging.info("Turned off windows updates service")


### PR DESCRIPTION
Sometimes Windows guests OS will automatically install updates
which can result in test timeout and guest be arbitrarily killed.
Therefore Windows OS registry table damanged unfortunately.
This patch will stop update service and delete it from installed.

Signed-off-by: Yolkfull Chow yzhou@redhat.com

This patch try to fix all the tab and trailing space problems.

Signed-off-by: Jason Wang jasowang@redhat.com

KVM test: Fix the typo in run_disable_win_update.

Signed-off-by: Jason Wang jasowang@redhat.com

Change 'int' to be 'float' to fix the bug of ValueError.

Signed-off-by: Yolkfull Chow yzhou@redhat.com

subtest disable_win_update: Add param login_timeout for booting guest

Signed-off-by: Yolkfull Chow yzhou@redhat.com
