### PR TITLE
virttest.qemu_vm: Remove default value for get_monitors_by_type()

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2620,7 +2620,7 @@ class VM(virt_vm.BaseVM):
         return None
 
 
-    def get_monitors_by_type(self, mon_type=None):
+    def get_monitors_by_type(self, mon_type):
         """
         Return list of monitors of mon_type type.
         @param mon_type: desired monitor type (qmp, human)


### PR DESCRIPTION
Default value None is misleading, remove it.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
