### PR TITLE
multicast_iperf:change test name to multicast_iperf

### DIFF
--- a/qemu/tests/cfg/multicast_iperf.cfg
+++ b/qemu/tests/cfg/multicast_iperf.cfg
@@ -1,4 +1,4 @@
-- multicast: install setup image_copy unattended_install.cdrom
+- multicast_iperf: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu
     type = multicast_iperf
     win_iperf_url = https://nocweboldcst.ucf.edu/files/iperf.exe


### PR DESCRIPTION
multicast_iperf case is named multicast in cfg file, this is fault,
because multicast has been used in case virt/tests/multicast.py,

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
