### PR TITLE
add commas of qemu cpu flags in cfg, not qemu_vm(issue 604)

### DIFF
--- a/qemu/cfg/multi-host-tests.cfg
+++ b/qemu/cfg/multi-host-tests.cfg
@@ -24,7 +24,7 @@ variants:
         only pc
         only Fedora.17.x86_64
         cpu_model = "core2duo"
-        cpu_model_flags = "+sse3"
+        cpu_model_flags = ",+sse3"
         only migrate_multi_host
 
     # Runs qemu, f16 64 bit guest OS, install, boot, shutdown

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1172,7 +1172,7 @@ class VM(virt_vm.BaseVM):
                 if vendor_id:
                     cmd += ",vendor=\"%s\"" % vendor_id
                 if flags:
-                    cmd += ",%s" % flags
+                    cmd += "%s" % flags
                 if family is not None:
                     cmd += ",family=%s" % family
                 return cmd

--- a/virttest/unittest_data/testcfg.huge/multi-host-tests.cfg
+++ b/virttest/unittest_data/testcfg.huge/multi-host-tests.cfg
@@ -24,7 +24,7 @@ variants:
         only pc
         only Fedora.17.64
         cpu_model = "core2duo"
-        cpu_model_flags = "+sse3"
+        cpu_model_flags = ",+sse3"
         only migrate_multi_host
 
     # Runs qemu, f16 64 bit guest OS, install, boot, shutdown


### PR DESCRIPTION
otherwise would generate qemu cmd like -cpu SandyBridge,,+sep
This fix is for https://github.com/autotest/virt-test/issues/604

Signed-off-by: Xiaoqing Wei xwei@redhat.com
