### PR TITLE
qemu.tests: Add new subtest to qemu_img

### DIFF
--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -6,7 +6,7 @@
     variants:
         - check:
             subcommand = check
-            image_name_dd = dd_created_image
+            image_name_dd = images/dd_created_image
             force_create_image_dd = no
             remove_image_dd = yes
             create_image_cmd = "dd if=/dev/zero of=%s bs=1G count=1"
@@ -16,9 +16,25 @@
             subcommand = create
             images += " large"
             force_create_image_large = yes
-            image_size_large = 1G
+            image_size_large = 2G
             image_name_large = create_large_image
             remove_image_large = yes
+            variants:
+                 - non-preallocated:
+                     variants:
+                         - cluster_512:
+                             cluster_size = 512
+                         - cluster_1024:
+                             cluster_size = 1024
+                         - cluster_4096:
+                             cluster_size = 4096
+                         - cluster_1M:
+                             cluster_size = 1M
+                         - cluster_2M:
+                             cluster_size = 2M
+                 - preallocated:
+                     no raw
+                     preallocated = metadata
         - convert:
             subcommand = convert
             compressed = no
@@ -26,6 +42,18 @@
             variants:
                 - to_qcow2:
                     dest_image_format = qcow2
+                    variants:
+                        - @cluster_size_default:
+                        - cluster_size_2048:
+                            # This case come from qemu-kvm bug that " qcow2 converting
+                            # error when -o cluster_size <= 2048"
+                            # qemu_img_options set qemu-img -o options. It support multi options.
+                            # If you want support multi options here, e.g.  A, B. JUst set qemu_img_options = A B
+                            # Then set A = xx, B = xx in configure
+                            qemu_img_options = cluster_size
+                            #cluster_size set cluster size used in qemu-img -o cluster_size=, default is 64k.
+                            cluster_size = 2048
+                            no Host_RHEL.5
                 - to_raw:
                     dest_image_format = raw
                 - to_qed:
@@ -33,13 +61,14 @@
 
         - snapshot:
             subcommand = snapshot
+            only qcow2
         - info:
             subcommand = info
         - rebase:
             subcommand = rebase
             rebase_mode = unsafe
-            image_name_snapshot1 = sn1
-            image_name_snapshot2 = sn2
+            image_name_snapshot1 = images/sn1
+            image_name_snapshot2 = images/sn2
         # Commit is the only subtest that does need an installed guest
         - commit:  install setup image_copy unattended_install.cdrom
             subcommand = commit


### PR DESCRIPTION
Signed-off-by: Feng Yang fyang@redhat.com
KVM-Test: Boot/shutdown rebased image
Signed-off-by: Suqin Huang shuang@redhat.com
KVM Test: check the image after image creation.
KVM test: qemu_img: Pre-allocated metadata qcow2 format support
KVM Test: Raw device support for qemu_img test
KVM test: qemu_img add the qcow2 over LVM checking
Signed-off-by: Jason Wang jasowang@redhat.com
KVM Test: Add cluster_size_2048 test case.
Bug fix and add error.context in qemu_img.py script
Fix bug that guest start twice.
Signed-off-by: Feng Yang fyang@redhat.com
