### PR TITLE
qemu.qemu_img:Fix convert.to_qed and to_raw test cases SKIP

### DIFF
--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -21,11 +21,11 @@
             remove_image_large = yes
         - convert:
             subcommand = convert
+            compressed = no
+            encrypted = no
             variants:
                 - to_qcow2:
                     dest_image_format = qcow2
-                    compressed = no
-                    encrypted = no
                 - to_raw:
                     dest_image_format = raw
                 - to_qed:


### PR DESCRIPTION
Currently, qemu.convert.to_qed and qemu.convert.to_raw will
be skip, and the log is:

17:37:31 INFO | SKIP qcow2.virtio_blk.smp2.virtio_net.
Fedora.18.x86_64.qemu_img.convert.to_qed -> ParamNotFound:
Mandatory parameter 'compressed' is missing.
Check your cfg files for typos/mistakes

This is because in convert test, it will use params["compressed"]
and params["encrypted"], but for to_qed and to_raw, the two params
does not exits.
In old version virttest, it will be OK, as it use
params.get("compressed"), and it will return 'None', the test can
run safely.

But in the new version, it will just SKIP with no parameter
'compressed'.

This patch is to enable this two case.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
