### PR TITLE
virttest.test_setup: Add KSM setup class

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -53,7 +53,7 @@ variants:
                 ksm_base:
                     status_query_cmd = "ksmctl info"
                     setup_cmd = "ksmctl start 5000 50"
-                    query_cmd = "top -p `pidof qemu` -n  1"
+                    query_cmd = "top -p QEMU_PID -n  1"
                     query_regex = "(\d+.\d+\w)\s+.\s+\d+\.\d+\s+\d+\.\d+\s+\d+:\d+\.\d+\s+qemu"
                     ksm_module = "ksm"
                 cpuinfo_query.qmachine_type:
@@ -81,8 +81,6 @@ variants:
                 host_kernel_ver_str += ".6"
                 netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\s"
                 ksm_base:
-                    status_query_cmd = "cat /sys/kernel/mm/ksm/run"
-                    setup_cmd = "echo 1 > /sys/kernel/mm/ksm/run"
                     query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
                 virtio_net:
                     vhost = "vhost=on"
@@ -120,8 +118,6 @@ variants:
                     block_reopen_cmd = "block-job-complete"
                     check_event = yes
                 ksm_base:
-                    status_query_cmd = "cat /sys/kernel/mm/ksm/run"
-                    setup_cmd = "echo 1 > /sys/kernel/mm/ksm/run"
                     query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
                 flag_check:
                     pattern = r"flags:\s+(.*)\s+(.*)\s+(.*)\s+(.*)"

--- a/qemu/tests/cfg/ksm_base.cfg
+++ b/qemu/tests/cfg/ksm_base.cfg
@@ -2,8 +2,7 @@
     only Linux
     type = ksm_base
     virt_test_type = qemu
-    status_query_cmd = "cat /sys/kernel/mm/ksm/run"
-    setup_cmd = "echo 1 > /sys/kernel/mm/ksm/run"
+    setup_ksm = yes
     shared_mem = 1024
     query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
     split = "yes"

--- a/qemu/tests/cfg/ksm_overcommit.cfg
+++ b/qemu/tests/cfg/ksm_overcommit.cfg
@@ -16,6 +16,7 @@
     # Host memory reserve (default - best fit for used mem)
     # ksm_host_reserve = 512
     # ksm_guest_reserve = 1024
+    setup_ksm = yes
     variants:
         - ksm_serial:
             ksm_mode = "serial"

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -423,6 +423,11 @@ def preprocess(test, params, env):
         thp = test_setup.TransparentHugePageConfig(test, params)
         thp.setup()
 
