### PR TITLE
xfstests fix

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/3.9.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/3.9.cfg
@@ -1,6 +1,6 @@
 - 3.9:
     no virtio_net, virtio_blk, e1000
-    no setup autotest linux_s3 guest_s4 shutdown multi_disk
+    no setup autotest linux_s3 guest_s4 shutdown multi_disk xfstests
     no usb_multi_disk, balloon_check
     mem_chk_cmd = dmidecode | awk -F: '/Maximum Capacity/ {print $2}'
     image_name = images/rhel39

--- a/shared/cfg/guest-os/Linux/RHEL/4.7.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/4.7.cfg
@@ -1,5 +1,5 @@
 - 4.7:
-    no setup autotest
+    no setup autotest xfstests
     image_name = images/rhel47
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-4-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/4.8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/4.8.cfg
@@ -1,5 +1,5 @@
 - 4.8:
-    no setup autotest
+    no setup autotest xfstests
     image_name = images/rhel48
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-4-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.3.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.3.cfg
@@ -1,5 +1,5 @@
 - 5.3:
-    no setup
+    no setup xfstests
     image_name = images/rhel53
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.4.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.4.cfg
@@ -1,5 +1,5 @@
 - 5.4:
-    no setup
+    no setup xfstests
     image_name = images/rhel54
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.5.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.5.cfg
@@ -1,5 +1,5 @@
 - 5.5:
-    no setup
+    no setup xfstests
     image_name = images/rhel55
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.6.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.6.cfg
@@ -1,5 +1,5 @@
 - 5.6:
-    no setup
+    no setup xfstests
     image_name = images/rhel56
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.7.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.7.cfg
@@ -1,5 +1,5 @@
 - 5.7:
-    no setup
+    no setup xfstests
     image_name = images/rhel57
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.8.cfg
@@ -1,5 +1,5 @@
 - 5.8:
-    no setup
+    no setup xfstests
     image_name = images/rhel58
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/5.9.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.9.cfg
@@ -1,5 +1,5 @@
 - 5.9:
-    no setup
+    no setup xfstests
     image_name = images/rhel59
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-5-series.ks

--- a/shared/unattended/RHEL-6-series.ks
+++ b/shared/unattended/RHEL-6-series.ks
@@ -37,6 +37,7 @@ coreutils
 usbutils
 qemu-guest-agent
 sg3_utils
+xfsprogs
 
 %post
 echo "OS install is completed" > /dev/ttyS0


### PR DESCRIPTION
share.cfg: disable xfstests on old RHEL OSes dont have xfs support
and add xfsprogs in RHEL-6 ks
