### PR TITLE
virttest.qemu_vm: Fix ahci null drive parameter

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -692,7 +692,7 @@ class VM(virt_vm.BaseVM):
                 dev = QDevice('ide-drive')
                 dev.set_param('bus', 'ahci.%s' % index)
                 dev.set_param('drive', blkdev_id)
-                dev.set_param("id", name)
+                dev.set_param("id", tmp)
                 fmt = "none"
                 index = None
             elif fmt in ['usb1', 'usb2', 'usb3']:


### PR DESCRIPTION
ahci would get a drive='' on the -device part, setting
the name to ahci%s would resolve this issue

Signed-off-by: Xiaoqing Wei xwei@redhat.com
