### PR TITLE
virttest.env_process : add pci msi on/off support in autotest

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/5.3.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.3.i386.cfg
@@ -1,4 +1,5 @@
 - 5.3.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel53-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.3.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.3.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.3.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel53-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/5.4.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.4.i386.cfg
@@ -1,4 +1,5 @@
 - 5.4.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel54-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.4.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.4.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.4.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel54-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/5.5.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.5.i386.cfg
@@ -1,4 +1,5 @@
 - 5.5.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel55-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.5.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.5.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.5.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel55-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/5.6.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.6.i386.cfg
@@ -1,4 +1,5 @@
 - 5.6.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel56-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.6.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.6.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.6.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel56-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/5.7.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.7.i386.cfg
@@ -1,4 +1,5 @@
 - 5.7.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel57-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.7.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.7.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.7.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel57-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/5.8.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.8.i386.cfg
@@ -1,4 +1,5 @@
 - 5.8.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel58-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.8.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.8.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.8.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel58-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/5.9.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.9.i386.cfg
@@ -1,4 +1,5 @@
 - 5.9.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     image_name = images/rhel59-32

--- a/shared/cfg/guest-os/Linux/RHEL/5.9.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.9.x86_64.cfg
@@ -1,4 +1,5 @@
 - 5.9.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     image_name = images/rhel59-64
     vm_arch_name = x86_64

--- a/shared/cfg/guest-os/Linux/RHEL/6.0.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.0.i386.cfg
@@ -1,4 +1,5 @@
 - 6.0.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.0.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.0.x86_64.cfg
@@ -1,4 +1,5 @@
 - 6.0.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     vm_arch_name = x86_64
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.1.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.1.i386.cfg
@@ -1,4 +1,5 @@
 - 6.1.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.2.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.2.i386.cfg
@@ -1,4 +1,5 @@
 - 6.2.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.2.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.2.x86_64.cfg
@@ -1,4 +1,5 @@
 - 6.2.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     vm_arch_name = x86_64
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.3.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.3.i386.cfg
@@ -1,4 +1,5 @@
 - 6.3.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.3.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.3.x86_64.cfg
@@ -1,4 +1,5 @@
 - 6.3.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     vm_arch_name = x86_64
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.4.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.4.i386.cfg
@@ -1,4 +1,5 @@
 - 6.4.i386:
+    grub_file = /boot/grub/grub.conf
     vm_arch_name = i686
     no setup
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.4.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.4.x86_64.cfg
@@ -1,4 +1,5 @@
 - 6.4.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     vm_arch_name = x86_64
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel.i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel.i386.cfg
@@ -1,4 +1,5 @@
 - 6.devel.i386:
+    grub_file = /boot/grub/grub.conf
     no setup
     nic_hotplug:
         modprobe_module =

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel.x86_64.cfg
@@ -1,4 +1,5 @@
 - 6.devel.x86_64:
+    grub_file = /boot/grub/grub.conf
     no setup
     vm_arch_name = x86_64
     nic_hotplug:

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -3,7 +3,7 @@ from autotest.client import utils
 from autotest.client.shared import error
 import aexpect, qemu_monitor, ppm_utils, test_setup, virt_vm
 import libvirt_vm, video_maker, utils_misc, storage, qemu_storage
-import remote, data_dir, utils_net
+import remote, data_dir, utils_net, utils_disk
 
 
 try:
@@ -433,6 +433,46 @@ def preprocess(test, params, env):
         process_command(test, params, env, params.get("pre_command"),
                         int(params.get("pre_command_timeout", "600")),
                         params.get("pre_command_noncritical") == "yes")
+
+
+    #if you want set "pci=nomsi" before test, set "disable_pci_msi = yes"
+    #and pci_msi_sensitive = "yes"
+    if params.get("pci_msi_sensitive", "no") == "yes":
+        disable_pci_msi = params.get("disable_pci_msi", "no")
+        image_filename = storage.get_image_filename(params,
+                                                    data_dir.get_data_dir())
+        grub_file = params.get("grub_file", "/boot/grub2/grub.cfg")
+        kernel_cfg_pos_reg =  params.get("kernel_cfg_pos_reg",
+                                         r".*vmlinuz-\d+.*")
+        msi_keyword = params.get("msi_keyword", " pci=nomsi")
+
+        disk_obj = utils_disk.GuestFSModiDisk(image_filename)
+        kernel_config_ori = disk_obj.read_file(grub_file)
+        kernel_config = re.findall(kernel_cfg_pos_reg, kernel_config_ori)
+        if not kernel_config:
+            raise error.TestError("Cannot find the kernel config, reg is %s" %
+                                  kernel_cfg_pos_reg)
+        kernel_config_line = kernel_config[0]
+
+        kernel_need_modify = False
+        if disable_pci_msi == "yes":
+            if not re.findall(msi_keyword, kernel_config_line):
+                kernel_config_set = kernel_config_line + msi_keyword
+                kernel_need_modify = True
+        else:
+            if re.findall(msi_keyword, kernel_config_line):
+                kernel_config_set = re.sub(msi_keyword, "", kernel_config_line)
+                kernel_need_modify = True
+
+        if kernel_need_modify:
+            for vm in env.get_all_vms():
+                if vm:
+                    vm.destroy()
+                    env.unregister_vm(vm.name)
+            disk_obj.replace_image_file_content(grub_file, kernel_config_line,
+                                                kernel_config_set)
+        logging.debug("Guest cmdline 'pci=nomsi' setting is: [ %s ]" %
+                       disable_pci_msi)
 
     #Clone master image from vms.
     base_dir = data_dir.get_data_dir()


### PR DESCRIPTION
Using this patch you can enable or disable pci msi by modify the
guest disk directly before test start.
if you want to disable (pci=nomsi) pci msi before test, just set:
    pci_msi_sensitive = yes
    disable_pci_msi = yes
in tests.cfg.

Install python-libguestfs before using this patch.

chang_log:
    V2 from V1:
        using python guestfs lib.
