### PR TITLE
qemu.tests.floppy: Fix issue 'NoneType' object has no attribute 'create'

### DIFF
--- a/qemu/tests/floppy.py
+++ b/qemu/tests/floppy.py
@@ -98,8 +98,11 @@ def run_floppy(test, params, env):
     class test_singlehost(MiniSubtest):
         def test(self):
             create_floppy(params)
-            vm = env.get_vm(params["main_vm"])
-            vm.create()
+            params["start_vm"] = "yes"
+            vm_name = params.get("main_vm", "vm1")
+            env_process.preprocess_vm(test, params, env, vm_name)
+            vm = env.get_vm(vm_name)
+            vm.verify_alive()
             self.session = vm.wait_for_login(timeout=login_timeout)
 
             self.dest_dir = params["mount_dir"]


### PR DESCRIPTION
When fail to get vm from env file, we will meet following issue:
Traceback (most recent call last):
  File "/root/ypu/autotest_upstream_master/client/shared/test.py", line 426, in _exec
    _call_test_function(self.execute, _p_args, *_p_dargs)
  File "/root/ypu/autotest_upstream_master/client/shared/test.py", line 853, in _call_test_function
    raise error.UnhandledTestFail(e)
UnhandledTestFail: Unhandled AttributeError: 'NoneType' object has no attribute 'create'    [context: Boot up guest with a floppy]
Traceback (most recent call last):
  File "/root/ypu/autotest_upstream_master/client/shared/test.py", line 846, in _call_test_function
    return func(_args, *_dargs)
  File "/root/ypu/autotest_upstream_master/client/shared/test.py", line 299, in execute
    postprocess_profiled_run, args, dargs)
  File "/root/ypu/autotest_upstream_master/client/shared/test.py", line 216, in _call_run_once
    _args, *_dargs)
  File "/root/ypu/autotest_upstream_master/client/shared/test.py", line 322, in run_once_profiling
    self.run_once(_args, *_dargs)
  File "/root/ypu/autotest_upstream_master/client/tests/virt/virt.py", line 133, in run_once
    run_func(self, params, env)
  File "/root/ypu/autotest_upstream_master/client/shared/error.py", line 138, in new_fn
    return fn(_args, *_kwargs)
  File "/root/ypu/autotest_upstream_master/client/tests/virt/qemu/tests/floppy.py", line 33, in run_floppy
    vm.create()
AttributeError: 'NoneType' object has no attribute 'create'

Call env_process.preprocess_vm(test, params, env, vm_name) to create vm could skip this issue.

Signed-off-by: Feng Yang fyang@redhat.com
