### PR TITLE
virsh-schedinfo-qemu-posix: fix the cgroup path

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -1,4 +1,4 @@
-import re, logging
+import re, logging, os.path
 from autotest.client import cgroup_utils
 from autotest.client.shared import utils, error
 from virttest import virsh
@@ -37,8 +37,14 @@ def run_virsh_schedinfo_qemu_posix(test, params, env):
         except IndexError:
             return None
         if ctl_mount is not False:
-            get_value_cmd = "cat %s/%s/%s/%s" % (ctl_mount,
-                                 libvirt_cgroup_path, domname, parameter)
+            cgroup_path = os.path.join(ctl_mount, libvirt_cgroup_path,
+                                       domname, parameter)
+            if not os.path.exists(cgroup_path):
+                cgroup_path = os.path.join(ctl_mount, "machine", domname
+                                           + ".libvirt-qemu", parameter)
+            if not os.path.exists(cgroup_path):
+                raise error.TestNAError("Unknown path to cgroups")
+            get_value_cmd = "cat %s" % cgroup_path
             result = utils.run(get_value_cmd, ignore_status=True)
             return result.stdout.strip()
         else:


### PR DESCRIPTION
Libvirt has changed the path where cgroups are stored and therefore
the tests fails for newer libvirt because it cannot get the value
of cgroups. To fix this, we should check if the old path exists and
eventualy change the path to new one and for sure also check it.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
