### PR TITLE
shared.cfg: Check SSDT for both S3/S4 tests

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora.cfg
@@ -5,9 +5,27 @@
         boot_path = "images/pxeboot"
         kernel_params = "ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0"
         anaconda_log = "yes"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "yum install -y iasl"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "yum install -y iasl"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
     guest_s4:
         17, 18:
             s4_log_chk_cmd = 'dmesg | grep -E "PM: Image restored successfully."'
+        global_enable_s4:
+            s4_support_chk_cmd = "yum install -y iasl"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
         global_disable_s4:
             s4_support_chk_cmd = "yum install -y iasl"
             s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"

--- a/shared/cfg/guest-os/Linux/RHEL/5.4/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.4/x86_64.cfg
@@ -13,8 +13,27 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel54-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/5.5/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.5/x86_64.cfg
@@ -13,8 +13,27 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel55-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/5.6/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.6/x86_64.cfg
@@ -13,8 +13,27 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel56-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/5.7/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.7/x86_64.cfg
@@ -13,8 +13,27 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel56-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/5.8/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.8/x86_64.cfg
@@ -13,8 +13,27 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel58-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/5.9/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.9/x86_64.cfg
@@ -13,8 +13,27 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel59-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/5/os/x86_64/CentOS/iasl-20090123-1.el5.x86_64.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.0.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.0.cfg
@@ -8,3 +8,27 @@
         modprobe_module =
     block_hotplug:
         modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.0/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.0/i386.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel60-32/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.0/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.0/x86_64.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel60-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.1.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.1.cfg
@@ -8,3 +8,27 @@
         modprobe_module =
     block_hotplug:
         modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.1/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.1/i386.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel61-32/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.2.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.2.cfg
@@ -8,3 +8,27 @@
         modprobe_module =
     block_hotplug:
         modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.2/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.2/i386.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel62-32/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.2/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.2/x86_64.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel62-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.3.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.3.cfg
@@ -8,3 +8,27 @@
         modprobe_module =
     block_hotplug:
         modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.3/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.3/i386.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel63-32/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.3/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.3/x86_64.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel63-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.4.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.4.cfg
@@ -8,3 +8,27 @@
         modprobe_module =
     block_hotplug:
         modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.4/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.4/i386.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel64-32/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.4/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.4/x86_64.cfg
@@ -13,8 +13,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel64-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel.cfg
@@ -8,3 +8,27 @@
         modprobe_module =
     block_hotplug:
         modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel/i386.cfg
@@ -11,8 +11,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel63-64/ks.vfd
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel/x86_64.cfg
@@ -12,8 +12,3 @@
         floppies = "fl"
         floppy_name = images/rhel6-64/ks.vfd
         cdrom_cd1 = isos/linux/RHEL6-devel-x86_64.iso
-    guest_s4..global_disable_s4:
-        s4_support_chk_cmd = "rpm --force --nodeps http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
-        s4_support_chk_cmd += " && cat cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
-        s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
-        s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"


### PR DESCRIPTION
The SSDT shows whether the bios set the suspend status
correctly, so it's another test point for both S3/S4
tests.

Signed-off-by: Qingtang Zhou qzhou@redhat.com

Tested guest_suspend..guest_enable/disable_s3/s4 for Fedora18 and RHEL6.4 guests, all passed.
