### PR TITLE
virt: Modify test-example for machine type

### DIFF
--- a/libvirt/cfg/tests-example.cfg
+++ b/libvirt/cfg/tests-example.cfg
@@ -19,6 +19,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.17.x86_64
+        no q35
         only unattended_install.cdrom.extra_cdrom_ks, boot, reboot, shutdown, remove_guest.with_disk
 
 
@@ -37,6 +38,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.17.x86_64
+        no q35
         only unattended_install.cdrom.http_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, f17 64 as a 64 bit HVM (full virt) guest OS,
@@ -56,6 +58,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.17.x86_64
+        no q35
         only unattended_install.cdrom.in_cdrom_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, RHEL 6.0 64 bit guest OS, install, boot, shutdown
@@ -71,6 +74,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only RHEL.6.0.x86_64
+        no q35
         only unattended_install.cdrom.extra_cdrom_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     - @libvirt_windows:
@@ -90,6 +94,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Win7.x86_64.sp1
+        no q35
         only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
 
 # Choose your test list from the testsets defined

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -1,12 +1,12 @@
 # Variants describing the various machines
 
 variants:
-     - @i440fx:
-          only i386, x86_64
-          machine_type = pc
+    - @i440fx:
+        only i386, x86_64
+        machine_type = pc
     - q35:
         only i386, x86_64
         machine_type = q35
-     - @pseries:
-          only ppc64
-          machine_type = pseries
+    - @pseries:
+        only ppc64
+        machine_type = pseries


### PR DESCRIPTION
Since machine_type 'q35' has been added to machine.cfg.If I do not change tests.cfg, when I execute libvirt a test case , I will get two:

``` javascript
16:36:04 INFO | Test    1:  qcow2.virtio_blk.smp2.virtio_net.RHEL.6.0.x86_64.virsh_help.normal_test
16:36:04 INFO | Test    2:  qcow2.virtio_blk.smp2.virtio_net.RHEL.6.0.x86_64.q35.virsh_help.normal_test
```

So I think perhaps tests-example.cfg need a modification that show users how to run one case.
