### PR TITLE
qemu.tests: Handle QMP monitors in tests properly

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -60,7 +60,7 @@ def run_balloon_check(test, params, env):
         try:
             output = vm.monitor.info("balloon")
             ballooned_mem = int(re.findall("\d+", str(output))[0])
-            if params["monitor_type"] == "qmp":
+            if vm.monitor.protocol == "qmp":
                 ballooned_mem *= 1024 ** -2
         except qemu_monitor.MonitorError, e:
             logging.error(e)

--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -23,7 +23,7 @@ def run_change_media(test, params, env):
     """
 
     def check_block_locked(block_name):
-        blocks_info = vm.monitor.info("block")
+        blocks_info = monitor.info("block")
 
         if isinstance(blocks_info, str):
             lock_str = "locked=1"
@@ -39,16 +39,22 @@ def run_change_media(test, params, env):
 
     def change_block(cmd=None):
         try:
-            output = vm.monitor.send_args_cmd(cmd)
+            output = monitor.send_args_cmd(cmd)
         except Exception, err:
             output = str(err)
         return output
 
 
-    if not utils_misc.qemu_has_option("qmp"):
-        logging.warn("qemu does not support qmp. Human monitor will be used.")
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
+    monitor = vm.get_monitors_by_type('qmp')
+    if monitor:
+        monitor = monitor[0]
+    else:
+        logging.warn("qemu does not support qmp. Human monitor will be used.")
+        monitor = vm.monitor
+    print monitor
+    print vm.monitors
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
 
     logging.info("Wait until device is ready")
@@ -62,9 +68,9 @@ def run_change_media(test, params, env):
     orig_img_name = params.get("orig_img_name")
     change_insert_cmd = "change device=%s,target=%s" % (device_name,
                                                         orig_img_name)
-    vm.monitor.send_args_cmd(change_insert_cmd)
+    monitor.send_args_cmd(change_insert_cmd)
     logging.info("Wait until device is ready")
-    blocks_info = lambda: orig_img_name in str(vm.monitor.info("block"))
+    blocks_info = lambda: orig_img_name in str(monitor.info("block"))
     if not utils_misc.wait_for(blocks_info, 10):
         msg = "Fail to insert device %s to guest" % orig_img_name
         raise error.TestFail(msg)
@@ -94,7 +100,7 @@ def run_change_media(test, params, env):
         msg += "Device is not locked after 'change' the locked device."
         raise error.TestFail("Device is not locked")
 
-    blocks_info = vm.monitor.info("block")
+    blocks_info = monitor.info("block")
     if orig_img_name not in str(blocks_info):
         raise error.TestFail("Locked device %s is changed!" % orig_img_name)
 
@@ -110,5 +116,4 @@ def run_change_media(test, params, env):
     umount_cmd = params.get("cd_umount_cmd")
     if umount_cmd:
         session.cmd(umount_cmd, timeout=360)
-    if session:
-        session.close()
+    session.close()

--- a/qemu/tests/live_snapshot.py
+++ b/qemu/tests/live_snapshot.py
@@ -27,7 +27,7 @@ def run_live_snapshot(test, params, env):
         cmd = params.get("create_sn_cmd")
 
         block_info = vm.monitor.info("block")
-        if utils_misc.qemu_has_option("qmp") and params.get("monitor_type") == "qmp":
+        if vm.monitor.protocol == 'qmp':
             device = block_info[0]["device"]
         else:
             string = ""


### PR DESCRIPTION
Use `monitor.protocol` to detect QMP and other QMP monitor changes.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
