### PR TITLE
tests.mac_change : change mac when the interface is active

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -46,7 +46,7 @@
         readlink_command = readlink -e
         sys_path = "/sys/class/net/%s/device/driver"
     mac_change:
-        change_cmd = ifconfig %s down && ifconfig %s hw ether %s &&  ifconfig %s up
+        change_cmd = ifconfig %s hw ether %s
     multi_disk:
         show_mount_cmd = mount|gawk '/mnt/{print $1}'
         clean_cmd = "\rm -rf /mnt/*"

--- a/tests/cfg/mac_change.cfg
+++ b/tests/cfg/mac_change.cfg
@@ -2,3 +2,13 @@
     virt_test_type = qemu libvirt
     type = mac_change
     kill_vm = yes
+    variants:
+        - down_change:
+            only Linux
+            shutdown_int = yes
+            int_shutdown_cmd = ifconfig %s down
+            int_activate_cmd = ifconfig %s up
+        - @up_change:
+            virtio_net:
+                no RHEL.5, RHEL.6.0, RHEL.6.1, RHEL.6.2, RHEL.6.3
+            shutdown_int = no


### PR DESCRIPTION
this patch make the mac_change test support changing mac when the
interface is active
this patch also modify the method of get drive number of win_utils

Signed-off-by: Yunping Zheng yunzheng@redhat.com
