### PR TITLE
qemu.tests: Add a subtest stub

### DIFF
--- a/qemu/tests/cfg/image_remove.cfg
+++ b/qemu/tests/cfg/image_remove.cfg
@@ -1,0 +1,5 @@
+- image_remove:
+    virt_test_type = qemu
+    kill_vm = yes
+    type = stub
+    remove_image = yes

--- a/qemu/tests/cfg/qemu_img_check.cfg
+++ b/qemu/tests/cfg/qemu_img_check.cfg
@@ -1,0 +1,8 @@
+- qemu_img_check:
+    virt_test_type = qemu
+    only qcow2
+    vms = ''
+    type = stub
+    post_command_noncritical = no
+    check_image = yes
+    post_command_timeout = 600

--- a/qemu/tests/stub.py
+++ b/qemu/tests/stub.py
@@ -1,0 +1,9 @@
+def run_stub(test, params, env):
+    """
+    A stub test case for using framework feature to do the test
+
+    @param test: Kvm test object
+    @param params: Dictionary with the test parameters.
+    @param env: Dictionary with test environment.
+    """
+    pass


### PR DESCRIPTION
This testcase which itself is doing nothing is used for dealing with VM(s)
via framework, i.e. create_image, destroy VM(s) etc.

Normally these two cases are used for a test loop overall check and clean up.
