### PR TITLE
Fix md5sum paramter name conflict

### DIFF
--- a/qemu/tests/block_stream_stress.py
+++ b/qemu/tests/block_stream_stress.py
@@ -28,7 +28,7 @@ class BlockStreamStress(blk_stream.BlockStream):
             return True
         error.context("install stress app in guest", logging.info)
         link = params.get("download_link")
-        md5sum = params.get("md5sum")
+        md5sum = params.get("pkg_md5sum")
         tmp_dir = params.get("tmp_dir")
         install_cmd = params.get("install_cmd")
         config_cmd = params.get("config_cmd")

--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -57,7 +57,7 @@
         - with_stress:
             type = block_stream_stress
             download_link = http://weather.ou.edu/~apw/projects/stress/stress-1.0.4.tar.gz
-            md5sum = a607afa695a511765b40993a64c6e2f4
+            pkg_md5sum = a607afa695a511765b40993a64c6e2f4
             install_cmd = "tar -xzvf ${tmp_dir}/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install "
             config_cmd = ""
             app_check_cmd = "stress --help"

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -64,7 +64,7 @@
             variants:
                 - heavyload:
                     download_link = http://weather.ou.edu/~apw/projects/stress/stress-1.0.4.tar.gz
-                    md5sum = a607afa695a511765b40993a64c6e2f4
+                    pkg_md5sum = a607afa695a511765b40993a64c6e2f4
                     install_cmd = "tar -xzvf ${tmp_dir}/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install "
                     config_cmd = ""
                     app_check_cmd = "stress --help"
@@ -103,7 +103,7 @@
             type = drive_mirror_powerdown
             app_check_cmd = "test -d  ${tmp_dir}/linux-2.6.35.14"
             download_link = "https://www.kernel.org/pub/linux/kernel/v2.6/longterm/v2.6.35/linux-2.6.35.14.tar.gz"
-            md5sum = "15e4021ffcb47b93c218083e1f2734a7"
+            pkg_md5sum = "15e4021ffcb47b93c218083e1f2734a7"
             install_cmd = "tar xzvf ${tmp_dir}/linux-2.6.35.14.tar.gz -C ${tmp_dir}/"
             config_cmd = "cd ${tmp_dir}/linux-2.6.35.14 && make defconfig"
             start_cmd = "cd ${tmp_dir}/linux-2.6.35.14 && make clean && make -j `grep processor /proc/cpuinfo|wc -l` && make modules"

--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -10,7 +10,7 @@
     start_vm = no
     image_size = 20G
     # md5sum binary path
-    md5sum = "md5sum"
+    md5sum_bin = "md5sum"
     force_create_image = no
     backup_image_before_testing = yes
     restore_image_before_testing = yes

--- a/qemu/tests/drive_mirror_stress.py
+++ b/qemu/tests/drive_mirror_stress.py
@@ -17,7 +17,7 @@ class DriveMirrorStress(drive_mirror.DriveMirror):
             return True
         error.context("install stress app in guest", logging.info)
         link = params.get("download_link")
-        md5sum = params.get("md5sum")
+        md5sum = params.get("pkg_md5sum")
         tmp_dir = params.get("tmp_dir")
         install_cmd = params.get("install_cmd")
         config_cmd = params.get("config_cmd")

--- a/qemu/tests/qemu_disk_img.py
+++ b/qemu/tests/qemu_disk_img.py
@@ -77,7 +77,7 @@ class QemuImgTest(qemu_storage.QemuImg):
             return False
         login_timeout = int(self.params.get("login_timeout", 360))
         session = self.vm.wait_for_login(timeout=login_timeout)
-        md5bin = self.params["md5sum"]
+        md5bin = self.params["md5sum_bin"]
         cmd = "%s %s" % (md5bin, cmd)
         s, o = session.cmd_status_output(cmd)
         if s != 0:

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -278,7 +278,7 @@
         tmp_dir = "C:\"
         #if this link not available, please download from http://www.chrysocome.net/downloads/dd-0.5.zip
         download_link = "http://www.chrysocome.net/downloads/dd.exe"
-        md5sum = 168b73cc0f3d8c92c98c5028aec770df
+        pkg_md5sum = 168b73cc0f3d8c92c98c5028aec770df
         install_cmd = 'mkdir "C:\Program Files\dd" && copy /b %s\dd.exe "C:\Program Files\dd\"'
         config_cmd = 'setx path "%path%;C:\Program Files\dd" -m'
         app_check_cmd = "dd --list"
@@ -288,7 +288,7 @@
     drive_mirror.with_stress.heavyload, drive_mirror.with_powerdown, block_stream.with_stress:
         tmp_dir = "C:\"
         download_link = "http://www.jam-software.com/heavyload/HeavyLoadSetup.exe"
-        md5sum = 5bf187bd914ac8ce7f79361d7b56bc15
+        pkg_md5sum = 5bf187bd914ac8ce7f79361d7b56bc15
         install_cmd = 'start /wait %s\HeavyLoadSetup.exe /verysilent'
         config_cmd = 'setx path "%path%;C:\Program Files\JAM Software\HeavyLoad" -m'
         app_check_cmd = "heavyload"
@@ -296,7 +296,8 @@
         check_cmd = 'tasklist | findstr /I  "heavyload.exe"'
         stop_cmd = "taskkill /T /F /IM heavyload.exe"
     qemu_disk_img:
-        #md5sum =
+        # md5sum binary path, eg, c:\program\md5sum.exe
+        md5sum_bin = "md5sum"
         guest_file_name  = "c:\test.img"
         guest_file_name_image1  = "c:\test.img"
         guest_file_name_snA = "c:\sna.img"


### PR DESCRIPTION
Parameter 'md5sum'  will over write ISO file md5sum parameter, so if we re-create vm in test script, will raise HASH mismatch error; this commit rename md5sum parameter  to  resolve this conflict;

Thanks,
Xu
