### PR TITLE
virt: Replace deprecated template with eval in cart-config.

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -535,6 +535,9 @@ class Node(object):
                 child.dump(indent + 3, recurse)
 
 
+match_subtitute = re.compile("\$\{(.+)\}")
+
+
 def _subtitution(value, d):
     """
     Only optimization string Template subtitute is quite expensive operation.
@@ -545,8 +548,19 @@ def _subtitution(value, d):
     @return: Substituted string
     """
     if "$" in value:
-        st = string.Template(value)
-        return st.safe_substitute(d)
+        start = 0
+        st = ""
+        try:
+            match = match_subtitute.search(value, start)
+            while match:
+                val = eval(match.group(1), None, d)
+                st += value[start:match.start()] + str(val)
+                start = match.end()
+                match = match_subtitute.search(value, start)
+        except:
+            pass
+        st += value[start:len(value)]
+        return st
     else:
         return value
 

--- a/virttest/cartesian_config_unittest.py
+++ b/virttest/cartesian_config_unittest.py
@@ -339,7 +339,9 @@ class CartesianConfigTest(unittest.TestCase):
                     var += a
                     var <= b
                     system = 2
-                    s.* ?= ${tests}4
+                    ddd = ${tests + str(int(system) + 3)}4
+                    error = ${tests + str(system + 3)}4
+                    s.* ?= ${tests + "ahoj"}4
                     s.* ?+= c
                     s.* ?<= d
                     system += 4
@@ -349,7 +351,9 @@ class CartesianConfigTest(unittest.TestCase):
             {'dep': [],
              'name': '(tests=system1)',
              'shortname': '(tests=system1)',
-             'system': 'dsystem14c4',
+             'system': 'dsystem1ahoj4c4',
+             'ddd': 'system154',
+             'error': '${tests + str(system + 3)}4',
              'tests': 'system1',
              'var': 'b2atest'},
             ],


### PR DESCRIPTION
Replace templates.subtitution by eval in Cartesian config.
It allows use basic python expression in configuration code.
Speed is almost same as with tempaltes.subtitution.

Example:
 cfg:
   mem = 1000
   real_mem = ${float(mem) \* 0.7}M

 output:
    mem = 1000
    real_mem = 700M

Signed-off-by: Jiří Župka jzupka@redhat.com
