### PR TITLE
qemu.tests.physical_resources_check: Always use human monitor info comma...

### DIFF
--- a/qemu/tests/physical_resources_check.py
+++ b/qemu/tests/physical_resources_check.py
@@ -23,7 +23,7 @@ def run_physical_resources_check(test, params, env):
         expected_num = params.objects(devices).__len__()
         o = ""
         try:
-            o = vm.monitor.info(info_cmd)
+            o = vm.monitor.human_monitor_cmd("info %s " % info_cmd)
         except qemu_monitor.MonitorError, e:
             fail_log =  e + "\n"
             fail_log += "info/query monitor command failed (%s)" % info_cmd
@@ -49,7 +49,7 @@ def run_physical_resources_check(test, params, env):
                 expected = "rtl8139"
             o = ""
             try:
-                o = vm.monitor.info(info_cmd)
+                o = vm.monitor.human_monitor_cmd("info %s" % info_cmd)
             except qemu_monitor.MonitorError, e:
                 fail_log = e + "\n"
                 fail_log += "info/query monitor command failed (%s)" % info_cmd
@@ -257,7 +257,7 @@ def run_physical_resources_check(test, params, env):
     logging.info("Network card MAC check")
     o = ""
     try:
-        o = vm.monitor.info("network")
+        o = vm.monitor.human_monitor_cmd("info network")
     except qemu_monitor.MonitorError, e:
         fail_log =  e + "\n"
         fail_log += "info/query monitor command failed (network)"


### PR DESCRIPTION
...nd

Current code only works with human monitor info command,
so always use human monitor info command for qmp/human monitor.

Signed-off-by: Feng Yang fyang@redhat.com
