### PR TITLE
qemu.tests: Add ignore string for hdparm

### DIFF
--- a/qemu/tests/cfg/hdparm.cfg
+++ b/qemu/tests/cfg/hdparm.cfg
@@ -7,7 +7,9 @@
     device_cache_read_cmd = hdparm -tT %s
     high_status_cmd = hdparm -a256 -d1 -u1 %s
     cmd_timeout = 540
+    ignore_string = "Inappropriate ioctl for device"
     virtio_blk:
+        no RHEL.3.9
         get_disk_cmd = \ls /dev/vda
         low_status_cmd = hdparm -a32 -r0 %s
         high_status_cmd = hdparm -a256 -r1 %s

--- a/qemu/tests/hdparm.py
+++ b/qemu/tests/hdparm.py
@@ -1,5 +1,6 @@
 import re, logging
 from autotest.client.shared import error
+from virttest import aexpect
 
 
 @error.context_aware
@@ -19,12 +20,21 @@ def run_hdparm(test, params, env):
         params = re.findall("(-[a-zA-Z])([0-9]*)", set_cmd)
         disk = re.findall("(\/+[a-z]*\/[a-z]*$)", set_cmd)[0]
         for (param, value) in params:
+            check_value = True
             cmd = "hdparm %s %s" % (param, disk)
             (s, output) = session.cmd_status_output(cmd, timeout)
             if s != 0:
-                raise error.TestError("Fail to get %s parameter value. "
-                                      "Output is:\n%s" % (param, output.strip()))
-            if value not in output:
+                check_value = False
+                failed_count = len(re.findall("failed:", output))
+                ignore_count = len(re.findall(ignore_string, output))
+                if failed_count > ignore_count:
+                    raise error.TestError("Fail to get %s parameter value. "
+                                          "Output is:\n%s" % (param,
+                                                              output.strip()))
+                else:
+                    logging.warn("Disk %s not support parameter %s" % (disk,
+                                                                       param))
+            if check_value and value not in output:
                 raise error.TestFail("Fail to set %s parameter to value: %s"
                                      % (param, value))
 
@@ -49,6 +59,7 @@ def run_hdparm(test, params, env):
         return results/num
 
 
+    ignore_string = params.get("ignore_string")
     vm = env.get_vm(params["main_vm"])
     vm.create()
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
@@ -60,7 +71,14 @@ def run_hdparm(test, params, env):
 
         error.context("Setting hard disk to lower performance")
         cmd = params["low_status_cmd"] % disk
-        session.cmd(cmd, timeout)
+        try:
+            session.cmd(cmd, timeout)
+        except aexpect.ShellCmdError, err:
+            failed_count = len(re.findall("failed:", err.output))
+            ignore_count = len(re.findall(ignore_string, err.output))
+            if failed_count > ignore_count:
+                raise error.TestError("Fail to setting hard disk to lower "
+                                      "performance. Output is:%s", err.output)
 
         error.context("Checking hard disk keyval under lower performance "
                       "settings")
@@ -71,7 +89,14 @@ def run_hdparm(test, params, env):
 
         error.context("Setting hard disk to higher performance")
         cmd = params["high_status_cmd"] % disk
-        session.cmd(cmd, timeout)
+        try:
+            session.cmd(cmd, timeout)
+        except aexpect.ShellCmdError, err:
+            failed_count = len(re.findall("failed:", err.output))
+            ignore_count = len(re.findall(ignore_string, err.output))
+            if failed_count > ignore_count:
+                raise error.TestError("Fail to setting hard disk to higher "
+                                      "performance. Output is:%s", err.output)
 
         error.context("Checking hard disk keyval under higher performance "
                       "settings")


### PR DESCRIPTION
Add ignore string for test hdparm to ignore some hardware not support
parameters in cfg files, and will output the parameters in warn file.
