### PR TITLE
qemu.test: merge block_mirror test

### DIFF
--- a/qemu/tests/block_mirror.py
+++ b/qemu/tests/block_mirror.py
@@ -1,4 +1,4 @@
-import re, os, logging, time
+import os, logging, time
 from autotest.client.shared import utils, error
 from virttest import qemu_monitor, storage, env_process, data_dir, utils_misc
 
@@ -17,65 +17,78 @@ def run_block_mirror(test, params, env):
     """
     image_name = params.get("image_name", "image")
     image_format = params.get("image_format", "qcow2")
-    image_orig = "%s.%s" % (image_name, image_format)
     image_mirror = utils_misc.get_path(data_dir.get_data_dir(),
-                                       "%s-mirror.%s" % (image_name, image_format))
-    drive_format = params["drive_format"]
+                                       "%s-mirror.%s" % (image_name,
+                                           image_format))
     block_mirror_cmd = params.get("block_mirror_cmd", "drive-mirror")
-    device_id = "None"
-    qemu_img = params["qemu_img_binary"]
+    qemu_img = params.get("qemu_img_binary")
+    source_images = params.get("source_images", "image1").split()
+    source_image = source_images[0]
+    _params = params.object_params(source_image)
+    speed = int(_params.get("default_speed", 0))
+    sync = _params.get("full_copy").lower()
+    if block_mirror_cmd.startswith("__"):
+            sync = (sync == "full")
+    mode = _params.get("create_mode", "absolute-paths")
+    format = _params.get("target_format", "qcow2")
+    check_event = _params.get("check_event")
 
 
-    def check_block_jobs_info():
+    def check_block_jobs_info(device_id):
         """
         Verify block-jobs status reported by monitor command info block-jobs.
 
         @return: parsed output of info block-jobs
         """
         fail = 0
-
+        status = dict()
         try:
-            output = vm.monitor.info("block-jobs")
+            status = vm.get_job_status(device_id)
         except qemu_monitor.MonitorError, e:
             logging.error(e)
             fail += 1
-            return None, None
-        return (re.match("[\w ]+", str(output)), re.findall("\d+", str(output)))
+            return status
+        return status
 
 
-    def run_mirroring(vm, cmd, device, dest, complete = True):
+    def run_mirroring(vm, device, dest, sync, speed=0, foramt="qcow2",
+            mode="absolute-paths", complete = True):
         """
         Run block mirroring.
 
         @param vm: Virtual machine object
-        @param cmd: Command for start mirroring
         @param device: Guest device that has to be mirrored
         @param dest: Location image has to be mirrored into
+        @param speed: limited speed
+        @param format: target image format
+        @param mode: image create mode
         @param complete: If True, mirroring will complete (switch to mirror),
                          If False, finish image synchronization and keep
                          mirroring running (any changes will be mirrored)
         """
-        vm.monitor.cmd("%s %s %s" % (cmd, device, dest))
-
+        vm.block_mirror(device, dest, speed, sync, format, mode)
         while True:
-            blkjobout, blkjobstatus = check_block_jobs_info()
-            if 'mirror' in blkjobout.group(0):
+            status = check_block_jobs_info(device)
+            if 'mirror' in status.get("type", ""):
                 logging.info("[(Completed bytes): %s (Total bytes): %s "
-                             "(Speed limit in bytes/s): %s]", blkjobstatus[-3],
-                             blkjobstatus[-2], blkjobstatus[-1])
-                if int(blkjobstatus[-3]) != int(blkjobstatus[-2]):
+                             "(Speed limit in bytes/s): %s]", status["offset"],
+                             status["len"], status["speed"])
+                if status["offset"] != int(status["len"]):
                     time.sleep(10)
                     continue
+                elif vm.monitor.protocol == "qmp" and check_event == "yes":
+                    if vm.monitor.get_event("BLOCK_JOB_READY") is None:
+                        continue
                 else:
                     logging.info("Target synchronized with source")
                     if complete:
                         logging.info("Start mirroring completing")
-                        vm.monitor.cmd("stop")
-                        vm.monitor.cmd("block_job_complete %s" % device)
+                        vm.pause()
+                        vm.block_reopen(device, dest, format)
                         time.sleep(5)
                     else:
                         break
-            elif 'No' in blkjobout.group(0):
+            elif not status:
                 logging.info("Block job completed")
                 break
 
@@ -110,20 +123,14 @@ def run_block_mirror(test, params, env):
         timeout = int(params.get("login_timeout", 360))
         session = vm.wait_for_login(timeout=timeout)
         img_path = storage.get_image_filename(params, data_dir.get_data_dir())
+        device_id = vm.get_block({"file": img_path})
 
-        if 'ide' in drive_format:
-            device_id = " id0-hd0"
-        elif 'virtio' in drive_format:
-            device_id = " virtio0"
-        else:
-            raise error.TestNAError("Drive format %s is not supported" %
-                                    drive_format)
 
         # Subtest 1 - Complete mirroring
         error.context("Testing complete mirroring")
-        run_mirroring(vm, block_mirror_cmd, device_id, image_mirror)
-        output = vm.monitor.info("block")
-        if image_orig in output or image_mirror not in output:
+        run_mirroring(vm, device_id, image_mirror, sync, speed, format, mode)
+        _device_id = vm.get_block({"file": image_mirror})
+        if device_id != _device_id:
             raise error.TestError("Mirrored image not being used by guest")
         error.context("Compare fully mirrored images")
         compare_images(qemu_img, img_path, image_mirror)
@@ -133,14 +140,13 @@ def run_block_mirror(test, params, env):
         error.context("Testing continuous backup")
         vm.create()
         session = vm.wait_for_login(timeout=timeout)
-        run_mirroring(vm, block_mirror_cmd, device_id, image_mirror,False)
-        if image_orig in output or image_mirror not in output:
-            raise error.TestError("Mirrored image not used by guest")
+        run_mirroring(vm, device_id, image_mirror, sync,
+                speed, format, mode, False)
         for fn in range(0,128):
             session.cmd("dd bs=1024 count=1024 if=/dev/urandom of=tmp%d.file"
                         % fn)
         time.sleep(10)
-        vm.monitor.cmd("stop")
+        vm.pause()
         time.sleep(5)
         error.context("Compare original and backup images")
         compare_images(qemu_img, img_path, image_mirror)

--- a/qemu/tests/cfg/block_mirror.cfg
+++ b/qemu/tests/cfg/block_mirror.cfg
@@ -1,3 +1,0 @@
-- block_mirror:
-    type = block_mirror
-    block_mirror_cmd = drive_mirror

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -31,6 +31,7 @@
             variants:
                 - cancel:
                     before_steady = "cancel"
+                    cancel_timeout_image1 = 3
                 - set_speed:
                     max_speed_image1 = 10M
                     before_steady = "set_speed"
@@ -42,6 +43,8 @@
                     before_steady = "query_status"
                     default_speed_image1 = 3M
                     max_speed_image1 = 10M
+                - mirroring:
+                    type = block_mirror
         - with_stress:
             type = drive_mirror_stress
             reopen_timeout = 360


### PR DESCRIPTION
Fix incorrect command when run test with qmp monitor;
Fix logical error that target image file should not be opening before do
reopen step;
Merge configuration file into drive_mirror.cfg

Signed-off-by: Xu Tian xutian@redhat.com
