### PR TITLE
virttest.test_setup: Add some hugepage related config params

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -132,6 +132,24 @@ variants:
     - @smallpages:
     - hugepages:
         setup_hugepages = yes
+        # In some special conditions, such as low mem PPC systems, you might
+        # want to define how many large memory pages you want to set directly.
+        # If you don't, virt-test will use an heuristic to calculate the number
+        # (default). The heuristic can be found on virttest/test_setup.py
+        #target_hugepages = 500
+
+        # In some special conditions, such as low mem PPC systems, one might
+        # want to set the overhead to 0, so leave this configurable. Keep in
+        # mind that, if target_hugepages is set, this value will be ignored
+        # since virt test won't try to calculate the required pages.
+        hugepages_qemu_overhead = 128
+
+        # Similarly, on low mem systems if you deallocate hugepages and try
+        # to allocate them again it won't be possible to find contiguous pages,
+        # so make it possible to turn it off by setting this to 'no'.
+        hugepages_deallocate = yes
+
+        # Some other params that one might find useful to configure
         extra_params += " -mem-path /mnt/kvm_hugepage"
         domain_xml_snippet = "<memoryBacking><hugepages/></memoryBacking>"
 


### PR DESCRIPTION
Alexander reported some problems running virt test on some
low memory PPC systems w.r.t. hugepages setup. In order to
make it easier to run virt-test without local code changes,
turn the QEMU memory overhead and whether to dealocate
huge pages something configurable.

Signed-off-by: Alexander Graf agraf@suse.de
Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
