### PR TITLE
Fixes the topic issue https://github.com/autotest/virt-test/issues/427

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -493,7 +493,7 @@ class VM(virt_vm.BaseVM):
 
         def add_serial(help_text, filename):
             if has_option(help_text, "serial"):
-                return "  --serial file,path=%s --serial pty" % filename
+                return "  --serial pty"
             else:
                 return "" # FIXME: Add additional serial ports on old libvirt?
 


### PR DESCRIPTION
Now the serial log is populated using virsh console <domain_name> command which needs a serial console to be configured as just as pty, hence

Before this patch:

$cat serial-virt-tests-vm1.log
2013-05-22 04:20:43: Connected to domain virt-tests-vm1
2013-05-22 04:20:43: Escape character is ^]
2013-05-22 04:20:43: error: internal error character device (null) is not using a PTY
2013-05-22 04:20:43: 
2013-05-22 04:20:43: (Process terminated with status 1)

$ cat serial-virt-tests-vm1.log 
2013-05-22 04:52:41: Connected to domain virt-tests-vm1
2013-05-22 04:52:41: Escape character is ^]
2013-05-22 04:52:46: Initializing cgroup subsys cpuset
2013-05-22 04:52:46: Initializing cgroup subsys cpu
2013-05-22 04:52:46: Linux version 2.6.32-220.el6.x86_64 (mockbuild@x86-004.build.bos.redhat.com) (gcc version 4.4.5 20110214 (Red Hat 4.4.5-6) (GCC) ) #1 SMP Wed Nov 9 08:03:13 EST 2011
2013-05-22 04:52:46: Command line:  ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0
2013-05-22 04:52:46: KERNEL supported cpus:
......
......
2013-05-22 04:52:51: Freeing unused kernel memory: 1244k freed
2013-05-22 04:52:51: Write protecting the kernel read-only data: 10240k
2013-05-22 04:52:51: Freeing unused kernel memory: 1040k freed
2013-05-22 04:52:51: Freeing unused kernel memory: 1760k freed
2013-05-22 04:57:02: Post set up finished
2013-05-22 04:57:10: Power down.
2013-05-22 04:57:10: 
2013-05-22 04:57:10: (Process terminated with status 0)

Hope this fix would solve the issue.
