### PR TITLE
Aexpect spawn's definition

### DIFF
--- a/virttest/aexpect.py
+++ b/virttest/aexpect.py
@@ -342,7 +342,7 @@ def run_fg(command, output_func=None, output_prefix="", timeout=1.0):
     return (status, output)
 
 
-class Spawn:
+class Spawn(object):
     """
     This class is used for spawning and controlling a child process.
 


### PR DESCRIPTION
I realized this problem when I tried to test guestfs_add.
@lmr replaced aexpect.ShellSession.**init** with super(...), then it always outputs:
TypeError: super() argument 1 must be type, not classobj
