### PR TITLE
common.py: check the autotest client library directory

### DIFF
--- a/libguestfs/common.py
+++ b/libguestfs/common.py
@@ -27,5 +27,11 @@ except ImportError:
             print("Environment variable $AUTOTEST_PATH not set. "
                   "please set it to a path containing an autotest checkout")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")

--- a/libvirt/common.py
+++ b/libvirt/common.py
@@ -28,5 +28,11 @@ except ImportError:
                   "please set it to a path containing an autotest checkout")
             print("Or install the autotest-framework package for your distro")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")

--- a/openvswitch/common.py
+++ b/openvswitch/common.py
@@ -28,5 +28,11 @@ except ImportError:
                   "please set it to a path containing an autotest checkout")
             print("Or install the autotest-framework package for your distro")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")

--- a/qemu/common.py
+++ b/qemu/common.py
@@ -28,5 +28,11 @@ except ImportError:
                   "please set it to a path containing an autotest checkout")
             print("Or install the autotest-framework package for your distro")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")

--- a/tools/common.py
+++ b/tools/common.py
@@ -28,5 +28,11 @@ except ImportError:
                   "please set it to a path containing an autotest checkout")
             print("Or install the autotest-framework package for your distro")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")

--- a/v2v/common.py
+++ b/v2v/common.py
@@ -28,5 +28,11 @@ except ImportError:
                   "please set it to a path containing an autotest checkout")
             print("Or install the autotest-framework package for your distro")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")

--- a/virttest/common.py
+++ b/virttest/common.py
@@ -28,5 +28,11 @@ except ImportError:
                   "please set it to a path containing an autotest checkout")
             print("Or install the autotest-framework package for your distro")
             sys.exit(1)
+        if not os.path.isdir(client_dir):
+            print('Autotest client library directory was not found at: "%s"' %
+                  client_dir)
+            print('Please check if the environment variable "$AUTOTEST_PATH" '
+                  'points to a valid location')
+            sys.exit(1)
         sm = load_setup_modules(client_dir)
 sm.setup(base_path=client_dir, root_module_name="autotest.client")


### PR DESCRIPTION
When relying on the environment variable $AUTOTEST_PATH to locate
the autotest libraries, we only check if the variable is set. This
adds another sanity check, if the client library directory actually
exists.

This prevents an ImportError exception to be thrown with no clear
error message.

Signed-off-by: Cleber Rosa crosa@redhat.com
