### PR TITLE
rename qcow3 to qcow2_v3 and disable it on unsupported hosts

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -27,6 +27,7 @@ variants:
         host_kernel_ver_str = Host_RHEL
         variants:
             - 5:
+                no qcow2v3
                 host_kernel_ver_str += ".5"
                 monitor_type = human
                 monitors = hmp1
@@ -84,6 +85,7 @@ variants:
                         host_kernel_ver_str += ".9"
                         requires_kernel = [">= 2.6.18-348", "<  2.6.19"]
             - 6:
+                no qcow2v3
                 # RHEL-6 pointer
                 host_kernel_ver_str += ".6"
                 netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\s"

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -85,8 +85,8 @@ variants:
         # placeholder
 
 variants:
-    - qcow3:
-        image_format = qcow2
+    - qcow2v3:
+        image_format = qcow2v3
         image_extra_params = "compat=1.1"
     - qcow2:
         image_format = qcow2


### PR DESCRIPTION
images created with qemu-img -f qcow2 -o compat=1.1 is still qcow2 formation, but Version 3

Signed-off-by: Xiaoqing Wei xwei@redhat.com
