### PR TITLE
tests: Snapshot list check for floppy when savevm

### DIFF
--- a/tests/boot_savevm.py
+++ b/tests/boot_savevm.py
@@ -1,5 +1,6 @@
 import logging, time, tempfile, os
 from autotest.client.shared import error
+from virttest import qemu_storage, data_dir
 
 
 def run_boot_savevm(test, params, env):
@@ -7,14 +8,30 @@ def run_boot_savevm(test, params, env):
     libvirt boot savevm test:
 
     1) Start guest booting
-    2) Periodically savevm/loadvm while guest booting
+    2) Record origin informations of snapshot list for floppy(optional).
+    3) Periodically savevm/loadvm while guest booting
     4) Stop test when able to login, or fail after timeout seconds.
+    5) Check snapshot list for floppy and compare with the origin
+       one(optional).
 
     @param test: test object
     @param params: Dictionary with the test parameters
     @param env: Dictionary with test environment.
     """
     vm = env.get_vm(params["main_vm"])
+    if params.get("with_floppy") == "yes":
+        floppy_name = params.get("floppies", "fl")
+        floppy_params = {"image_format": params.get("floppy_format", "qcow2"),
+                         "image_size": params.get("floppy_size", "1.4M"),
+                         "image_name": params.get("%s_name" % floppy_name,
+                                                  "images/test"),
+                         "vm_type": params.get("vm_type")}
+        floppy = qemu_storage.QemuImg(floppy_params,
+                                     data_dir.get_data_dir(), floppy_name)
+        floppy.create(floppy_params)
+        floppy_orig_info = floppy.snapshot_list()
+        vm.create(params=params)
+
     vm.verify_alive() # This shouldn't require logging in to guest
     savevm_delay = float(params.get("savevm_delay"))
     savevm_login_delay = float(params.get("savevm_login_delay"))
@@ -31,8 +48,12 @@ def run_boot_savevm(test, params, env):
         logging.info("Save/Restore cycle %d", cycles + 1)
         time.sleep(savevm_delay)
         vm.pause()
-        vm.save_to_file(savevm_statefile) # Re-use same filename
-        vm.restore_from_file(savevm_statefile)
+        if params['save_method'] == 'save_to_file':
+            vm.save_to_file(savevm_statefile) # Re-use same filename
+            vm.restore_from_file(savevm_statefile)
+        else:
+            vm.savevm("1")
+            vm.loadvm("1")
         vm.resume() # doesn't matter if already running or not
         vm.verify_kernel_crash() # just in case
         try:
@@ -50,3 +71,12 @@ def run_boot_savevm(test, params, env):
         raise error.TestFail("Can't log on '%s' %s" % (vm.name, info))
     else:
         logging.info("Test ended %s", info)
+
+    if params.get("with_floppy")  == "yes":
+        vm.destroy()
+        floppy_info = floppy.snapshot_list()
+        if floppy_info == floppy_orig_info:
+            raise error.TestFail("savevm didn't create snapshot in floppy."
+                                 "    original snapshot list is: %s"
+                                 "    now snapshot list is: %s"
+                                 % (floppy_orig_info, floppy_info))

--- a/tests/cfg/boot_savevm.cfg
+++ b/tests/cfg/boot_savevm.cfg
@@ -1,9 +1,23 @@
 - boot_savevm: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu libvirt
+    no raw
+    no raw_dd
     type = boot_savevm
+    save_method = save_to_file
     savevm_delay = 0.3
     savevm_login_delay = 5
     savevm_timeout = 2000
     kill_vm_on_error = yes
     kill_vm_gracefully = yes
     kill_vm = yes
+    variants:
+        - default_savevm:
+
+        - with_floppy:
+            virt_test_type = qemu
+            save_method = save_to_tag
+            with_floppy = yes
+            floppy_name = images/test.qcow2
+            floppies = fl
+            start_vm = no
+            floppy_format = qcow2

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3280,6 +3280,27 @@ class VM(virt_vm.BaseVM):
         self.verify_status('running') # Throws exception if not
 
 
+    def savevm(self, tag_name):
+        """
+        Override BaseVM savevm method
+        """
+        self.verify_status('paused') # Throws exception if not
+        logging.debug("Saving VM %s to %s" % (self.name, tag_name))
+        self.monitor.send_args_cmd("savevm id=%s" % tag_name)
+        self.monitor.cmd("system_reset")
+        self.verify_status('paused') # Throws exception if not
+
+
+    def loadvm(self, tag_name):
+        """
+        Override BaseVM loadvm method
+        """
+        self.verify_status('paused') # Throws exception if not
+        logging.debug("Loading VM %s from %s" % (self.name, tag_name))
+        self.monitor.send_args_cmd("loadvm id=%s" % tag_name)
+        self.verify_status('paused') # Throws exception if not
+
+
     def pause(self):
         """
         Pause the VM operation.

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1218,6 +1218,25 @@ class BaseVM(object):
         raise NotImplementedError
 
 
+    def savevm(self, tag_name):
+        """
+        Save the virtual machine as the tag 'tag_name'
+
+        @param: tag_name: tag of the virtual machine that saved
+
+        """
+        raise NotImplementedError
+
+
+    def loadvm(self, tag_name):
+        """
+        Load the virtual machine tagged 'tag_name'.
+
+        @param: tag_name: tag of the virtual machine that saved
+        """
+        raise NotImplementedError
+
+
     def pause(self):
         """
         Stop the VM operation.


### PR DESCRIPTION
Savevm should create scnapshot for floppy. Use qemu-img to check
the floppy snapshot list before and after savevm. Not sure if libvirt have similar operations so make this case only runs for qemu.
