### PR TITLE
remove qcow3 cfg from guest-hw.cfg and add qcow2 V3 cfg in RHEL.7 host cfg

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -27,6 +27,7 @@ variants:
         host_kernel_ver_str = Host_RHEL
         variants:
             - 5:
+                no qcow2_v3
                 host_kernel_ver_str += ".5"
                 monitor_type = human
                 monitors = hmp1
@@ -85,6 +86,7 @@ variants:
                         requires_kernel = [">= 2.6.18-348", "<  2.6.19"]
             - 6:
                 # RHEL-6 pointer
+                no qcow2_v3
                 host_kernel_ver_str += ".6"
                 netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\s"
                 ksm_base:

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -83,7 +83,7 @@ variants:
         # placeholder
 
 variants:
-    - qcow3:
+    - qcow2_v3:
         image_format = qcow2
         image_extra_params = "compat=1.1"
     - qcow2:


### PR DESCRIPTION
images created with  qemu-img -f qcow2 -o compat=1.1 is still qcow2 formation, but Version 3

Signed-off-by: Xiaoqing Wei xwei@redhat.com
