### PR TITLE
disable qemu-iotest for some image format on RHEL host

### DIFF
--- a/qemu/tests/cfg/qemu_iotests.cfg
+++ b/qemu/tests/cfg/qemu_iotests.cfg
@@ -13,14 +13,19 @@
         - raw_format:
             qemu_io_image_format = raw
         - qcow_format:
+            no Host_RHEL
             qemu_io_image_format = qcow
         - qcow2_format:
             qemu_io_image_format = qcow2
         - qed_format:
+            no Host_RHEL
             qemu_io_image_format = qed
         - vdi_format:
+            no Host_RHEL
             qemu_io_image_format = vdi
         - vpc_format:
+            no Host_RHEL
             qemu_io_image_format = vpc
         - vmdk_format:
+            no Host_RHEL
             qemu_io_image_format = vmdk


### PR DESCRIPTION
Only qcow2 and raw format is support by qemu-kvm in RHEL host, so exclude qemu-io testing on unsupported image format for RHEL host;
