### PR TITLE
qemu.balloon_check:add the missing command to cfg file

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -15,6 +15,7 @@
        - balloon-migrate:
            sub_balloon_test_enlarge = "migration"
            sub_balloon_test_evict = "migration"
+           migration_test_command = help
        - guest_s3:
            extra_params += " -global PIIX4_PM.disable_s3=0"
            sub_balloon_test_enlarge = "guest_suspend"


### PR DESCRIPTION
When run the case balloon_check.balloon_evict.balloon-migrate,
it will get 'SKIP' result becasue the needed command
'migration_test_command' has been removed.This command
will be used in migration tests.

Readd the command to solve this problem.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
