### PR TITLE
qemu.enospc:update the test.bindir to data_dir.get_data_dir

### DIFF
--- a/qemu/tests/cfg/enospc.cfg
+++ b/qemu/tests/cfg/enospc.cfg
@@ -5,7 +5,7 @@
     images += " stg"
     drive_werror = stop
     drive_cache = none
-    image_name_stg = enospc
+    image_name_stg = images/enospc
     image_format_stg = qcow2
     image_boot_stg = no
     image_snapshot_stg = no

--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -146,9 +146,9 @@ def run_enospc(test, params, env):
             for image_name in vm.params.objects("images"):
                 image_params = vm.params.object_params(image_name)
                 try:
-                    image = qemu_storage.QemuImg(image_params, test.bindir,
-                                               image_name)
-                    image.check_image(image_params, test.bindir)
+                    image = qemu_storage.QemuImg(image_params,
+                                  data_dir.get_data_dir(), image_name)
+                    image.check_image(image_params, data_dir.get_data_dir())
                 except (virt_vm.VMError, error.TestWarn), e:
                     logging.error(e)
             logging.info("Guest paused, extending Logical Volume size")


### PR DESCRIPTION
Now use test.bindir will not find the image file, just update it
to new interface data_dir.get_data_dir

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
