### PR TITLE
libvirt: Fix a bug in virsh_change_media test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -1,14 +1,15 @@
 - virsh_change_media:
+    virt_test_type = libvirt
     type = virsh_change_media
-    old_iso = "change_media_old.iso"
-    new_iso = "change_media_new.iso"
-    update_iso_xml = "update_iso.xml"
-    disk_device = "hdc"
-    vm_ref = "name"
-    init_cdrom = "''"
+    change_media_update_iso_xml = "update_iso.xml"
+    change_media_disk_device = "hdc"
+    change_media_vm_ref = "name"
+    change_media_init_cdrom = "''"
+    change_media_old_iso = "change_media_old.iso"
+    change_media_new_iso = "change_media_new.iso"
     libvirtd = "on"
-    init_iso = "change_media_old.iso"
     change_media_source =
+    change_media_init_iso = "change_media_old.iso"
     variants:
         - positive_test:
             status_error = "no"
@@ -21,52 +22,52 @@
                 - options:
                     variants:
                         - none:
-                            options = " "
+                            change_media_options = " "
                         - current:
-                            options = "--current"
+                            change_media_options = "--current"
                         - live:
                             no shutoff_guest
-                            options = "--live"
+                            change_media_options = "--live"
                         - force:
-                            options = "--force"
+                            change_media_options = "--force"
                         - config:
-                            options = "--config"
+                            change_media_options = "--config"
             variants:
                 - eject:
-                    action = "--eject "
-                    check_file =
+                    change_media_action = "--eject "
+                    change_media_check_file =
                 - insert:
                     change_media_source = "change_media_old.iso"
-                    action = "--insert "
-                    check_file = "old"
-                    init_iso =
+                    change_media_action = "--insert "
+                    change_media_check_file = "old"
+                    change_media_init_iso =
                 - update:
                     change_media_source = "change_media_new.iso"
-                    action = "--update "
-                    check_file = "new"
+                    change_media_action = "--update "
+                    change_media_check_file = "new"
         - negative_test:
             status_error = "yes"
             start_vm = "no"
-            options = "--current"
+            change_media_options = "--current"
             variants:
                 - no_option:
                     only insert
-                    options = " "
+                    change_media_options = " "
                 - no_name:
-                    vm_ref = " "
+                    change_media_vm_ref = " "
                 - unexpect_option:
-                    vm_ref = "\#"
+                    change_media_vm_ref = "\#"
                 - invalid_option:
-                    options = "--xyz"
+                    change_media_options = "--xyz"
                 - with_libvirtd_stop:
-                    requires_root = "yes"
+                    change_media_requires_root = "yes"
                     libvirtd = "off"
                 - shutoff_guest_with_live:
-                    options = "--live"
+                    change_media_options = "--live"
             variants:
                 - eject:
-                    action = "--eject "
+                    change_media_action = "--eject "
                 - insert:
-                    action = "--insert "
+                    change_media_action = "--insert "
                 - update:
-                    action = "--update "
+                    change_media_action = "--update "

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -1,4 +1,4 @@
-import logging, os, shutil
+import logging, os
 from autotest.client.shared import error, utils
 from virttest import virsh, utils_libvirtd
 from virttest.libvirt_xml import vm_xml
@@ -20,6 +20,9 @@ def run_virsh_change_media(test, params, env):
     def env_pre(old_iso, new_iso):
         """
         Prepare ISO image for test
+
+        @param: old_iso: sourse file for insert
+        @param: new_iso: sourse file for update
         """
         error.context("Preparing ISO images")
         utils.run("dd if=/dev/urandom of=%s/old bs=10M count=1" % cdrom_dir)
@@ -31,9 +34,10 @@ def run_virsh_change_media(test, params, env):
     def check_media(session, target_file, action):
         """
         Check guest cdrom files
-        1. guest session
-        2. the expected files
-        3. test case action
+
+        @param: session: guest session
+        @param: target_file: the expected files
+        @action: action: test case action
         """
         if action != "--eject ":
             error.context("Checking guest cdrom files")
@@ -49,26 +53,34 @@ def run_virsh_change_media(test, params, env):
     def add_cdrom_device(vm_name, init_cdrom):
         """
         Add cdrom device for test vm
+
+        @param: vm_name: guest name
+        @param: init_cdrom: source file
         """
         if vm.is_alive():
             virsh.destroy(vm_name)
 
         virsh.attach_disk(vm_name, init_cdrom,
-                          " hdc", " --type cdrom --sourcetype file --config",
+                          disk_device, " --type cdrom --sourcetype file --config",
                           debug=True)
 
