### PR TITLE
 qemu.tests.multi_nics_verify: Mofidy the method of get guest nics count

### DIFF
--- a/qemu/tests/multi_nics_verify.py
+++ b/qemu/tests/multi_nics_verify.py
@@ -1,6 +1,6 @@
-import os, logging, re
+import os, logging
 from autotest.client.shared import error
-from virttest import utils_test
+from virttest import utils_test, utils_net
 
 
 @error.context_aware
@@ -20,29 +20,13 @@ def run_multi_nics_verify(test, params, env):
     @param params: Dictionary with the test parameters
     @param env: Dictionary with test environment.
     """
-    # A helper function for getting NICs counts from ifconfig output of guest
-    def get_nics_list(session):
-        s, o = session.get_command_status_output("ifconfig")
-        if s != 0:
-            raise error.TestError("Running command 'ifconfig' failed in guest"
-                                  " with output %s" % o)
-
-        logging.debug("The ifconfig ouput from guest is:\n%s" % o)
-
-        nics_list = re.findall(r'eth(\d+)\s+Link', o, re.M)
-        logging.info("NICs list: %s" % nics_list)
-
-        return nics_list
-
-
-    # A helper function for checking NICs number
     def check_nics_num(expect_c, session):
         txt = "Check whether guest NICs info match with params setting."
         error.context(txt, logging.info)
-        nics_list = get_nics_list(session)
+        nics_list = utils_net.get_linux_ifname(session)
         actual_c = len(nics_list)
-        msg = "Expect NICs nums are: %d\nPractical NICs nums are: %d\n" % \
-                                                       (expect_c, actual_c)
+        msg = "Expect NICs nums are: %d\n" % expect_c
+        msg += "Practical NICs nums are: %d\n" % actual_c
 
         if not expect_c == actual_c:
             msg += "Nics count mismatch!\n"
@@ -65,20 +49,21 @@ def run_multi_nics_verify(test, params, env):
     logging.debug(check_nics_num(nics_num, session)[1])
     txt = "Create configure file for every NIC interface in guest."
     error.context(txt, logging.info)
-    ifcfg_prefix = "/etc/sysconfig/network-scripts/ifcfg-eth"
-    for num in range(nics_num):
-        eth_config_path = "".join([ifcfg_prefix, str(num)])
+    ifname_list = utils_net.get_linux_ifname(session)
+    ifcfg_path = "/etc/sysconfig/network-scripts/ifcfg-%s"
+    for ifname in ifname_list:
+        eth_config_path = ifcfg_path % ifname
 
-        eth_config = """DEVICE=eth%s
+        eth_config = """DEVICE=%s
 BOOTPROTO=dhcp
 ONBOOT=yes
-""" % num
+""" % ifname
 
         cmd = "echo '%s' > %s" % (eth_config, eth_config_path)
         s, o = session.get_command_status_output(cmd)
         if s != 0:
-            raise error.TestError("Failed to create ether config file: %s\n"
-                                  "Reason is: %s" % (eth_config_path, o))
+            err_msg = "Failed to create ether config file: %s\nReason is: %s"
+            raise error.TestError(err_msg % (eth_config_path, o))
 
     # Reboot and check the configurations.
     new_session = vm.reboot(session)


### PR DESCRIPTION
The output of ifconfig is different between different os,
so some time the regex can not get the nics number in the guest.
This patch try to fix this issue

this patch depend on : https://github.com/autotest/virt-test/pull/686
Signed-off-by: Yunping Zheng yunzheng@redhat.com
