### PR TITLE
virttest.qemu_vm: Remove init_pci_addr from VM.

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -105,7 +105,6 @@ class VM(virt_vm.BaseVM):
             self.instance = state['instance']
         self.qemu_command = ''
         self.start_time = 0.0
-        self.init_pci_addr = int(params.get("init_pci_addr", 4))
 
 
     def verify_alive(self):
@@ -452,7 +451,7 @@ class VM(virt_vm.BaseVM):
             @param pci_addr: *decimal* formated, desired pci_add
             """
             if pci_addr is None:
-                pci_addr = self.init_pci_addr
+                pci_addr = int(params.get("init_pci_addr", 3))
                 while True:
                     # actually when pci_addr > 20? errors may happen
                     if pci_addr > 31:


### PR DESCRIPTION
Now vm.init_pci_addr is effected by previous vm.

We set init_pci_addr to 3 in multi_disk.max_disk, but this case still
fail for:
VMPCIOutOfRangeError: Too many PCI devices added on vm 'virt-tests-vm1',
 max supported '31'

because previous case use default value 4.

As init_pci_addr only used in get_free_pci_addr, so remove it from vm
 and only get init_pci_addr in get_free_pci_addr().
Also set default for init_pci_addr to 3.

Signed-off-by: Feng Yang fyang@redhat.com
