### PR TITLE
libvirt: fix VMXML.define and VMXML.undefine.

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -296,14 +296,18 @@ class VMXML(VMXMLBase):
 
     def undefine(self):
         """Undefine this VM with libvirt retaining XML in instance"""
-        # Allow any exceptions to propigate up
-        self.virsh.remove_domain(self.vm_name)
+        return self.virsh.remove_domain(self.vm_name):
 
 
     def define(self):
         """Define VM with virsh from this instance"""
-        # Allow any exceptions to propigate up
-        self.virsh.define(self.xml)
+        result = self.virsh.define(self.xml)
+        if result.exit_status:
+            logging.debug("Define %s failed.\n"
+                          "Detail: %s."
+                          % (self.vm_name, result.stderr))
+            return False
+        return True
 
 
     @staticmethod

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -999,7 +999,7 @@ def define(xml_path, **dargs):
 
 def undefine(name, **dargs):
     """
-    Return True on successful domain undefine (after shutdown/destroy).
+    Return cmd result of domain undefine (after shutdown/destroy).
 
     @param: name: VM name
     @param: dargs: standardized virsh function API keywords


### PR DESCRIPTION
Why we "Allow any exceptions to propigate up" in vmxml.define()
and vmxml.undefine()????If define or undefine failed and there is no
error raised, user will be mistaken I think.

This patch fix define and undefine method in VMXML class to raise a
error if define or undefine fail.

Fixing the comment of virsh.undefine by the way.

Signed-off-by: yangdongsheng yangds.fnst@cn.fujitsu.com