-    def update_cdrom(vm_name, init_iso, options, start_vm ):
+    def update_cdrom(vm_name, init_iso, options, start_vm):
         """
         Update cdrom iso file for test case
+
+        @param: vm_name: guest name
+        @param: init_iso: source file
+        @param: options: update-device option
+        @param: start_vm: guest start flag
         """
         snippet = """
 <disk type='file' device='cdrom'>
 <driver name='qemu' type='raw'/>
 <source file='%s'/>
-<target dev='hdc' bus='ide'/>
+<target dev='%s' bus='ide'/>
 <readonly/>
 </disk>
-""" % (init_iso)
+""" % (init_iso, disk_device)
         update_iso_file = open(update_iso_xml, "w")
         update_iso_file.write(snippet)
         update_iso_file.close()
@@ -84,27 +96,31 @@ def run_virsh_change_media(test, params, env):
 
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
-    vm_ref = params.get("vm_ref")
-    action = params.get("action")
+    vm_ref = params.get("change_media_vm_ref")
+    action = params.get("change_media_action")
     start_vm = params.get("start_vm")
-    options = params.get("options")
+    options = params.get("change_media_options")
+    disk_device = params.get("change_media_disk_device")
+    libvirtd = params.get("libvirtd", "on")
+    source_name = params.get("change_media_source")
+    status_error =  params.get("status_error", "no")
+    check_file = params.get("change_media_check_file")
+    init_cdrom = params.get("change_media_init_cdrom")
+    update_iso_xml_name = params.get("change_media_update_iso_xml")
+    init_iso_name = params.get("change_media_init_iso")
+    old_iso_name = params.get("change_media_old_iso")
+    new_iso_name = params.get("change_media_new_iso")
     cdrom_dir = os.path.join(test.tmpdir, "tmp")
+
+    old_iso = os.path.join(cdrom_dir, old_iso_name)
+    new_iso = os.path.join(cdrom_dir, new_iso_name)
+    update_iso_xml = os.path.join(cdrom_dir, update_iso_xml_name)
     if not os.path.exists(cdrom_dir):
         os.mkdir(cdrom_dir)
-
-    old_iso_name = params.get("old_iso")
-    new_iso_name = params.get("new_iso")
-    old_iso = cdrom_dir + old_iso_name
-    new_iso = cdrom_dir + new_iso_name
-    init_cdrom = params.get("init_cdrom")
-    update_iso_xml_name = params.get("update_iso_xml")
-    update_iso_xml = cdrom_dir + update_iso_xml_name
-    init_iso_name = params.get("init_iso")
     if not init_iso_name :
         init_iso = ""
-
     else:
-        init_iso = cdrom_dir + init_iso_name
+        init_iso = os.path.join(cdrom_dir, init_iso_name)
 
     if vm_ref == "name":
         vm_ref = vm_name
@@ -113,7 +129,7 @@ def run_virsh_change_media(test, params, env):
     # Check domain's disk device
     disk_blk =  vm_xml.VMXML.get_disk_blk(vm_name)
     logging.info("disk_blk %s" % disk_blk)
-    if "hdc" not in  disk_blk:
+    if disk_device not in  disk_blk:
         logging.info("Adding cdrom device")
         add_cdrom_device(vm_name, init_cdrom)
 
@@ -126,33 +142,27 @@ def run_virsh_change_media(test, params, env):
         vm.start()
 
     update_cdrom(vm_name, init_iso, options, start_vm)
-    disk_device = params.get("disk_device")
-    libvirtd = params.get("libvirtd", "on")
 
     if libvirtd == "off":
         utils_libvirtd.libvirtd_stop()
 
-    source_name = params.get("change_media_source")
     # Libvirt will ignore --source when action is eject
     if action == "--eject ":
         source = ""
-
     else:
-        source = cdrom_dir + source_name
+        source = os.path.join(cdrom_dir, source_name)
 
     all_options = action + options + " " + source
     result = virsh.change_media(vm_ref, disk_device,
                                 all_options, ignore_status=True, debug=True)
     status = result.exit_status
-    status_error =  params.get("status_error", "no")
 
     if status_error == "no":
         if options == "--config" and vm.is_alive():
             vm.destroy()
-
-        vm.start()
+        if vm.is_dead():
+            vm.start()
         session = vm.wait_for_login()
-        check_file = params.get("check_file")
         check_media(session, check_file, action)
         session.close()
 
@@ -162,7 +172,6 @@ def run_virsh_change_media(test, params, env):
 
     # Clean the cdrom dir  and clean the cdrom device
     update_cdrom(vm_name, "", options, start_vm)
-    shutil.rmtree(cdrom_dir)
 
     # Check status_error
 


### PR DESCRIPTION
If vm is running, vm.start() will raise an exception.
