### PR TITLE
qemu.tests: Add heavy disk write load test for windows guests

### DIFF
--- a/qemu/tests/cfg/win_disk_write.cfg
+++ b/qemu/tests/cfg/win_disk_write.cfg
@@ -1,0 +1,7 @@
+- win_disk_write:
+    virt_test_type = qemu
+    only Windows
+    type = win_disk_write
+    drive_cache = writeback
+    crystal_install_cmd = D:\cystaldisk_install.exe
+    crystal_run_cmd = D:\run_cystalfdisk.exe

--- a/qemu/tests/win_disk_write.py
+++ b/qemu/tests/win_disk_write.py
@@ -1,0 +1,40 @@
+import logging
+from autotest.client.shared import error
+
+
+@error.context_aware
+def run_win_disk_write(test, params, env):
+    """
+    KVM virtio viostor heavy random write load:
+    1) Log into a guest
+    2) Instaill Crystal Disk Mark
+    3) Start Crystal Disk Mark with heavy write load
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+    error.context("Try to log into guest.", logging.info)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    timeout = float(params.get("login_timeout", 240))
+    session = vm.wait_for_login(timeout=timeout)
+
+    crystal_install_cmd = params.get("crystal_install_cmd")
+    crystal_run_cmd = params.get("crystal_run_cmd")
+    test_timeout = float(params.get("test_timeout", "7200"))
+
+    error.context("Install Crystal Disk Mark", logging.info)
+    if crystal_install_cmd:
+        session.cmd(crystal_install_cmd, timeout=test_timeout)
+    else:
+        raise error.TestError("Can not get the crystal disk mark"
+                              " install command.")
+
+    error.context("Start the write load", logging.info)
+    if crystal_run_cmd:
+        session.cmd(crystal_run_cmd, timeout=test_timeout)
+    else:
+        raise error.TestError("Can not get the load start command.")
+
+    session.close()


### PR DESCRIPTION
Add heavy disk write load test for windows guests. Using Crystal
Disk Mark to generate the write load inside the guest. And set the
default cache to writeback in this test.

changes from v1:
- Record steps in INFO logs
- Close the session after test
- Add command empty check

Signed-off-by: Yiqiao Pu ypu@redhat.com
Acked-by: Feng Yang fyang@redhat.com
