### PR TITLE
virt: Remove '7za' command check in bootstrap module

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -3,7 +3,7 @@ from autotest.client.shared import logging_manager, error
 from autotest.client import utils
 import utils_misc, data_dir, asset, cartesian_config
 
-basic_program_requirements = ['7za', 'tcpdump', 'nc', 'ip', 'arping']
+basic_program_requirements = ['tcpdump', 'nc', 'ip', 'arping']
 
 recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',), ('qemu-io',)],
                         'libvirt': [('virsh',), ('virt-install',), ('fakeroot',)],


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
I think '7za' is not a essential command for it's only for JeOS's download. If a user just wants to run a testcase, '7za' is not necessary for him. So I modify that the '7za' will be checked in JeOS's download branch.
