### PR TITLE
tests.boot: Support multi VMs

### DIFF
--- a/tests/boot.py
+++ b/tests/boot.py
@@ -17,21 +17,25 @@ def run_boot(test, params, env):
     @param env: Dictionary with test environment.
     """
 
-    error.context("Try to log into guest.", logging.info)
-    vm = env.get_vm(params["main_vm"])
-    vm.verify_alive()
     timeout = float(params.get("login_timeout", 240))
-    session = vm.wait_for_login(timeout=timeout)
+    vms = env.get_all_vms()
+    for vm in vms:
+        error.context("Try to log into guest '%s'." % vm.name, logging.info)
+        session = vm.wait_for_login(timeout=timeout)
 
     if params.get("rh_perf_envsetup_script"):
-        utils_test.service_setup(vm, session, test.virtdir)
+        for vm in vms:
+            utils_test.service_setup(vm, session, test.virtdir)
 
     if params.get("reboot_method"):
-        error.context("Reboot guest.", logging.info)
-        if params["reboot_method"] == "system_reset":
-            time.sleep(int(params.get("sleep_before_reset", 10)))
+        for vm in vms:
+            error.context("Reboot guest '%s'." % vm.name, logging.info)
+            if params["reboot_method"] == "system_reset":
+                time.sleep(int(params.get("sleep_before_reset", 10)))
             # Reboot the VM
-        for i in range(int(params.get("reboot_count", 1))):
-            session = vm.reboot(session, params["reboot_method"], 0, timeout)
-
-    session.close()
+            for i in range(int(params.get("reboot_count", 1))):
+                session = vm.reboot(session,
+                                    params["reboot_method"],
+                                    0,
+                                    timeout)
+            session.close()


### PR DESCRIPTION
In some case we need boot multi vms. Update boot.py to support it.

Signed-off-by: Feng Yang fyang@redhat.com
