### PR TITLE
virt.test: fix some netperf issues

### DIFF
--- a/tests/cfg/netperf.cfg
+++ b/tests/cfg/netperf.cfg
@@ -8,7 +8,7 @@
     image_snapshot = yes
     nics += ' nic2'
     # nic1 is for control, nic2 is for data connection
-    netdst_nic1 = virbr0
+    netdst_nic1 = private
     nic_model_nic1 = virtio
     netdst_nic2 = switch
     nic_model_nic2 = e1000
@@ -19,7 +19,7 @@
     # 0.5 * l, the wait time will augments if you have move
     # threads. So experientially suggest l should be not less than 60.
     l = 60
-    protocols = "TCP_STREAM TCP_MAERTS TCP_RR"
+    protocols = "TCP_STREAM TCP_MAERTS TCP_RR TCP_CRR"
     sessions = "1 2 4"
     sessions_rr = "50 100 250 500"
     sizes = "64 256 512 1024"
@@ -80,7 +80,7 @@
     netperf_with_numa = yes
     # configure netperf test parameters
     l = 30
-    protocols = "TCP_STREAM TCP_MAERTS TCP_RR"
+    protocols = "TCP_STREAM TCP_MAERTS TCP_RR TCP_CRR"
     sessions_rr="1 25 50 100"
     sessions="1 2 4"
     sizes_rr="256"
@@ -101,7 +101,7 @@
     variants:
         - netperf_exe:
             use_cygwin = no
-            netserv_start_cmd = "(dir C:\temp || mkdir C:\temp) && start /b D:\netserver.exe"
+            netserv_start_cmd = "(dir C:\temp || mkdir C:\temp) && start /b %s:\netserver.exe"
             variants:
                 - default_setting:
                 - best_registry_setting:
@@ -120,7 +120,7 @@
                         config_cmds += ,disable_tcp_heuristics_cmd,disabled_tcp_autotuning_cmd,enable_ctcp_cmd
         - netperf_cygwin:
             use_cygwin = yes
-            netperf_src = D:\netperf\netperf-2.6.0
+            netperf_src = %s:\netperf\netperf-2.6.0
             cygwin_root = C:\rhcygwin\home\Administrator
             cygwin_start = C:\rhcygwin\Cygwin.bat -i /Cygwin-Terminal.ico -
             netserv_pattern = "hostname\s+[\d+\.]+\s+port\s+\d+"

--- a/virttest/utils_test.py
+++ b/virttest/utils_test.py
@@ -1288,6 +1288,29 @@ def start_windows_service(session, service, timeout=120):
         raise error.TestError("Could not start service '%s'" % service)
 
 
+def get_windows_file_abs_path(session, filename, extension="exe", tmout=240):
+    """
+    return file abs path "drive+path" by "wmic datafile"
+    """
+    cmd_tmp = "wmic datafile where \"Filename='%s' and "
+    cmd_tmp += "extension='%s'\" get drive^,path"
+    cmd = cmd_tmp % (filename, extension)
+    info = session.cmd_output(cmd, timeout=tmout).strip()
+    drive_path = re.search(r'(\w):\s+(\S+)', info, re.M)
+    if not drive_path:
+        raise error.TestError("Not found file %s.%s in your guest"
+                              % (filename, extension))
+    return ":".join(drive_path.groups())
+
+
+def get_windows_disk_drive(session, filename, extension="exe", tmout=240):
+    """
+    Get the windows disk drive number
+    """
+    return get_windows_file_abs_path(session, filename,
+                                     extension).split(":")[0]
+
+
 def get_time(session, time_command, time_filter_re, time_format):
     """
     Return the host time and guest time.  If the guest time cannot be fetched


### PR DESCRIPTION
this patch:
1.fix the issue netperf cannot login with two nics,
2.add  netperf test support tcp_crr protocol
3.add an automated way to get the cdrom drive number.
4.modify the file path of netperf.tar.gz. now should
put the src file under "virt/shared/deps"
5.add more step info
