### PR TITLE
qemu/tests/qemu_guest_agent:disable isa serial with ppc64

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -67,6 +67,8 @@
         - isa_serial:
             # Windows guests don't support isa serial, disable it directly.
             no Windows
+            # ppc64 platform doesn't support isa serial 
+            no ppc64
             gagent_serial_type = isa
             isa_serials += " org.qemu.guest_agent.0"
             gagent_start_cmd = "pgrep qemu-ga || qemu-ga -d -m isa-serial -p /dev/ttyS1"


### PR DESCRIPTION
ppc64 platform does not support isa serial, so disable this.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
