### PR TITLE
shared.cfg: update SLES and OpenSUSE kernel_params

### DIFF
--- a/shared/cfg/guest-os/Linux/OpenSUSE.cfg
+++ b/shared/cfg/guest-os/Linux/OpenSUSE.cfg
@@ -2,5 +2,5 @@
     no setup
     shell_prompt = ".*:.*\s#"
     unattended_install:
-        kernel_params = "autoyast=device://sr0/autoinst.xml console=ttyS0,115200 console=tty0"
+        kernel_params = "autoyast=device://sr1/autoinst.xml console=ttyS0,115200 console=tty0"
         wait_no_ack = yes

--- a/shared/cfg/guest-os/Linux/SLES.cfg
+++ b/shared/cfg/guest-os/Linux/SLES.cfg
@@ -1,7 +1,7 @@
 - SLES:
     shell_prompt = "^root@.*[\#\$]\s*$|#"
     unattended_install:
-        kernel_params = "autoyast=device://scd0/autoinst.xml console=ttyS0,115200 console=tty0"
+        kernel_params = "autoyast=device://scd1/autoinst.xml console=ttyS0,115200 console=tty0"
         kernel = linux
         initrd = initrd
         wait_no_ack = yes


### PR DESCRIPTION
for unattended_install tests, autoyast.iso mount as second cdrom device
in guest for OpenSUSE/SLES, so replace scd0 to scd1 in kernel_params

Signed-off-by: Xu Tian xutian@redhat.com
