### PR TITLE
virttest.qemu_vm: support vhostfd in netdev.

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -91,6 +91,8 @@ variants:
                     query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
                 virtio_net:
                     vhost = "vhost=on"
+                    # enable_vhostfd only works with vhost=on
+                    enable_vhostfd = yes
                 Win2008, Win2008r2, Win7:
                     cpu_model_flags += ",hv_relaxed"
                 block_stream, drive_mirror, live_snapshot, live_snapshot_chain:
@@ -135,6 +137,8 @@ variants:
                     cpu_model_flags += ",hv_relaxed"
                 virtio_net:
                     vhost = "vhost=on"
+                    # enable_vhostfd only works with vhost=on
+                    enable_vhostfd = yes
                 monitor_cmds_check.qmp:
                     black_cmds = "block-stream block-job-cancel block-job-set-speed drive-mirror block-job-complete block-job-pause block-job-resume"
                 monitor_cmds_check.human:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -828,6 +828,10 @@ class VM(virt_vm.BaseVM):
                 cmd = " -netdev %s,id=%s" % (mode, netdev_id)
                 if vhost:
                     cmd += ",%s" % vhost
+                    enable_vhostfd = params.get("enable_vhostfd", "yes")
+                    if vhost == 'vhost=on' and enable_vhostfd == 'yes':
+                        vhostfd = os.open("/dev/vhost-net", os.O_RDWR)
+                        cmd += ",vhostfd=%s" % vhostfd
                 if netdev_extra_params:
                     cmd += "%s" % netdev_extra_params
             else:


### PR DESCRIPTION
vhostfd only works when vhost on.

Signed-off-by: Feng Yang fyang@redhat.com
