### PR TITLE
Virttest.qemu vm modify pci bus name and spapr vlan params

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -816,7 +816,8 @@ class VM(virt_vm.BaseVM):
                 # libvirt gains the pci_slot, free_pci_addr here,
                 # value by parsing the xml file, i.e. counting all the
                 # pci devices and store the number.
-                cmd += ",bus=%s,addr=%s" % (get_pci_bus(), free_pci_addr)
+                if model != 'spapr-vlan':
+                    cmd += ",bus=%s,addr=%s" % (get_pci_bus(), free_pci_addr)
                 if nic_extra_params:
                     cmd += ",%s" % nic_extra_params
                 cmd += _add_option("bootindex", bootindex)


### PR DESCRIPTION
For ppc64 and x86, the pci bus name is different as qtree shows,
in qtree, the pci bus named 'pci' for ppc64, but 'pci.0' for x86.

As a result, it will cause an error if use 'pci.0' for ppc64.

At the same time, ppc64 qemu use spapr-vlan for nic device,
and this device is belongs to bus 'spapr-vio-bus' not 'pci'.

The two patches are to solve the problems.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
