### PR TITLE
Add qmp_command test case.

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -1,11 +1,10 @@
 - qmp_command:
     no Host_RHEL.5
+    no RHEL.3 RHEL.4
     type = qmp_command
     virt_test_type = qemu
-    pre_command += "/usr/libexec/qemu-kvm --help|grep '\-qmp' || echo 'Qemu-kvm does not support qmp!';"
-    monitors = ' humanmonitor1 qmp1 qmp2'
+    monitors = ' humanmonitor1 qmp1'
     monitor_type_qmp1 = qmp
-    monitor_type_qmp2 = qmp
     monitor_type = human
     main_monitor = humanmonitor1
     event_cmd_type = monitor_cmd
@@ -19,7 +18,9 @@
             qmp_cmd = "query-mice"
             post_cmd = "info mice"
             cmd_result_check = contain
-            cmd_return_value = "u'name': u'QEMU PS/2 Mouse';u'name': u'QEMU USB Tablet'"
+            cmd_return_value = "u'name': u'QEMU PS/2 Mouse';u'name': u'QEMU HID Tablet'"
+            Host_RHEL.6:
+                cmd_return_value = "u'name': u'QEMU PS/2 Mouse';u'name': u'QEMU USB Tablet'"
         - qmp_query-status:
             pre_cmd = stop
             qmp_cmd = "query-status"
@@ -36,9 +37,8 @@
             cmd_result_check = m_in_q
         - qmp_query-version:
             qmp_cmd = query-version
+            cmd_result_check = m_equal_q
             post_cmd = info version
-            cmd_result_check = contain
-            cmd_return_value = qemu-kvm-0.12.1.2
         - qmp_query-chardev:
             qmp_cmd = "query-chardev"
             post_cmd = info chardev
@@ -53,14 +53,14 @@
             event_cmd_type = host_cmd
             qmp_cmd = "memsave val=0, size=4096, filename=memsave"
             pre_cmd = rm -rf memsave
-            post_cmd = ls memsave
+            post_cmd = "ls memsave; true"
             cmd_result_check = post_contain
             cmd_return_value = memsave
         - qmp_pmemsave:
             event_cmd_type = host_cmd
             qmp_cmd = "pmemsave val=0, size=4096, filename=pmemsave"
             pre_cmd = rm -rf pmemsave
-            post_cmd = ls pmemsave
+            post_cmd = "ls pmemsave; true"
             cmd_result_check = post_contain
             cmd_return_value = pmemsave
         - qmp_query-cpus:
@@ -69,8 +69,8 @@
             cmd_result_check = m_equal_q
             event_cmd_type = monitor_cmd
         - qmp_cpu:
+            only smp2
             event_cmd_type = qmp_cmd
-            smp_equal= 2
             pre_cmd = "cpu index=1"
             qmp_cmd = "query-cpus"
             cmd_result_check = contain
@@ -90,12 +90,6 @@
             qmp_cmd = "query-commands"
             cmd_result_check = contain
             cmd_return_value = "balloon;cont;stop"
-        - qmp_query-balloon:
-            extra_params += " -balloon virtio"
-            event_cmd_type = monitor_cmd
-            qmp_cmd = "query-balloon"
-            post_cmd = "info balloon"
-            cmd_result_check = m_equal_q
         - qmp_cont:
             qmp_cmd = cont
             pre_cmd = stop
@@ -110,8 +104,9 @@
             post_cmd = cont
             cmd_result_check = equal
             cmd_return_value = "{u'status': u'paused', u'singlestep': False, u'running': False}"
-        - qmp_device_add:
+        - qmp_redhat_device_add:
             no ide
+            only Host_RHEL.6
             pre_command += "qemu-img create -f qcow2 /tmp/device_add01.qcow2 100M"
             event_cmd_type = qmp_cmd
             pre_cmd = "__com.redhat_drive_add file=/tmp/device_add01.qcow2,format=qcow2,id=device_add01"
@@ -122,6 +117,7 @@
             post_command += " rm -rf /tmp/device_add01.qcow2;"
         - qmp_device_del:
             no ide
+            only Host_RHEL.6
             pre_command += "qemu-img create -f qcow2 /tmp/device_del01.qcow2 100M"
             event_cmd_type = qmp_cmd
             pre_cmd = "__com.redhat_drive_add file=/tmp/device_del01.qcow2, format=qcow2, id=device_del01"
@@ -151,6 +147,7 @@
             post_cmd = info kvm
             cmd_result_check = m_in_q
         - qmp__com.redhat.drive_del:
+            only Host_RHEL.6
             pre_command += "qemu-img create -f qcow2 /tmp/__com.redhat.drive_del01.qcow2 100M"
             event_cmd_type = qmp_cmd
             pre_cmd = "__com.redhat_drive_add file=/tmp/__com.redhat.drive_del01.qcow2, format=qcow2, id=com.redhat.drive_del01;query-block"
@@ -160,9 +157,19 @@
             cmd_return_value = com.redhat.drive_del01
             post_command += " rm -rf /tmp/__com.redhat.drive_del01.qcow2;"
         - qmp_netdev_del:
-            pre_cmd = netdev_add type=tap,id=netdev_del01;device_add driver=virtio-net-pci,netdev=netdev_del01,mac=11:22:33:44:5f:66,id=netdev_del002
-            qmp_cmd = netdev_del id=netdev_del01
-            post_cmd = query-block
-            event_cmd_type = qmp_cmd
+            nics += " del01"
+            netdev_id_del01 = "netdev_del01"
+            device_id_del01 = "device_del01"
+            ifname_del01 = "ifname_del01"
+            qmp_cmd = "netdev_del id=netdev_del01"
+            pre_cmd = info network
+            post_cmd = info network
+            event_cmd_type = monitor_cmd
             cmd_result_check = post_not_contain
             cmd_return_value = netdev_del01:
+        - qmp_query-balloon:
+            extra_params += " -balloon virtio"
+            event_cmd_type = monitor_cmd
+            qmp_cmd = "query-balloon"
+            post_cmd = "info balloon"
+            cmd_result_check = m_equal_q


### PR DESCRIPTION
Send qmp_command test case to upstream.

This case just want to use a simple way to test basic qmp command.

Run these case in latest rhel6 host.  For other host, may need update the config for some case.
