### PR TITLE
qemu.tests: Add a subtest tsc_drift

### DIFF
--- a/qemu/tests/cfg/tsc_drift.cfg
+++ b/qemu/tests/cfg/tsc_drift.cfg
@@ -1,0 +1,9 @@
+- tsc_drift:
+    virt_test_type = qemu
+    only Linux
+    type = tsc_drift
+    drift_threshold = 10
+    interval = 30
+    required_cpu_flags = "constant_tsc"
+    pre_command = "/usr/bin/python shared/scripts/check_cpu_flag.py"
+    smp_min = 2

--- a/qemu/tests/tsc_drift.py
+++ b/qemu/tests/tsc_drift.py
@@ -1,0 +1,94 @@
+import time, os, logging, commands, re
+from autotest.client.shared import error
+from autotest.client import local_host
+from virttest import data_dir
+
+
+def run_tsc_drift(test, params, env):
+    """
+    Check the TSC(time stamp counter) frequency of guest and host whether match
+    or not
+
+    1) Test the vcpus' TSC of host by C the program
+    2) Copy the C code to the guest, complie and run it to get the vcpus' TSC
+       of guest
+    3) Sleep sometimes and get the TSC of host and guest again
+    4) Compute the TSC frequency of host and guest
+    5) Compare the frequency deviation between host and guest with standard
+
+    @param test: Kvm test object
+    @param params: Dictionary with the test parameters.
+    @param env: Dictionary with test environment.
+    """
+
+    drift_threshold = float(params.get("drift_threshold"))
+    interval = float(params.get("interval"))
+    cpu_chk_cmd = params.get("cpu_chk_cmd")
+    tsc_freq_path = os.path.join(data_dir.get_root_dir(),
+                                 'shared/deps/get_tsc.c')
+    host_freq = 0
+
+    def get_tsc(machine="host", i=0):
+        cmd = "taskset -c %s ./a.out" % i
+        if machine == "host":
+            s, o = commands.getstatusoutput(cmd)
+        else:
+            s, o = session.get_command_status_output(cmd)
+        if s != 0:
+            raise error.TestError("Fail to get tsc of host, ncpu: %d" % i)
+        o = re.findall("(\d+)",o)[0]
+        return float(o)
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
+
+    commands.getoutput("gcc %s" % tsc_freq_path)
+    ncpu = local_host.LocalHost().get_num_cpu()
+
+    logging.info("Interval is %s" % interval)
+    logging.info("Determine the TSC frequency in the host")
+    for i in range(ncpu):
+        tsc1 = get_tsc("host", i)
+        time.sleep(interval)
+        tsc2 = get_tsc("host", i)
+
+        delta = tsc2 - tsc1
+        logging.info("Host TSC delta for cpu %s is %s" % (i, delta))
+        if delta < 0:
+            raise error.TestError("Host TSC for cpu %s warps %s" % (i, delta))
+
+        host_freq += delta / ncpu
+    logging.info("Average frequency of host's cpus: %s" % host_freq)
+
+    vm.copy_files_to(tsc_freq_path,'/tmp/get_tsc.c')
+    if session.get_command_status("gcc /tmp/get_tsc.c") != 0:
+        raise error.TestError("Fail to compile program on guest")
+
+    s, guest_ncpu = session.get_command_status_output(cpu_chk_cmd)
+    if s != 0:
+        raise error.TestError("Fail to get cpu number of guest")
+
+    success = True
+    for i in range(int(guest_ncpu)):
+        tsc1 = get_tsc("guest", i)
+        time.sleep(interval)
+        tsc2 = get_tsc("guest", i)
+
+        delta = tsc2 - tsc1
+        logging.info("Guest TSC delta for vcpu %s is %s" % (i, delta))
+        if delta < 0:
+            logging.error("Guest TSC for vcpu %s warps %s" % (i, delta))
+
+        ratio = 100 * (delta - host_freq) / host_freq
+        logging.info("TSC drift ratio for vcpu %s is %s" % (i, ratio))
+        if abs(ratio) > drift_threshold:
+            logging.error("TSC drift found for vcpu %s ratio %s" % (i, ratio))
+            success = False
+
+    if not success:
+        raise error.TestFail("TSC drift found for the guest, please check the "
+                             "log for details")
+
+    session.close()

--- a/shared/deps/get_tsc.c
+++ b/shared/deps/get_tsc.c
@@ -1,0 +1,27 @@
+/*
+ * Programme to get cpu's TSC(time stamp counter)
+ * Copyright(C) 2009 Redhat, Inc.
+ * Amos Kong <akong@redhat.com>
+ * Dec 9, 2009
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdint.h>
+
+typedef unsigned long long u64;
+
+u64 rdtsc(void)
+{
+	unsigned tsc_lo, tsc_hi;
+
+	asm volatile("rdtsc" : "=a"(tsc_lo), "=d"(tsc_hi));
+	return tsc_lo | (u64)tsc_hi << 32;
+}
+
+int main(void)
+{
+	printf("%lld\n", rdtsc());
+	return 0;
+}

--- a/shared/scripts/check_cpu_flag.py
+++ b/shared/scripts/check_cpu_flag.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+import os, sys
+
+class check_error(Exception):
+    pass
+
+def check_cpu_flag():
+    cpuinfo = file('/proc/cpuinfo').read()
+    flags = os.environ['KVM_TEST_required_cpu_flags']
+    for i in flags.split():
+        if not i in cpuinfo:
+            err_msg = "Host CPU doestn't have flag(%s)" % i
+            print err_msg
+            raise check_error(err_msg)
+
+if __name__ == "__main__":
+    check_cpu_flag()


### PR DESCRIPTION
Use taskset to set the CPU affinity of tsc read program in both guest and host.
Make the code easy to read and drop the tsc list for both guest and host.
Signed-off-by: Amos Kong akong@redhat.com

Use more reasonable varialbe name and optimize the code path.
Signed-off-by: Jason Wang jasowang@redhat.com

Convert tsc_drift ratio to absolute value
If tsc_drift ratio is a large negative, case could not raise exception.

Signed-off-by: Amos Kong akong@redhat.com

Filter integer from the return value of get_tsc

If the return value of get_tsc() contains other string, it will fail to convert
the return value to float. Use re.findall('(\d+)',o)[0] to filter tsc value.

Signed-off-by: Amos Kong akong@redhat.com

tsc_drift: Fix a bug of set CPU affinity

We need set process running on a single processor. There is a misunderstand of
mask and cpulist.
 "taskset 1 command": command will execute on CPU0 or CPU1, not only CPU1
 "taskset -c 1 command": command will only execute on CPU1

Signed-off-by: Amos Kong akong@redhat.com
Reported-by: Shuxi Shang sshang@redhat.com

Update interface to fit the new framework

Signed-off-by: Feng Yang fyang@redhat.com
Signed-off-by: Yiqiao Pu ypu@redhat.com