+
+    if params.get("setup_ksm") == "yes":
+        ksm = test_setup.KSMConfig(params, env)
+        ksm.setup(env)
+
     # Execute any pre_commands
     if params.get("pre_command"):
         process_command(test, params, env, params.get("pre_command"),
@@ -562,6 +567,10 @@ def postprocess(test, params, env):
     if params.get("setup_thp") == "yes":
         thp = test_setup.TransparentHugePageConfig(test, params)
         thp.cleanup()
+
+    if params.get("setup_ksm") == "yes":
+        ksm = test_setup.KSMConfig(params, env)
+        ksm.cleanup(env)
 
     # Execute any post_commands
     if params.get("post_command"):

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -3,7 +3,7 @@ Library to perform pre/post test setup for KVM autotest.
 """
 import os, logging, time, re, random, commands
 from autotest.client.shared import error
-from autotest.client import utils, kvm_control
+from autotest.client import utils, kvm_control, os_dep
 import utils_misc
 
 
@@ -314,6 +314,164 @@ class HugePageConfig(object):
             return
         utils.system("echo 0 > %s" % self.kernel_hp_file)
         logging.debug("Hugepage memory successfuly dealocated")
+
+
+class KSMError(Exception):
+    """
+    Base exception for KSM setup
+    """
+    pass
+
+
+class KSMNotSupportedError(KSMError):
+    """
+    Thrown when host does not support KSM.
+    """
+    pass
+
+
+class KSMConfigError(KSMError):
+    """
+    Thrown when host does not config KSM as expect.
+    """
+    pass
+
+
+class KSMConfig(object):
+    def __init__(self, params, env):
+        """
+
+        @param params: Dict like object containing parameters for the test.
+        """
+        KSM_PATH = "/sys/kernel/mm/ksm"
+
+        self.pages_to_scan = params.get("ksm_pages_to_scan")
+        self.sleep_ms = params.get("ksm_sleep_ms")
+        self.run = params.get("ksm_run", "1")
+        self.ksm_module = params.get("ksm_module")
+
+        if self.run == "yes":
+            self.run = "1"
+        elif self.run == "no":
+            self.run == "0"
+
+        # Get KSM module status if there is one
+        # Set the ksm_module_loaded to True in default as we consider it is
+        # compiled into kernel
+        self.ksm_module_loaded = True
+        if self.ksm_module:
+            status = utils.system("lsmod |grep ksm", ignore_status=True)
+            if status != 0:
+                self.ksm_module_loaded = False
+
+        # load the ksm module for furthur information check
+        if not self.ksm_module_loaded:
+            utils.system("modprobe ksm")
+
+        if os.path.isdir(KSM_PATH):
+            self.interface = "sysfs"
+            ksm_cmd = "cat /sys/kernel/mm/ksm/run;"
+            ksm_cmd += " cat /sys/kernel/mm/ksm/pages_to_scan;"
+            ksm_cmd += " cat /sys/kernel/mm/ksm/sleep_millisecs"
+            self.ksm_path = KSM_PATH
+        else:
+            try:
+                os_dep.command("ksmctl")
+            except ValueError:
+                raise KSMNotSupportedError
+            self.interface = "ksmctl"
+            ksm_cmd = "ksmctl info"
+            # For ksmctl both pages_to_scan and sleep_ms should have value
+            # So give some default value when it is not set up in params
+            if self.pages_to_scan is None:
+                self.pages_to_scan = "5000"
+            if self.sleep_ms is None:
+                self.sleep_ms = "50"
+
+        self.ksmtuned_process = 0
+        # Check if ksmtuned is running before the test
+        ksmtuned_process = utils.system_output("ps -C ksmtuned -o pid=",
+                                               ignore_status=True)
+        if ksmtuned_process:
+            self.ksmtuned_process = int(re.findall("\d+",
+                                                   ksmtuned_process)[0])
+
+        # As ksmtuned may update KSM config most of the time we should disable
+        # it when we test KSM
+        self.disable_ksmtuned = params.get("disable_ksmtuned", "yes") == "yes"
+
+        output = utils.system_output(ksm_cmd)
+        self.default_status = re.findall("\d+", output)
+        if len(self.default_status) != 3:
+            raise KSMError("Can not get KSM default setting: %s" % output)
+        self.default_status.append(int(self.ksmtuned_process))
+        self.default_status.append(self.ksm_module_loaded)
+
+
+    def setup(self, env):
+        if self.ksmtuned_process != 0 and self.disable_ksmtuned:
+            kill_cmd = "kill -1 %s" % self.ksmtuned_process
+            utils.system(kill_cmd)
+
+        env.data["KSM_default_config"] = self.default_status
+        ksm_cmd = ""
+        if self.interface == "sysfs":
+            if self.run != self.default_status[0]:
+                ksm_cmd += " echo %s > KSM_PATH/run;" % self.run
+            if (self.pages_to_scan
+                and self.pages_to_scan != self.default_status[1]):
+                ksm_cmd += " echo %s > KSM_PATH" % self.pages_to_scan
+                ksm_cmd += "/pages_to_scan;"
+            if (self.sleep_ms
+                and self.sleep_ms != self.default_status[2]):
+                ksm_cmd += " echo %s > KSM_PATH" % self.sleep_ms
+                ksm_cmd += "/sleep_millisecs"
+            ksm_cmd = re.sub("KSM_PATH", self.ksm_path, ksm_cmd)
+        elif self.interface == "ksmctl":
+            if self.run == "1":
+                ksm_cmd += "ksmctl start %s %s" % (self.pages_to_scan,
+                                                   self.sleep_ms)
+            else:
+                ksm_cmd += "ksmctl stop"
+
+        utils.system(ksm_cmd)
+
+
+    def cleanup(self, env):
+        default_status = env.data.get("KSM_default_config")
+
+        if default_status[3] != 0:
+            # ksmtuned used to run in host. Start the process
+            # and don't need set up the configures.
+            utils.system("ksmtuned")
+            return
+
+        if default_status == self.default_status:
+            # Nothing changed
+            return
+
+        ksm_cmd = ""
+        if self.interface == "sysfs":
+            if default_status[0] != self.default_status[0]:
+                ksm_cmd += " echo %s > KSM_PATH/run;" % default_status[0]
+            if default_status[1] != self.default_status[1]:
+                ksm_cmd += " echo %s > KSM_PATH" % default_status[1]
+                ksm_cmd += "/pages_to_scan;"
+            if default_status[2] != self.default_status[2]:
+                ksm_cmd += " echo %s > KSM_PATH" % default_status[2]
+                ksm_cmd += "/sleep_millisecs"
+            ksm_cmd = re.sub("KSM_PATH", self.ksm_path, ksm_cmd)
+        elif self.interface == "ksmctl":
+            if default_status[0] == "1":
+                ksm_cmd += "ksmctl start %s %s" % (default_status[1],
+                                                   default_status[2])
+            else:
+                ksm_cmd += "ksmctl stop"
+
+        utils.system(ksm_cmd)
+
+        if not default_status[4]:
+            utils.system("modprobe -r ksm")
 
 
 class PrivateBridgeError(Exception):


### PR DESCRIPTION
This class will setup and clean KSM config in different hosts.
You can use setup_ksm to configure it. There are several params
that can be used for ksm configure:

ksm_pages_to_scan: pages ksmd will scan in one loop
ksm_sleep_ms: million secs ksmd will sleep between two scan
ksm_run: start ksmd or not
ksm_module: if ksm is not compiled into kerenl need this parameter
            tell scripts which module should it load
disable_ksmtuned: if we need idsable ksmtuned during our test

This class also can be used to disable KSM in some special case with
set setup_ksm to yes and ksm_run to 0 or no.

Signed-off-by: Yiqiao Pu ypu@redhat.com
