### PR TITLE
qemu/tests:Disable s3 and s4 tests for ppc64

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -17,6 +17,7 @@
            sub_balloon_test_evict = "migration"
            migration_test_command = help
        - guest_s3:
+           no ppc64
            extra_params += " -global PIIX4_PM.disable_s3=0"
            sub_balloon_test_enlarge = "guest_suspend"
            sub_balloon_test_evict = "guest_suspend"
@@ -26,6 +27,7 @@
            # s3_bg_program_chk_cmd, s3_bg_program_kill_cmd, s3_log_chk_cmd,
            # s3_start_cmd and services_up_timeout are set in guest-os.cfg
        - guest_s4:
+           no ppc64
            extra_params += " -global PIIX4_PM.disable_s4=0"
            sub_balloon_test_enlarge = "guest_suspend"
            sub_balloon_test_evict = "guest_suspend"

--- a/qemu/tests/cfg/cdrom_test.cfg
+++ b/qemu/tests/cfg/cdrom_test.cfg
@@ -30,6 +30,7 @@
             not_insert_at_start = yes
             cdrom_without_file = yes
         - guest_s3:
+            no ppc64
             cdrom_test_locked = no
             sub_test = guest_suspend
             extra_params += " -global PIIX4_PM.disable_s3=0"
@@ -39,6 +40,7 @@
             # s3_bg_program_chk_cmd, s3_bg_program_kill_cmd, s3_log_chk_cmd,
             # s3_start_cmd and services_up_timeout are set in guest-os.cfg
         - guest_s4:
+            no ppc64
             cdrom_test_locked = no
             sub_test = guest_suspend
             extra_params += " -global PIIX4_PM.disable_s4=0"


### PR DESCRIPTION
ppc64 platform does not support s3 and s4 cases.
So disable them when in ppc64 platform.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
