### PR TITLE
qemu.tests: add qemu_io tests

### DIFF
--- a/qemu/tests/cfg/qemu_io.cfg
+++ b/qemu/tests/cfg/qemu_io.cfg
@@ -1,0 +1,14 @@
+- qemu_io:
+    virt_test_type = qemu
+    only Linux
+    only qcow2
+    type = qemu_io
+    vms = ''
+    variants:
+        - file_based:
+        - lvm_based:
+            test_type = "lvm"
+            vgtest_name = "vg_kvm_test_qemu_io"
+            lvtest_name = "lv_kvm_test_qemu_io"
+            test_image = "/dev/vg_kvm_test_qemu_io/lv_kvm_test_qemu_io"
+

--- a/qemu/tests/qemu_io.py
+++ b/qemu/tests/qemu_io.py
@@ -1,0 +1,146 @@
+import os, re, logging, time
+from autotest.client.shared import error
+from autotest.client import utils
+from virttest import aexpect, utils_misc, data_dir
+
+class QemuIOConfig(object):
+    """
+    Performs setup for the test qemu_io. This is a borg class, similar to a
+    singleton. The idea is to keep state in memory for when we call cleanup()
+    on postprocessing.
+    """
+    __shared_state = {}
+    def __init__(self, test, params):
+        self.__dict__ = self.__shared_state
+        root_dir = test.bindir
+        self.tmpdir = test.tmpdir
+        self.qemu_img_binary = params.get('qemu_img_binary')
+        if not os.path.isfile(self.qemu_img_binary):
+            self.qemu_img_binary = utils_misc.get_path(os.path.join(root_dir,
+                                                       params.get("vm_type")),
+                                                       self.qemu_img_binary)
+        self.raw_files = ["stg1.raw", "stg2.raw"]
+        self.raw_files = map(lambda f: os.path.join(self.tmpdir, f),
+                             self.raw_files)
+        # Here we're trying to choose fairly explanatory names so it's less
+        # likely that we run in conflict with other devices in the system
+        self.vgtest_name = params.get("vgtest_name", "vg_kvm_test_qemu_io")
+        self.lvtest_name = params.get("lvtest_name", "lv_kvm_test_qemu_io")
+        self.lvtest_device = "/dev/%s/%s" % (self.vgtest_name, self.lvtest_name)
+        try:
+            getattr(self, 'loopback')
+        except AttributeError:
+            self.loopback = []
+
+
+    @error.context_aware
+    def setup(self):
+        error.context("performing setup", logging.debug)
+        utils_misc.display_attributes(self)
+        # Double check if there aren't any leftovers
+        self.cleanup()
+        try:
+            for f in self.raw_files:
+                utils.run("%s create -f raw %s 10G" % (self.qemu_img_binary, f))
+                # Associate a loopback device with the raw file.
+                # Subject to race conditions, that's why try here to associate
+                # it with the raw file as quickly as possible
+                l_result = utils.run("losetup -f")
+                utils.run("losetup -f %s" % f)
+                loopback = l_result.stdout.strip()
+                self.loopback.append(loopback)
+                # Add the loopback device configured to the list of pvs
+                # recognized by LVM
+                utils.run("pvcreate %s" % loopback)
+            loopbacks = " ".join(self.loopback)
+            utils.run("vgcreate %s %s" % (self.vgtest_name, loopbacks))
+            # Create an lv inside the vg with starting size of 200M
+            utils.run("lvcreate -L 19G -n %s %s" %
+                      (self.lvtest_name, self.vgtest_name))
+        except Exception:
+            try:
+                self.cleanup()
+            except Exception, e:
+                logging.warn(e)
+            raise
+
+
+    @error.context_aware
+    def cleanup(self):
+        error.context("performing qemu_io cleanup", logging.debug)
+        if os.path.isfile(self.lvtest_device):
+            utils.run("fuser -k %s" % self.lvtest_device)
+            time.sleep(2)
+        l_result = utils.run("lvdisplay")
+        # Let's remove all volumes inside the volume group created
+        if self.lvtest_name in l_result.stdout:
+            utils.run("lvremove -f %s" % self.lvtest_device)
+        # Now, removing the volume group itself
+        v_result = utils.run("vgdisplay")
+        if self.vgtest_name in v_result.stdout:
+            utils.run("vgremove -f %s" % self.vgtest_name)
+        # Now, if we can, let's remove the physical volume from lvm list
+        p_result = utils.run("pvdisplay")
+        l_result = utils.run('losetup -a')
+        for l in self.loopback:
+            if l in p_result.stdout:
+                utils.run("pvremove -f %s" % l)
+            if l in l_result.stdout:
+                try:
+                    utils.run("losetup -d %s" % l)
+                except error.CmdError, e:
+                    logging.error("Failed to liberate loopback %s, "
+                                  "error msg: '%s'", l, e)
+
+        for f in self.raw_files:
+            if os.path.isfile(f):
+                os.remove(f)
+
+
+def run_qemu_io(test, params, env):
+    """
+    Run qemu_iotests.sh script:
+    1) Do some qemu_io operations(write & read etc.)
+    2) Check whether qcow image file is corrupted
+
+    @param test:   QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env:    Dictionary with test environment.
+    """
+
+    test_type = params.get("test_type")
+    qemu_io_config = None
+    if test_type == "lvm":
+        qemu_io_config = QemuIOConfig(test, params)
+        qemu_io_config.setup()
+
+    test_script = os.path.join(data_dir.get_root_dir(),
+                               'shared/scripts/qemu_iotests.sh')
+    logging.info("Running script now: %s" % test_script)
+    test_image = params.get("test_image", "/tmp/test.qcow2")
+    s, test_result = aexpect.run_fg("sh %s %s" % (test_script,
+                                                         test_image),
+                                           logging.debug, timeout = 1800)
+
+    err_string = {
+       "err_nums":    "\d errors were found on the image.",
+       "an_err":      "An error occurred during the check",
+       "unsupt_err":  "This image format does not support checks",
+       "mem_err":     "Not enough memory",
+       "open_err":    "Could not open",
+       "fmt_err":     "Unknown file format",
+       "commit_err":  "Error while committing image",
+       "bootable_err":  "no bootable device",
+       }
+
+    try:
+        for err_type in err_string.keys():
+            msg = re.findall(err_string.get(err_type), test_result)
+            if msg:
+                raise error.TestFail, msg
+    finally:
+        try:
+            if qemu_io_config:
+                qemu_io_config.cleanup()
+        except Exception, e:
+            logging.warn(e)

