### PR TITLE
qemu.tests.hdparm: Fix issue that start VM twice

### DIFF
--- a/qemu/tests/hdparm.py
+++ b/qemu/tests/hdparm.py
@@ -61,7 +61,7 @@ def run_hdparm(test, params, env):
 
     ignore_string = params.get("ignore_string")
     vm = env.get_vm(params["main_vm"])
-    vm.create()
+    vm.verify_alive()
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
     try:
         timeout = float(params.get("cmd_timeout", 60))


### PR DESCRIPTION
Now hdparm will start VM twice.
hdparm no need special setup before starting VM.
So only start VM in framework.

Signed-off-by: Feng Yang fyang@redhat.com
