### PR TITLE
virttest/qemu_qtree:Fix virtio-blk-pci disk drive verify error in qtree

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -152,7 +152,8 @@ class QtreeDev(QtreeNode):
 
     def guess_type(self):
         if ('drive' in self.qtree and
-                self.qtree['type'] != 'usb-storage'):
+                self.qtree['type'] != 'usb-storage' and
+                self.qtree['type'] != 'virtio-blk-device'):
             # ^^ HOOK when usb-storage-containter is detected as disk
             return QtreeDisk
         else:


### PR DESCRIPTION
This is the V2 of the patch send before.
change log compare to V1:
      V1: self.qtree['type'] != 'virtio-blk-pci'):
      V2:self.qtree['type'] != 'virtio-blk-device'):
This can pass both old fathion qemu and newest version.

The qemu has splite virtio-blk-pci into virtio-blk-{pci|device},
So when use the qemu command line with :
    -device virtio-blk-pci,bus=pci.0,addr=0x8,drive=drive-virtio-disk2

the qemu will create virtio-blk-device under virtio-blk-pci, but both
this two dev has drive with drive-virtio-disk2.

This will cause an error when do qtree verify, see qtree with
command "info qtree":
14:29:19 DEBUG| (monitor hmp1)          dev: virtio-blk-pci, id ""
14:29:19 DEBUG| (monitor hmp1)            ioeventfd = on
14:29:19 DEBUG| (monitor hmp1)            vectors = 2
14:29:19 DEBUG| (monitor hmp1)            indirect_desc = on
14:29:19 DEBUG| (monitor hmp1)            event_idx = on
14:29:19 DEBUG| (monitor hmp1)            drive = drive-virtio-disk2
14:29:19 DEBUG| (monitor hmp1)            logical_block_size = 512
14:29:19 DEBUG| (monitor hmp1)            physical_block_size = 512
14:29:19 DEBUG| (monitor hmp1)            min_io_size = 0
14:29:19 DEBUG| (monitor hmp1)            opt_io_size = 0
14:29:19 DEBUG| (monitor hmp1)            bootindex = -1
14:29:19 DEBUG| (monitor hmp1)            discard_granularity = 4294967295
14:29:19 DEBUG| (monitor hmp1)            cyls = 0
14:29:19 DEBUG| (monitor hmp1)            heads = 0
14:29:19 DEBUG| (monitor hmp1)            secs = 0
14:29:19 DEBUG| (monitor hmp1)            serial = <null>
14:29:19 DEBUG| (monitor hmp1)            config-wce = on
14:29:19 DEBUG| (monitor hmp1)            scsi = on
14:29:19 DEBUG| (monitor hmp1)            addr = 08.0
14:29:19 DEBUG| (monitor hmp1)            romfile = <null>
14:29:19 DEBUG| (monitor hmp1)            rombar = 1
14:29:19 DEBUG| (monitor hmp1)            multifunction = off
14:29:19 DEBUG| (monitor hmp1)            command_serr_enable = on
14:29:19 DEBUG| (monitor hmp1)            class SCSI controller, addr 00:08.0, pci id 1af4:1001 (sub 1af4:0002)
14:29:19 DEBUG| (monitor hmp1)            bar 0: i/o at 0xc280 [0xc2bf]
14:29:19 DEBUG| (monitor hmp1)            bar 1: mem at 0xf1026000 [0xf1026fff]
14:29:19 DEBUG| (monitor hmp1)            bus: virtio-bus
14:29:19 DEBUG| (monitor hmp1)              type virtio-pci-bus
14:29:19 DEBUG| (monitor hmp1)              dev: virtio-blk-device, id ""
14:29:19 DEBUG| (monitor hmp1)                drive = drive-virtio-disk2
14:29:19 DEBUG| (monitor hmp1)                logical_block_size = 512
14:29:19 DEBUG| (monitor hmp1)                physical_block_size = 512
14:29:19 DEBUG| (monitor hmp1)                min_io_size = 0
14:29:19 DEBUG| (monitor hmp1)                bootindex = -1
14:29:19 DEBUG| (monitor hmp1)                discard_granularity = 4294967295
14:29:19 DEBUG| (monitor hmp1)                cyls = 2
14:29:19 DEBUG| (monitor hmp1)                heads = 16
14:29:19 DEBUG| (monitor hmp1)                secs = 63
14:29:19 DEBUG| (monitor hmp1)                serial = <null>
14:29:19 DEBUG| (monitor hmp1)                config-wce = on
14:29:19 DEBUG| (monitor hmp1)                scsi = on

To fix this error, when type is virtio-blk-pci, just return QtreeDev.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
