### PR TITLE
virt.test : make file_transfer support vhostfore on and off

### DIFF
--- a/tests/cfg/file_transfer.cfg
+++ b/tests/cfg/file_transfer.cfg
@@ -6,3 +6,8 @@
     variants:
         - remote:
             transfer_type = remote
+    variants:
+        - vhostforce_off:
+            netdev_extra_params_nic1 += ',vhostforce=off'
+        - vhostforce_on:
+            netdev_extra_params_nic1 += ',vhostforce=on'


### PR DESCRIPTION
This patch make test file_transfer support vhostfore on
and off
