### PR TITLE
qemu.tests.enospc: Update code used to get qemu_img_binary

### DIFF
--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -17,8 +17,9 @@ class EnospcConfig(object):
         self.tmpdir = test.tmpdir
         self.qemu_img_binary = params['qemu_img_binary']
         if not os.path.isfile(self.qemu_img_binary):
-            self.qemu_img_binary = os.path.join(root_dir,
-                                                self.qemu_img_binary)
+            self.qemu_img_binary = utils_misc.get_path(os.path.join(root_dir,
+                                                       params.get("vm_type")),
+                                                       self.qemu_img_binary)
         self.raw_file_path = os.path.join(self.tmpdir, 'enospc.raw')
         # Here we're trying to choose fairly explanatory names so it's less
         # likely that we run in conflict with other devices in the system


### PR DESCRIPTION
Folder structure changed after merging.
Now qemu-img is in qemu folder.

Signed-off-by: Feng Yang fyang@redhat.com
Acked-by: Qingtang Zhou qzhou@redhat.com
