### PR TITLE
tests: Update nic driver directory in netstress_kill_guest.py

### DIFF
--- a/tests/cfg/netstress_kill_guest.cfg
+++ b/tests/cfg/netstress_kill_guest.cfg
@@ -3,6 +3,10 @@
     only Linux
     type = netstress_kill_guest
     image_snapshot = yes
+    nic_mode = tap
+    nic_module_cmd = "readlink /sys/class/net/*/device/driver/module"
+    RHEL.4.9:
+        nic_module_cmd = "readlink /sys/class/net/*/driver"
     # There should be enough vms for build topology.
     variants:
         -driver:

--- a/tests/netstress_kill_guest.py
+++ b/tests/netstress_kill_guest.py
@@ -8,7 +8,7 @@ def run_netstress_kill_guest(test, params, env):
     """
     Try stop network interface in VM when other VM try to communicate.
 
-    @param test: kvm test object
+    @param test: QEMU test object
     @param params: Dictionary with the test parameters
     @param env: Dictionary with test environment.
     """
@@ -33,10 +33,11 @@ def run_netstress_kill_guest(test, params, env):
         @param session: session to machine
         """
         modules = []
-        out = session.cmd("ls -l --color=never "
-                          "/sys/class/net/*/device/driver/module")
+        cmd = params.get("nic_module_cmd")
+        out = session.cmd(cmd)
         for module in out.split("\n"):
-            modules.append(module.split("/")[-1])
+            if not cmd in module:
+                modules.append(module.split("/")[-1])
         modules.remove("")
         return set(modules)
 


### PR DESCRIPTION
The nic driver directory is different for rhel4.9 guest
so make it configurable and update it to correct one.

Signed-off-by: Golita Yue gyue@redhat.com
Acked-by: Feng Yang fyang@redhat.com
