### PR TITLE
qemu.tests.cpu_hotplug: Make cpu hotplug command configurable.

### DIFF
--- a/qemu/tests/cfg/cpu_hotplug.cfg
+++ b/qemu/tests/cfg/cpu_hotplug.cfg
@@ -10,6 +10,7 @@
     kill_vm = yes
     smp = 1
     vcpu_maxcpus = 160
+    cpu_hotplug_cmd = 'cpu_set cpu=%s,state=online'
     # this at least need a RHEL.6.3 host
     # the smp can be overrided (tests.cfg is a good place)
     # if you want to test with a guest booted with diff SMP, pls modify it.

--- a/qemu/tests/cpu_hotplug.py
+++ b/qemu/tests/cpu_hotplug.py
@@ -35,6 +35,7 @@ def run_cpu_hotplug(test, params, env):
     maxcpus = int(params.get("maxcpus", 160))
     current_cpus = int(params.get("smp", 1))
     onoff_iterations = int(params.get("onoff_iterations", 20))
+    cpu_hotplug_cmd = params['cpu_hotplug_cmd']
 
     if n_cpus_add + current_cpus > maxcpus:
         logging.warn("CPU quantity more than maxcpus, set it to %s", maxcpus)
@@ -49,7 +50,7 @@ def run_cpu_hotplug(test, params, env):
 
     for i in range(current_cpus, total_cpus):
         error.context("hot-pluging vCPU %s" % i, logging.info)
-        vm.monitor.send_args_cmd("cpu_set %s online" % i)
+        vm.monitor.send_args_cmd(cpu_hotplug_cmd % i)
 
     output = vm.monitor.send_args_cmd("info cpus")
     logging.debug("Output of info CPUs:\n%s", output)


### PR DESCRIPTION
cpu_set command will be removed in new qemu. So make cpu hotplug
 command configurable.

'cpu_set 1 online' will always sent out as human monitor command no matter
 qmp support cpu_set or not.

Update it to 'cpu_set cpu=1,state=online'. send_args_cmd() will transfer
it to correct human monitor command 'cpu_set 1 online'. Or correct qmp
monitor command if qmp support it.

Signed-off-by: Feng Yang fyang@redhat.com
