### PR TITLE
Fix ImportError in serivce.py

### DIFF
--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -20,8 +20,7 @@ import os
 import re
 import logging
 
-import common
-import error
+from autotest.client.shared import error
 from tempfile import mktemp
 from autotest.client import utils
 


### PR DESCRIPTION
Fix ImportError when import  "error" module and drop unused module 'common'
