### PR TITLE
Adding LD_LIBRARY_PATH to qemu call to be able to use built libraries

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1369,11 +1369,6 @@ class VM(virt_vm.BaseVM):
         # Set the X11 display parameter if requested
         if params.get("x11_display"):
             qemu_cmd += "DISPLAY=%s " % params.get("x11_display")
-        # Update LD_LIBRARY_PATH for built libraries (libspice-server)
-        library_path = os.path.join(self.root_dir, 'build', 'lib')
-        if os.path.isdir(library_path):
-            library_path = os.path.abspath(library_path)
-            qemu_cmd += "LD_LIBRARY_PATH=%s " % library_path
         if params.get("qemu_audio_drv"):
             qemu_cmd += "QEMU_AUDIO_DRV=%s " % params.get("qemu_audio_drv")
         # Add command prefix for qemu-kvm. like taskset, valgrind and so on

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1337,9 +1337,21 @@ def get_qemu_binary(params):
     """
     Get the path to the qemu binary currently in use.
     """
-    return get_path(os.path.join(data_dir.get_root_dir(),
-                                 params.get("vm_type")),
-                                 params.get("qemu_binary", "qemu"))
+    # Update LD_LIBRARY_PATH for built libraries (libspice-server)
+    qemu_binary_path = get_path(os.path.join(data_dir.get_root_dir(),
+                                              params.get("vm_type")),
+                                   params.get("qemu_binary", "qemu"))
+    
+    library_path = os.path.join(data_dir.get_root_dir(), params.get('vm_type'), 'install_root', 'lib')
+    logging.info(library_path)
+    if os.path.isdir(library_path):
+       logging.info(library_path)
+       library_path = os.path.abspath(library_path)
+       qemu_binary = "LD_LIBRARY_PATH=%s %s" % (library_path, qemu_binary_path)
+    else:   
+       qemu_binary = qemu_binary_path
+
+    return qemu_binary
 
 
 def get_qemu_img_binary(params):


### PR DESCRIPTION
When spice-server is built, qemu can use the built spice-server libraries instead of the default by passing LD_LIBRARY_PATH environment variable. If the path exists, then LD_LIBRARY_PATH will be set. If not, just the binary will be sent. 
