### PR TITLE
qemu.tests: Add driver load/unload cases

### DIFF
--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -1,0 +1,35 @@
+driver_load: install setup image_copy unattended_install.cdrom
+    type = driver_load
+    kill_vm_on_error = yes
+    login_timeout = 240
+    driver_load_cmd = modprobe DRIVER_ID
+    driver_unload_cmd = modprobe -r DRIVER_ID
+    repeats = 1
+    variants:
+        - nic_device:
+            no e1000
+            nics += " nic2"
+            nic_model_nic2 = e1000
+            driver_id_cmd = lsmod |grep virtio_net
+            driver_id_pattern = virtio_net
+            test_after_load = file_transfer
+            filesize = 100
+            transfer_timeout = 1000
+            transfer_type = remote
+            Windows:
+                # The DevCon utility is a command-line utility that acts as an
+                # alternative to Device Manager. Please set up your windows guest
+                # following: http://support.microsoft.com/kb/311272/en-us
+                driver_id_cmd = C:\devcon.exe find * | find "VirtIO Ethernet Adapter"
+                driver_id_pattern = "(.*?):"
+                driver_load_cmd = C:\devcon.exe enable DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable DRIVER_ID
+        - balloon_device:
+            extra_params += " -balloon virtio"
+            driver_id_cmd = lsmod |grep virtio_balloon
+            driver_id_pattern = virtio_balloon
+            Windows:
+                driver_id_cmd = C:\devcon.exe find * | find "VirtIO Balloon Driver"
+                driver_id_pattern = "(.*?):"
+                driver_load_cmd = C:\devcon.exe enable DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable DRIVER_ID

--- a/qemu/tests/driver_load.py
+++ b/qemu/tests/driver_load.py
@@ -1,0 +1,58 @@
+import logging, re, time
+from autotest.client.shared import error
+from virttest import utils_test
+
+
+@error.context_aware
+def run_driver_load(test, params, env):
+    """
+    KVM driver load test:
+    1) Log into a guest
+    2) Get the driver device id(Windows) or module name(Linux) from guest
+    3) Unload/load the device driver
+    4) Check if the device still works properly(Optinal)
+    5) Repeat step 3-4 several times
+
+    @param test: QEMU test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment.
+    """
+
+    error.context("Try to log into guest.", logging.info)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    timeout = float(params.get("login_timeout", 240))
+    # Use the last nic for send driver load/unload command
+    nics = vm.virtnet
+    nic_index = len(vm.virtnet) - 1
+    session = vm.wait_for_login(nic_index=nic_index, timeout=timeout)
+
+    driver_id_cmd = params["driver_id_cmd"]
+    driver_id_pattern = params["driver_id_pattern"]
+    driver_load_cmd = params["driver_load_cmd"]
+    driver_unload_cmd = params["driver_unload_cmd"]
+
+    error.context("Get the driver module infor from guest.", logging.info)
+    output = session.cmd_output(driver_id_cmd)
+    driver_id = re.findall(driver_id_pattern, output)
+    if not driver_id:
+        raise error.TestError("Can not find driver module info from guest:"
+                              "%s" % output)
+
+    driver_id = driver_id[0]
+    if params["os_type"] == "windows":
+            driver_id = '^&'.join(driver_id.split('&'))
+    driver_load_cmd = driver_load_cmd.replace("DRIVER_ID", driver_id)
+    driver_unload_cmd = driver_unload_cmd.replace("DRIVER_ID", driver_id)
+
+    for repeat in range(0, int(params.get("repeats", "1"))):
+        error.context("Unload and load the driver. Round %s" % repeat,
+                      logging.info)
+        session.cmd(driver_unload_cmd)
+        time.sleep(5)
+        session.cmd(driver_load_cmd)
+        time.sleep(5)
+        if params.get("test_after_load"):
+            test_after_load = params.get("test_after_load")
+            utils_test.run_virt_sub_test(test, params, env,
+                                         sub_type=test_after_load)


### PR DESCRIPTION
This case is mainly for virtio drivers. It will load/unload driver
inside guest for several times and check if the device can
work properly.

Please notice that for Windows guests, you need set up devcon.exe in guest by yourself.
