### PR TITLE
qemu : make virtual_nic_sendbuffer test support windows guest

### DIFF
--- a/qemu/tests/cfg/virtual_nic_send_buffer.cfg
+++ b/qemu/tests/cfg/virtual_nic_send_buffer.cfg
@@ -1,7 +1,7 @@
 - virtual_nic_send_buffer:
-    only Linux
     type = virtual_nic_send_buffer
     virt_test_type = qemu
+    udt_url = git://git.code.sf.net/p/udt/git
     vms = "vm1 vm2 vm3 vm4"
     image_snapshot = yes
     variants:

--- a/qemu/tests/virtual_nic_send_buffer.py
+++ b/qemu/tests/virtual_nic_send_buffer.py
@@ -1,33 +1,57 @@
-import logging, time, re
+import logging
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import remote, utils_misc
+from virttest import  remote, utils_misc
 
 @error.context_aware
 def run_virtual_nic_send_buffer(test, params, env):
     """
-    1. boot up guest with this option sndbuf=1048576,...
-    2. Transfer file from guest to extrnal host by UDP
-    3. boot up four guest in the same host, transfer files between them
-    4. verify that it could not block other guests on the same host.
-    5. Repeat 1-4, test with the sndbuf=0, and default value in 6.2
+    Test Step:
+        1. boot up guest with this option sndbuf=1048576,...
+        2. Transfer file from host to guest
+        3. boot up four guest in the same host, transfer files between
+           them via udp
+        4. verify that it could not block other guests on the same host.
+        5. Repeat 1-4, test with the sndbuf=0, and default value in 6.2
 
-    @param test: QEMU test object
-    @param params: Dictionary with the test parameters
-    @param env: Dictionary with test environment.
+    Params:
+        @param test: kvm test object
+        @param params: Dictionary with the test parameters
+        @param env: Dictionary with test environment.
     """
+    def env_setup(session):
+        """
+        Linux guest env setup, install udt, set env and iptables
+        """
+        lib_path = "/usr/lib64"
+        if params.get("platform", 64) == 32:
+            lib_path = "/usr/lib"
+        cmd = r"git clone %s udt-git; " % params.get("udt_url")
+        cmd += r"cd udt-git/udt4; make; make install; "
+        cmd += r"cp src/*.so %s ; " %  lib_path
+        cmd += r"cp app/sendfile app/recvfile /usr/bin/; "
+        cmd += r"iptables -I INPUT -p udp  -j ACCEPT; "
+        cmd += r"iptables -I OUTPUT -p udp -j ACCEPT "
+        if session.cmd_status(cmd):
+            raise error.TestError("Install udt on guest failed")
+
 
     timeout = int(params.get("login_timeout", '360'))
     transfer_timeout = int(params.get("transfer_timeout", '120'))
     password = params.get("password")
     username = params.get("username")
     shell_port = params.get("shell_port")
+    prompt = params.get("shell_prompt", "[\#\$]")
+    client = params.get("shell_client")
+
     tmp_dir = params.get("tmp_dir", "/tmp/")
+    host_file = (test.tmpdir + "tmp-%s" % utils_misc.generate_random_string(8))
+    src_file = (tmp_dir + "src-%s" % utils_misc.generate_random_string(8))
+    dst_file = (tmp_dir + "dst-%s" %  utils_misc.generate_random_string(8))
+    data_port = params.get("data_port", "9000")
     clean_cmd = params.get("clean_cmd", "rm -f")
     filesize = int(params.get("filesize", '100'))
-
     dd_cmd = params.get("dd_cmd", "dd if=/dev/urandom of=%s bs=1M count=%d")
-    md5_check = params.get("md5_check", "md5sum %s")
 
     sessions = []
     addresses = []
@@ -41,34 +65,44 @@ def run_virtual_nic_send_buffer(test, params, env):
         sessions.append(vm.wait_for_login(timeout=timeout))
         addresses.append(vm.get_address())
 
-    src_file = (tmp_dir + "src-%s" % utils_misc.generate_random_string(8))
-    dst_file = (tmp_dir + "dst-%s" %  utils_misc.generate_random_string(8))
-    data_port = params.get("data_port", "8888")
+    logging.info("Creating %dMb file on host" , filesize)
+    cmd = dd_cmd % (host_file, filesize)
+    utils.run(cmd)
 
-    prompt = params.get("shell_prompt", "[\#\$]")
-    client = params.get("shell_client")
+    try:
+        error.context("Transfer datat form host to each guest")
+        for vm in vms:
+            error.context("Transfer date from host to %s " % vm.name,
+                          logging.info)
+            vm.copy_files_to(host_file, src_file, timeout=transfer_timeout)
 
-    logging.info("Creating %dMB file on every guest", filesize)
-    for session in sessions :
-        session.cmd(dd_cmd  % (src_file, filesize), timeout=timeout)
+        error.context("Transfer datat form guest to host")
+        for vm in vms:
+            error.context("Transfer date from %s to host" % vm.name,
+                          logging.info)
+            vm.copy_files_from(src_file, host_file, timeout=transfer_timeout)
 
-    # transfer data from guest to host
-    for vm in vms:
-        error.context("Transfer data from %s to host" % vm.name, logging.info)
-        vm.copy_files_from(src_file, dst_file, timeout=transfer_timeout)
+        #transfer data between guest
+        error.context("Transfer datat betweem every guest")
+        if params.get("os_type") == "linux":
+            for session in sessions:
+                env_setup(session)
 
-    # transfer data between guests
-    for vm_src in addresses:
-        for vm_dst in addresses:
-            if vm_src != vm_dst:
-                error.context("Transfering data from %s to %s" % (vm_src, vm_dst),
-                              logging.info)
-                remote.nc_copy_between_remotes(vm_src, vm_dst, shell_port,
-                                               password, password,
-                                               username, username,
-                                               src_file, dst_file,
-                                               client, prompt,
-                                               data_port, "udp")
-    for session in sessions:
-        if session:
-            session.close()
+        for vm_src in addresses:
+            for vm_dst in addresses:
+                if vm_src != vm_dst:
+                    error.context("Transfering data %s to %s" %
+                                  (vm_src, vm_dst), logging.info)
+                    remote.udp_copy_between_remotes(vm_src, vm_dst,
+                                                    shell_port,
+                                                    password, password,
+                                                    username, username,
+                                                    src_file, dst_file,
+                                                    client, prompt,
+                                                    data_port, timeout=1200)
+    finally:
+        utils.run("rm -rf %s " % host_file)
+        for session in sessions:
+            if session:
+                session.cmd("%s %s %s" % (clean_cmd, src_file, dst_file))
+                session.close()

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -116,6 +116,9 @@
         clean_cmd = reg delete  HKLM\SYSTEM\CurrentControlSet\Control\Class\{4D36E972-E325-11CE-BFC1-08002BE10318}\%04d /v NetworkAddress /f
     multicast_iperf:
         tmp_dir = C:\
+    virtual_nic_send_buffer:
+        tmp_dir = C:\
+        clean_cmd = del
     block_hotplug:
         wait_secs_for_hook_up = 10
         reference_cmd = wmic diskdrive list brief


### PR DESCRIPTION
This patch make virtual_nic_sendbuffer test support windows guest.
Windows guest:
1. download udt.sdk.4.8.win32.zip
    link :http://sourceforge.net/projects/udt/files/udt/4.8/udt.sdk.4.8.win32.zip
2. unzip it, and put the file in your guest disk or cdrom
3. make sure the programe can run normally in your guest.

Linux guest:
    make the udt_url is valid git repo
