### PR TITLE
qemu.test: changed test file localation in guest 

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -14,12 +14,13 @@
     force_create_image = no
     backup_image_before_testing = yes
     restore_image_before_testing = yes
-    tmp_file_name = /tmp/test.img
+    tmp_dir = /home
+    tmp_file_name = ${tmp_dir}/test.img
     file_create_cmd = "dd if=/dev/urandom of=%s bs=4k count=250"
     variants:
         - convert:
             type = qemu_disk_img_convert
-            guest_file_name = /tmp/test.img
+            guest_file_name = ${tmp_dir}/test.img
             variants:
                 - base_to_qcow2:
                     image_convert = "image1"
@@ -38,7 +39,7 @@
                     convert_format_sn1 = "qcow2"
         - commit:
             type = qemu_disk_img_commit
-            guest_file_name = /tmp/test.img
+            guest_file_name = ${tmp_dir}/test.img
             image_commit = "sn1"
             image_chain += " sn1"
             image_name_sn1 = "images/sn1"
@@ -47,23 +48,23 @@
             type = qemu_disk_img_rebase
             rebase_mode = safe
             base_format = qcow2
-            guest_file_name_image1 = "/tmp/base"
+            guest_file_name_image1 = "${tmp_dir}/base"
             image_chain += " snA snB"
             image_name_snA = "images/snA"
             image_name_snB = "images/snB"
-            guest_file_name_snA = "/tmp/snA"
-            guest_file_name_snB = "/tmp/snB"
+            guest_file_name_snA = "${tmp_dir}/snA"
+            guest_file_name_snB = "${tmp_dir}/snB"
             variants:
                 - snB:
-                    check_files = "/tmp/base /tmp/snA /tmp/snB"
+                    check_files = "${tmp_dir}/base ${tmp_dir}/snA ${tmp_dir}/snB"
                     variants:
                         - to_base:
                             rebase_list = "snB > image1"
                 - snC:
                     image_chain += " snC"
                     image_name_snC = "images/snC"
-                    guest_file_name_snC = "/tmp/snC"
-                    check_files = "/tmp/base /tmp/snA /tmp/snB /tmp/snC"
+                    guest_file_name_snC = "${tmp_dir}/snC"
+                    check_files = "${tmp_dir}/base ${tmp_dir}/snA ${tmp_dir}/snB ${tmp_dir}/snC"
                     variants:
                         - to_base:
                             rebase_list = "snC > image1"
@@ -82,9 +83,9 @@
                     image_chain += " snC snD"
                     image_name_snC = "images/snC"
                     image_name_snD = "images/snD"
-                    guest_file_name_snC = "/tmp/snC"
-                    guest_file_name_snD = "/tmp/snD"
-                    check_files = "/tmp/base /tmp/snA /tmp/snB /tmp/snC /tmp/snD"
+                    guest_file_name_snC = "${tmp_dir}/snC"
+                    guest_file_name_snD = "${tmp_dir}/snD"
+                    check_files = "${tmp_dir}/base ${tmp_dir}/snA ${tmp_dir}/snB ${tmp_dir}/snC ${tmp_dir}/snD"
                     variants:
                         - to_snB_snA_base:
                             rebase_list = "snD > snB; snD > snA; snD > image1"


### PR DESCRIPTION
"/tmp" is mounted as tmpfs in some guest(eg, ubuntu), files under /tmp will lost  after guest reboot and it will caused test failed;  So changed test file location from /tmp to /home in configure;

Signed-off-by: Xu Tian xutian@redhat.com
