### PR TITLE
tests.jumbo:Fix get_linux_ifname() error

### DIFF
--- a/tests/jumbo.py
+++ b/tests/jumbo.py
@@ -58,7 +58,7 @@ def run_jumbo(test, params, env):
         # Environment preparation
         mac = vm.get_mac_address(0)
         if os_type == "linux":
-            ethname = utils_test.get_linux_ifname(session, mac)
+            ethname = utils_net.get_linux_ifname(session, mac)
             guest_mtu_cmd = "ifconfig %s mtu %s" % (ethname , mtu)
         else:
             connection_id = utils_net.get_windows_nic_attribute(session,


### PR DESCRIPTION
get_linux_ifname() has been moved from utils_test into utils_net.
But the commit 7db6cc4db5ba5d86659839b4afee96603c346520
change it back to utils_test for linux.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
