### PR TITLE
utils_libvirtd: if libvirt is not availible in host, raise ImportError.

### DIFF
--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -41,7 +41,9 @@ try:
     os_dep.command("libvirtd")
     LIBVIRTD = "libvirtd"
 except ValueError:
-    raise LibvirtdError("There is no libvirtd on the host.")
+    LIBVIRTD = None
+    logging.warning("Libvirtd service is not availible in host, "
+                    "utils_libvirtd module will not function normally")
 
 
 def service_libvirtd_control(action, remote_ip=None,

--- a/virttest/utils_libvirtd_unittest.py
+++ b/virttest/utils_libvirtd_unittest.py
@@ -5,6 +5,7 @@ import common
 from virttest import utils_libvirtd
 
 class UtilsLibvirtdTest(unittest.TestCase):
+    @unittest.skipIf(not utils_libvirtd.LIBVIRTD, "skip if libvirtd is not available")
     def test_service_libvirtd_control(self):
         service_libvirtd_control = utils_libvirtd.service_libvirtd_control
         self.assertRaises(utils_libvirtd.LibvirtdActionUnknownError,
@@ -18,6 +19,5 @@ class UtilsLibvirtdTest(unittest.TestCase):
             self.assertRaises(utils_libvirtd.LibvirtdActionError,
                               utils_libvirtd.service_libvirtd_control,
                               action=action, libvirtd="")
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: yangdongsheng yangds.fnst@cn.fujitsu.com
