### PR TITLE
qemu.control.kernel-version: Bug fix for control.kernel-version

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -2,6 +2,13 @@
 # Here will set up a set up parameters for the test based on the different
 # kernel installed in RHEL system. You can also edit this to match other
 # packages in the host under test.
+# The parameters for package check for Fedora and REL are, take qemu-kvm
+# as an example:
+# required_packages = "qemu-kvm seabios-bin"
+# package_check_cmd = "rpm -q PACKNAME"
+# If need version check:
+# package_version_pattern = "PACKNAME-([\d\.]+)"
+# requires_qemu-kvm = [">= 0.15.1"]
 
 package_check_cmd_kernel = uname -r
 package_version_pattern_kernel = [\.\-\_\w\d]+

--- a/qemu/control.kernel-version
+++ b/qemu/control.kernel-version
@@ -33,25 +33,26 @@ def package_check(dict_test, verbose=False):
     """
     failed_message = ""
     for package in dict_test.get("required_packages", "").split():
-        package_check_cmd = dict_test.get("package_check_cmd_%s" % package)
-        package_version_pattern = dict_test.get("package_version_pattern_%s" %
-                                                package)
+        package_check_cmd = (dict_test.get("package_check_cmd_%s" % package)
+                             or dict_test.get("package_check_cmd"))
         package_check_cmd = re.sub("PACKNAME", package, package_check_cmd)
         s, o = commands.getstatusoutput(package_check_cmd)
         if s != 0:
             failed_message += "%s not installed.\n" % package
             continue
 
-        version_pattern = re.sub("PACKNAME", package, package_version_pattern)
-        packge_version = re.findall(version_pattern, o)
-        if packge_version:
-            packge_version = packge_version[0].strip()
-        else:
-            failed_message += "Can not get version info."
-            failed_message += " Please check your pattern and command."
-            continue
-
         if dict_test.get("requires_%s" % package):
+            tmp_str = (dict_test.get("package_version_pattern_%s" % package)
+                       or dict_test.get("package_version_pattern"))
+            version_pattern = re.sub("PACKNAME", package, tmp_str)
+            packge_version = re.findall(version_pattern, o)
+            if packge_version:
+                packge_version = packge_version[0].strip()
+            else:
+                failed_message += "Can not get version info."
+                failed_message += " Please check your pattern and command."
+                continue
+
             package_requires = eval(dict_test.get("requires_%s" % package))
             if isinstance(package_requires, list):
                 package_requires = (package_requires,)
@@ -91,7 +92,6 @@ utils.system(update_config)
 parser = cartesian_config.Parser()
 
 parser.parse_file(os.path.join(qemu_test_dir, "cfg", "tests-example.cfg"))
-parser.parse_file(os.path.join(qemu_test_dir, "cfg", "host-kernel.cfg"))
 
 host_kernel_ver_str = ""
 host_kernel_ver_file = "/tmp/host_kernel_version"
@@ -99,7 +99,7 @@ host_kernel_ver_file = "/tmp/host_kernel_version"
 filter_str = ""
 for dict_test in parser.get_dicts():
     verbose = dict_test.get("host_check_verbose", "no") == "yes"
-    if (dict_test.get("packages_require") and
+    if (dict_test.get("required_packages") and
         not package_check(dict_test, verbose=verbose)):
         filter_str += "no %s\n" % dict_test['name']
         logging.warning("Skip case '%s' due to package "


### PR DESCRIPTION
This patch fix three problems in control.kernel-version:
- Fix the wrong variable name.
- Remove the parse_file inside control file for host-kernel.cfg
  Just in clude it as other cfg files in your tests-example.cfg
  which is more flexible. And this also can work with the situation
  that without host-kernel.cfg.
- Don't get the package version if there is no need for package
  version check.

Also add some docstring for how to use the package filter.

Signed-off-by: Yiqiao Pu ypu@redhat.com
