### PR TITLE
virttest/qemu_vm:Fix unable to add nodefaults qemu command line

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1299,7 +1299,7 @@ class VM(virt_vm.BaseVM):
         qemu_cmd += add_name(help_text, name)
         # no automagic devices please
         use_nodefaults = params.get("use_nodefaults", "yes")
-        if has_option(help_text, "use_nodefaults") and use_nodefaults != "no":
+        if has_option(help_text, "nodefaults") and use_nodefaults != "no":
             qemu_cmd += " -nodefaults"
         # Add monitors
         for monitor_name in params.objects("monitors"):


### PR DESCRIPTION
has_option(help_text, "use_nodefaults") will always return false because
qemu help_text just has 'nodefaults' line, instead of 'use_nodefaults'.
So -nodefaults will never be used as qemu command line.

This patch is to avoid this error situation

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
