### PR TITLE
Various autotest_regression fixes

### DIFF
--- a/tests/autotest_regression.py
+++ b/tests/autotest_regression.py
@@ -67,12 +67,12 @@ def run_autotest_regression(test, params, env):
         if autotest_commit:
             install_cmd += " -c %s" % autotest_commit
         session_server.cmd(install_cmd, timeout=autotest_install_timeout)
-        vm_server.copy_files_from(guest_path="/tmp/install-autotest-server*log",
-                                  host_path=test.resultsdir)
     except aexpect.ShellCmdError, e:
         for line in e.output.splitlines():
             logging.error(line)
         step_failures.append(step1)
+    vm_server.copy_files_from(guest_path="/tmp/install-autotest-server*log",
+                              host_path=test.resultsdir)
 
     top_commit = None
     try:


### PR DESCRIPTION
#### autotest_regression: Too few arguments for format string

Fix TypeError: not enough arguments for format string
Found by PyCharm inspection.
#### autotest_regression: replace error.ValueError with ValueError

I think we mean ValueError here, I couldn't find any error.ValueError.
#### autotest_regression: move copy of install-autotest-server*log outside try/except

We need the install log file to debug any error, so move it outside the
try/except, otherwise any errors will trigger aexpect.ShellCmdError and
skip the copy
