### PR TITLE
virttest.virt_vm: Update panic_re used in verify_kernel_crash

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -711,14 +711,19 @@ class BaseVM(object):
                 found.
         """
         panic_re = [r"BUG:.*---\[ end trace .* \]---"]
-        panic_re.append(r"------------\[ cut here.*\[ end trace .* \]---")
+        panic_re.append(r"----------\[ cut here.* BUG .*\[ end trace .* \]---")
         panic_re.append(r"general protection fault:.* RSP.*>")
         panic_re = "|".join(panic_re)
         if self.serial_console is not None:
             data = self.serial_console.get_output()
-            match = re.search(panic_re, data, re.DOTALL|re.MULTILINE)
+            match = re.search(panic_re, data, re.DOTALL|re.MULTILINE|re.I)
             if match is not None:
                 raise VMDeadKernelCrashError(match.group(0))
+            else:
+                panic_re = r"------------\[ cut here.*\[ end trace .* \]---"
+                match = re.search(panic_re, data, re.DOTALL|re.MULTILINE|re.I)
+                if match is not None:
+                    raise error.TestWarn(match.group(0))
 
 
     def verify_illegal_instruction(self):


### PR DESCRIPTION
VMDeadKernelCrashError will be raised for following warning
call trace. This patch try to fix this issue.

------------[ cut here ]------------
[    0.023009] WARNING: at arch/x86/kernel/cpu/amd.c:27 init_amd+0x10e/0x654()
[    0.024004] Hardware name: KVM
[    0.025004] rdmsrl_amd_safe should only be used on K8!
[    0.026004] Modules linked in:
[    0.028005] Pid: 0, comm: swapper/0 Not tainted 3.9.0-0.55.el7.x86_64 #1
[    0.029004] Call Trace:
[    0.030008]  [<ffffffff815e98bd>] ? init_amd+0x10e/0x654
[    0.031008]  [<ffffffff810610c0>] warn_slowpath_common+0x70/0xa0
[    0.032006]  [<ffffffff8106113c>] warn_slowpath_fmt+0x4c/0x50
[    0.033006]  [<ffffffff815e9799>] ? early_init_amd+0xb7/0xcd
[    0.034008]  [<ffffffff815e98bd>] init_amd+0x10e/0x654
[    0.035006]  [<ffffffff815e87df>] identify_cpu+0x22c/0x357
[    0.036010]  [<ffffffff81a16d92>] identify_boot_cpu+0x10/0x3b
[    0.037006]  [<ffffffff81a1704e>] check_bugs+0x9/0x2d
[    0.038007]  [<ffffffff81a0deab>] start_kernel+0x3d1/0x409
[    0.039006]  [<ffffffff81a0d8e3>] ? repair_env_string+0x5c/0x5c
[    0.040006]  [<ffffffff81a0d120>] ? early_idt_handlers+0x120/0x120
[    0.041006]  [<ffffffff81a0d5e2>] x86_64_start_reservations+0x2a/0x2c
[    0.042008]  [<ffffffff81a0d6d7>] x86_64_start_kernel+0xf3/0x100
[    0.043013] ---[ end trace d793b5b0c6ba38cc ]---

Signed-off-by: Feng Yang fyang@redhat.com
