### PR TITLE
Add service module in virttest.(Base on client.shared.service)

### DIFF
--- a/virttest/service.py
+++ b/virttest/service.py
@@ -13,6 +13,8 @@ def get_remote_runner(session):
         Execute command with session and return a utils.CmdResult object.
 
         """
+        # Use a pipo to drop the color of output.
+        command = ("%s | cat" % command)
         status, output = session.cmd_status_output(command)
         return utils.CmdResult(command=command,
                                exit_status=status,


### PR DESCRIPTION
This service module is based on autotest.client.shared.service.
virt-service module extend the client-service to manager the
service on remote host (guest).

Signed-off-by: yangdongsheng yangds.fnst@cn.fujitsu.com