--- a/shared/scripts/qemu_iotests.sh
+++ b/shared/scripts/qemu_iotests.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+
+TEST_IMG=$1
+
+### regression function definition ###
+function regression() {
+
+    # Nolan I (incorrectly reports free clusters)
+    $QEMU_IMG create -f qcow2 $TEST_IMG 6G
+    $QEMU_IO <<EOF
+write 2048k 4k -P 65
+write 4k 4k
+write 9M 4k
+read 2044k 8k -P 65
+EOF
+    #FIXME: should use `$QEMU_IMG check $TEST_IMG` when the following
+    # bugs fixed:
+    # Bug 658753 - wrong file format when " qemu-img info " on lvm
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+
+    # Nolan II (wrong used cluster)
+    $QEMU_IMG create -f qcow2 $TEST_IMG 6G
+    $QEMU_IO <<EOF
+write 2048k 4k -P 165
+write 64k 4k
+write 9M 4k
+write 2044k 4k -P 165
+write 8M 4k -P 99
+read -P 165 2044k 8k
+EOF
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+
+    # Jason Wang (Regression for BZ#598407)
+    $QEMU_IMG create -f qcow2 -ocluster_size=512 $TEST_IMG 1G
+    $QEMU_IO <<EOF
+write -b 0 64M
+EOF
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+
+    # Avi (AIO allocation on the same cluster)
+
+    $QEMU_IMG create -f qcow2 $TEST_IMG 6G
+    for i in $(seq 1 10); do
+        off1=$(( i * 1024 * 1024 ))
+        off2=$(( i * 1024 * 1024 + 512 ))
+        $QEMU_IO <<EOF
+aio_write $off1 1M
+aio_write $off2 1M
+EOF
+    done
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+
+
+    # More AIO
+
+    $QEMU_IMG create -f qcow2 $TEST_IMG 6G
+    for i in $(seq 1 10); do
+        off1=$(( i * 1024 * 1024 ))
+        off2=$(( i * 1024 * 1024 + 512 ))
+        off3=$(( (i + 1) * 1024 * 1024 ))
+        $QEMU_IO <<EOF
+aio_write $off1 1M -P 99
+aio_write $off2 1M -P 123
+EOF
+        $QEMU_IO <<EOF
+read $off1 512 -P 99
+read $off3 512 -P 123
+EOF
+        $QEMU_IO <<EOF
+aio_write $off2 1M -P 88
+aio_write $off1 1M -P 234
+EOF
+        $QEMU_IO <<EOF
+read $off3 512 -P 88
+read $off1 512 -P 234
+EOF
+    done
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+
+    $QEMU_IMG create -f qcow2 $TEST_IMG 6G
+    for i in $(seq 1 10); do
+        off1=$(( i * 1024 * 1024 ))
+        off2=$(( i * 1024 * 1024 + 4096 ))
+        off3=$(( (i + 1) * 1024 * 1024 ))
+        $QEMU_IO <<EOF
+aio_write $off1 1M -P 99
+aio_write $off2 1M -P 123
+EOF
+        $QEMU_IO <<EOF
+read $off1 512 -P 99
+read $off3 512 -P 123
+EOF
+        $QEMU_IO <<EOF
+aio_write $off2 1M -P 88
+aio_write $off1 1M -P 234
+EOF
+        $QEMU_IO <<EOF
+read $off3 512 -P 88
+read $off1 512 -P 234
+EOF
+    done
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+
+    # bug 635354 by Feng Yang
+    $QEMU_IMG create -f raw $TEST_IMG 6G
+    $QEMU_IMG create -F raw -f qcow2 -b $TEST_IMG /tmp/$(basename $TEST_IMG).snapshot
+    $QEMU_IO <<EOF
+write 0 512k -P 3
+EOF
+    $QEMU_IMG commit /tmp/$(basename $TEST_IMG).snapshot
+
+    # Bug 558195
+    $QEMU_IMG create -f qcow2 test.qcow2 6G
+    $QEMU_IO <<EOF
+write 2M 4M -P 65
+EOF
+    $QEMU_IMG check -f qcow2 test.qcow2
+    mv test.qcow2 backing.qcow2
+
+    $QEMU_IMG create -f qcow2 -b backing.qcow2 test.qcow2
+    $QEMU_IO <<EOF
+write 4M 4M -P 97
+EOF
+    $QEMU_IMG check -f qcow2 test.qcow2
+    mv test.qcow2 overlay.qcow2
+
+    $QEMU_IMG convert -f qcow2 overlay.qcow2 -O qcow2 test.qcow2
+    $QEMU_IO <<EOF
+read 2M 2M -P 65
+read 4M 4M -P 97
+EOF
+    $QEMU_IMG check -f qcow2 test.qcow2
+}
+
+
+########### implement the qemu-io test ############
+
+QEMU_PATH="/usr/bin"
+QEMU_IMG="$QEMU_PATH/qemu-img"
+QEMU_IO="$QEMU_PATH/qemu-io "$TEST_IMG
+
+
+TEST_OFFSETS="0 4294967296"
+# TEST_OPS="writev read write readv aio_write readv"
+TEST_OPS="read write"
+
+function io_pattern() {
+    local op=$1
+    local start=$2
+    local size=$3
+    local step=$4
+    local count=$5
+    local pattern=$6
+
+    echo === IO: pattern $pattern >&2
+    for i in $(seq 1 $count); do
+        echo $op -P $pattern $(( start + i * step )) $size
+    done
+}
+
+function io() {
+    local start=$2
+    local pattern=$(( (start >> 9) % 256 ))
+
+    io_pattern $@ $pattern
+}
+
+function io_zero() {
+    io_pattern $@ 0
+}
+
+function io_test() {
+    local orig_offset=$1
+
+    for op in $TEST_OPS; do
+
+        offset=$orig_offset
+
+        # Complete clusters (size = 4k)
+        io $op $offset 4096 4096 256 | $QEMU_IO
+        offset=$((offset + 256 * 4096))
+
+        # From somewhere in the middle to the end of a cluster
+        io $op $((offset + 2048)) 2048 4096 256 | $QEMU_IO
+        offset=$((offset + 256 * 4096))
+
+        # From the start to somewhere in the middle of a cluster
+        io $op $offset 2048 4096 256 | $QEMU_IO
+        offset=$((offset + 256 * 4096))
+
+        # Completely misaligned (and small)
+        io $op $((offset + 1024)) 2048 4096 256 | $QEMU_IO
+        offset=$((offset + 256 * 4096))
+
+        # Spanning multiple clusters
+        io $op $((offset + 2048)) 8192 12288 64 | $QEMU_IO
+        offset=$((offset + 64 * 12288))
+
+        # Spanning multiple L2 tables
+        # L2 table size: 512 clusters of 4k = 2M
+        io $op $((offset + 2048)) 4194304 4999680 8 | $QEMU_IO
+        offset=$((offset + 8 * 4999680))
+if false; then
+    true
+fi
+    done
+}
+
+function io_test2() {
+    local orig_offset=$1
+
+    # Pattern (repeat after 9 clusters):
+    # used - used - free - used - compressed - compressed - free - free - compressed
+
+    # Write the clusters to be compressed
+    echo === Clusters to be compressed [1]
+    io_pattern writev $((offset + 4 * 4096)) 4096 $((9 * 4096)) 256 165 | $QEMU_IO
+    echo === Clusters to be compressed [2]
+    io_pattern writev $((offset + 5 * 4096)) 4096 $((9 * 4096)) 256 165 | $QEMU_IO
+    echo === Clusters to be compressed [3]
+    io_pattern writev $((offset + 8 * 4096)) 4096 $((9 * 4096)) 256 165 | $QEMU_IO
+
+    mv /tmp/test.qcow2 /tmp/test.orig
+    $QEMU_IMG convert -f qcow2 -O qcow2 -c /tmp/test.orig /tmp/test.qcow2
+
+    # Write the used clusters
+    echo === Used clusters [1]
+    io_pattern writev $((offset + 0 * 4096)) 4096 $((9 * 4096)) 256 165 | $QEMU_IO
+    echo === Used clusters [2]
+    io_pattern writev $((offset + 1 * 4096)) 4096 $((9 * 4096)) 256 165 | $QEMU_IO
+    echo === Used clusters [3]
+    io_pattern writev $((offset + 3 * 4096)) 4096 $((9 * 4096)) 256 165 | $QEMU_IO
+
+    # Read them
+    echo === Read used/compressed clusters
+    io_pattern readv $((offset + 0 * 4096)) $((2 * 4096)) $((9 * 4096)) 256 165 | $QEMU_IO
+    io_pattern readv $((offset + 3 * 4096)) $((3 * 4096)) $((9 * 4096)) 256 165 | $QEMU_IO
+    io_pattern readv $((offset + 8 * 4096)) $((1 * 4096)) $((9 * 4096)) 256 165 | $QEMU_IO
+
+    echo === Read zeros
+    io_zero readv $((offset + 2 * 4096)) $((1 * 4096)) $((9 * 4096)) 256 | $QEMU_IO
+    io_zero readv $((offset + 6 * 4096)) $((2 * 4096)) $((9 * 4096)) 256 | $QEMU_IO
+
+    # TODO Overwrite ranges containing multiple cluster types
+}
+
+# What needs to be checked?
+# - Images > 4 GB to avoid 32 bit truncation
+# - With backing file and without
+# - Compressed image, non-compressed image, images with both compressed and
+#   non-compressed clusters
+# - Encrypted image
+# - Read/Write operations...
+#   * ...on exactly one cluster (start - end)
+#   * ...on parts of one cluster (start offset, end offset, both)
+#   * ...spanning multiple clusters
+#   * ...spanning clusters of multiple L2 tables
+# - Snapshots (especially wrt refcounting)
+#   * copied clusters vs. cow clusters
+# - AIO
+#   * Concurrent overlapping writes
+
+# Run regression tests first
+regression
+
+#exit
+
+# Empty image
+$QEMU_IMG create -f qcow2 $TEST_IMG 6G
+for offset in $TEST_OFFSETS; do
+    io_test $offset
+    echo With offset $offset
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+done
+
+# Compressed image
+$QEMU_IMG create -f qcow2 /tmp/test.orig 6G
+$QEMU_IMG convert -f qcow2 -O qcow2 -c /tmp/test.orig $TEST_IMG
+ORIG_TEST_OPS="$TEST_OPS"
+#TEST_OPS="read readv"
+TEST_OPS="read"
+for offset in $TEST_OFFSETS; do
+    io_test $offset
+    echo test1: With offset $offset
+    $QEMU_IMG check -f qcow2 $TEST_IMG
+done
+TEST_OPS="$ORIG_TEST_OPS"
+for offset in $TEST_OFFSETS; do
+    # Some odd offset (1 sector), so tests will write to areas occupied partly
+    # by old (compressed) data and empty clusters
+    offset=$((offset + 512))
+    io_test $offset
+    echo With offset $offset
+    $QEMU_IMG check -f qcow2 /$TEST_IMG
+done
+if false; then
+	true
+fi
+
+# More interesting patterns
+#$QEMU_IMG create -f qcow2 /tmp/test.qcow2 6G
+#for offset in $TEST_OFFSETS; do
+#    io_test2 $offset
+#    echo test2: With offset $offset
+#    $QEMU_IMG check -f qcow2 /tmp/test.qcow2
+#done
+
+
+#exit
+
+# TODO Combine backing store and COW image
+
+# With snapshots
+for i in $(seq 1 3); do
+    $QEMU_IMG snapshot -c /tmp/test$i $TEST_IMG
+    for offset in $TEST_OFFSETS; do
+        io_test $offset
+        echo With snapshot test$i, offset $offset
+        $QEMU_IMG check -f qcow2 $TEST_IMG
+    done
+done


### PR DESCRIPTION
qemu_io test uses 'pre_command'/'post_command' to create/remove
loopback device, but it can't handle exception, if some cmd goes
wrong, the loopback devices would be left with used status.
This patch add a new class to create/cleanup loopback device
for qemu_io testing.

This patch also update 'script/qemu_iotest.sh' script, make it
create snapshot file in '/tmp' directory, instead creating file
in '/dev' dir.

Signed-off-by: Qingtang Zhou qzhou@redhat.com

Add case depends on exist bugs to regression function.

Udpate code style in regression.

Add missing for loop in regression.

Signed-off-by: Feng Yang fyang@redhat.com

The test_image is used to specify the image name to be tested. We could
also pass the raw device such as /dev/XXX to do teh qemu_io test.

Signed-off-by: Jason Wang jasowang@redhat.com

Current qemu_io.py launch qemuio_test.sh through kvm_subprocess.run_fg()
which does require an timeout value which default is 1 second. This patch
use 1800s.

Signed-off-by: Jason Wang jasowang@redhat.com
