### PR TITLE
libvirt: Add 'EDITOR' configuration in control

### DIFF
--- a/libvirt/control
+++ b/libvirt/control
@@ -22,6 +22,8 @@ from virttest import utils_misc, cartesian_config
 
 # set English environment (command output might be localized, need to be safe)
 os.environ['LANG'] = 'en_US.UTF-8'
+# set editor environment (some command will use default editor "vi")
+os.environ['EDITOR'] = 'vi'
 
 libvirt_test_dir = os.path.join(os.environ['AUTODIR'],'tests/virt/libvirt')
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -35,7 +35,6 @@ def run_virsh_edit(test, params, env):
         """
         session = aexpect.ShellSession("sudo -s")
         try:
-            session.sendline("export EDITOR=vi")
             session.sendline("virsh edit %s" % source)
             session.sendline(edit_cmd)
             session.send('\x1b')


### PR DESCRIPTION
Some commands will use OS default editor, if editor is changed to other, command may fail, so set it to "vi" defaultly when you start testing.
