### PR TITLE
shared.cfg: Disable S3/S4 test on all ppc64 guests

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/16.ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/16.ppc64.cfg
@@ -2,6 +2,7 @@
     image_name = images/f16-ppc64
     only pseries
     no unattended_install..floppy_ks
+    no guest_s3, guest_s4
     unattended_install:
         kernel_params = "root=live:CDLABEL=Fedora-16-ppc64 ks=cdrom:/ks.cfg console=hvc0 serial rd_NO_PLYMOUTH"
         unattended_file = unattended/Fedora-16.ks

--- a/shared/cfg/guest-os/Linux/Fedora/17.ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/17.ppc64.cfg
@@ -2,6 +2,7 @@
     image_name = images/f17-ppc64
     only pseries
     no unattended_install..floppy_ks
+    no guest_s3, guest_s4
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
     unattended_install:

--- a/shared/cfg/guest-os/Linux/Fedora/18.ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/18.ppc64.cfg
@@ -2,6 +2,7 @@
     image_name = images/f18-ppc64
     only pseries
     no unattended_install..floppy_ks
+    no guest_s3, guest_s4
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
     unattended_install:


### PR DESCRIPTION
According to https://github.com/autotest/virt-test/pull/558
All S3/S4 tests should be disabled on ppc64 guests.

Signed-off-by: Qingtang Zhou qzhou@redhat.com
