### PR TITLE
virttest.qemu_devices: Add parameter to workaround qemu qmp crash bug

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -24,6 +24,9 @@ main_vm = virt-tests-vm1
 
 # Always set optional parameters (addr, bus, ...)
 strict_mode = no
+# Uncomment this to always wait 1s before executing QMP command
+# (due of bug immediate use of QMP monitor after qemu start causes qemu crash)
+# workaround_qemu_qmp_crash = always
 
 # List of default network device object names (whitespace seperated)
 # All VMs get these by default, unless specific vm name references

--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -869,7 +869,8 @@ class DevContainer(object):
     Device container class
     """
     # General methods
-    def __init__(self, qemu_binary, vmname, strict_mode=False):
+    def __init__(self, qemu_binary, vmname, strict_mode=False,
+                 workaround_qemu_qmp_crash=False):
         """
         @param qemu_binary: qemu binary
         @param vm: related VM
@@ -891,9 +892,11 @@ class DevContainer(object):
                     hmp_cmds.extend(cmd.split('|'))
             return hmp_cmds
 
-        def get_qmp_cmds(qemu_binary):
+        def get_qmp_cmds(qemu_binary, workaround_qemu_qmp_crash=False):
             """ @return: list of qmp commands """
-            cmds = utils.system_output('echo -e \''
+            cmds = None
+            if not workaround_qemu_qmp_crash:
+                cmds = utils.system_output('echo -e \''
                             '{ "execute": "qmp_capabilities" }\n'
                             '{ "execute": "query-commands", "id": "RAND91" }\n'
                             '{ "execute": "quit" }\''
@@ -923,7 +926,7 @@ class DevContainer(object):
         self.__machine_types = utils.system_output("%s -M ?" % qemu_binary,
                                 timeout=10, ignore_status=True, verbose=False)
         self.__hmp_cmds = get_hmp_cmds(qemu_binary)
-        self.__qmp_cmds = get_qmp_cmds(qemu_binary)
+        self.__qmp_cmds = get_qmp_cmds(qemu_binary, workaround_qemu_qmp_crash)
         self.vmname = vmname
         self.strict_mode = strict_mode == 'yes'
         self.__devices = []

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1346,7 +1346,8 @@ class VM(virt_vm.BaseVM):
 
         # Start constructing devices representation
         devices = qemu_devices.DevContainer(qemu_binary, self.name,
-                                            params.get('strict_mode'))
+                        params.get('strict_mode'),
+                        params.get('workaround_qemu_qmp_crash') == "always")
         StrDev = qemu_devices.QStringDevice
         QDevice = qemu_devices.QDevice
 


### PR DESCRIPTION
In order to avoid qemu crash dump on older qemu you can set
"workaround_qemu_qmp_crash = always" in base.cfg and qemu_devices
will wait 1 second before using QMP monitor for the first time.

By default virt-test will try using QMP directly after qemu startup
and in case of failure it still fall backs to the workaround. Still
the first attempt generates unnecessarily crashdump which might
be stored in the autotest results.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
