### PR TITLE
Disable the serail number check in low verson Windows guest

### DIFF
--- a/shared/cfg/guest-os/Windows/Win2000.cfg
+++ b/shared/cfg/guest-os/Windows/Win2000.cfg
@@ -5,3 +5,5 @@
     os_variant = win2k
     image_name = images/win2000-32
     kill_vm_gracefully = no
+    physical_resources_check:
+        catch_serial_cmd =

--- a/shared/cfg/guest-os/Windows/Win2003.cfg
+++ b/shared/cfg/guest-os/Windows/Win2003.cfg
@@ -13,3 +13,5 @@
     whql_env_setup:
         mem = 2048
         update_cmd = cmd /c D:\whql\WUInstall.exe /install /criteria "IsHidden=0 and IsInstalled=0 and IsAssigned=1"
+    physical_resources_check:
+        catch_serial_cmd =

--- a/shared/cfg/guest-os/Windows/Win2008.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008.cfg
@@ -12,3 +12,5 @@
         disk_driver_install =  ""
     whql_env_setup.nic_device:
         nic_model_nic1 = e1000
+    physical_resources_check:
+        catch_serial_cmd =

--- a/shared/cfg/guest-os/Windows/Win7.cfg
+++ b/shared/cfg/guest-os/Windows/Win7.cfg
@@ -17,3 +17,5 @@
         disk_driver_install = ""
     whql_env_setup.nic_device:
         nic_model_nic1 = e1000
+    physical_resources_check:
+        catch_serial_cmd =

--- a/shared/cfg/guest-os/Windows/WinVista.cfg
+++ b/shared/cfg/guest-os/Windows/WinVista.cfg
@@ -5,3 +5,5 @@
         desc_path_desc1 = $\WDK\Logo Type\Device Logo\Vista Client\Device Premium
         desc_path_desc2 = $\WDK\Logo Type\Device Logo\Vista Client\Device Standard
         desc_path_desc3 = $\WDK\Logo Type\Device Logo\Vista Client
+    physical_resources_check:
+        catch_serial_cmd =

--- a/shared/cfg/guest-os/Windows/WinXP.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP.cfg
@@ -9,3 +9,5 @@
         s4_log_chk_cmd = 'echo "Since WinXP does not record ACPI event, Do nothing"'
     live_snapshot_chain.update:
         post_snapshot_cmd = {shell:cmd /c D:\wua_update.exe && cmd /c net stop wuauserv && cmd /c net start wuauserv && D:\whql\WUInstall.exe /install}
+    physical_resources_check:
+        catch_serial_cmd =


### PR DESCRIPTION
This patch is a following patch for:
https://github.com/autotest/virt-test/pull/697
