### PR TITLE
 virt.tests.nicdriver_unload : modify the file transfer method

### DIFF
--- a/tests/cfg/nicdriver_unload.cfg
+++ b/tests/cfg/nicdriver_unload.cfg
@@ -2,7 +2,6 @@
     virt_test_type = qemu libvirt
     only Linux
     type = nicdriver_unload
-    filesize = 100
-    transfer_timeout = 100
-    transfer_type = remote
-    sessions_num = 10
+    filesize = 512
+    transfer_timeout = 1000
+    sessions_num = 5

--- a/tests/nicdriver_unload.py
+++ b/tests/nicdriver_unload.py
@@ -1,8 +1,7 @@
-import logging, os, time
+import logging, os, time, random
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_test, utils_net
-
+from virttest import utils_misc, utils_net, aexpect, data_dir
 
 @error.context_aware
 def run_nicdriver_unload(test, params, env):
@@ -19,51 +18,138 @@ def run_nicdriver_unload(test, params, env):
     @param params: Dictionary with the test parameters.
     @param env: Dictionary with test environment.
     """
+    def send_cmd_safe(session, cmd, timeout=60):
+        logging.debug("Sending command: %s", cmd)
+        session.sendline(cmd)
+        output = ""
+        start_time = time.time()
+        # Wait for shell prompt until timeout.
+        while (time.time() - start_time) < timeout:
+            session.sendline()
+            try:
+                output += session.read_up_to_prompt(0.5)
+                break
+            except aexpect.ExpectTimeoutError:
+                pass
+        return output
 
+
+    def all_threads_done(threads):
+        for thread in threads:
+            if thread.isAlive():
+                return False
+            else:
+                continue
+        return True
+
+
+    def all_threads_alive(threads):
+        for thread in threads:
+            if not thread.isAlive():
+                return False
+            else:
+                continue
+        return True
 
     timeout = int(params.get("login_timeout", 360))
+    transfer_timeout = int(params.get("transfer_timeout", 1000))
+    filesize = int(params.get("filesize", 512))
+
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-    session_serial = vm.wait_for_serial_login(timeout=timeout)
+    session = vm.wait_for_login(timeout=timeout)
 
+    error.base_context("Test env prepare")
     error.context("Get NIC interface name in guest.", logging.info)
-    ethname = utils_net.get_linux_ifname(session_serial,
-                                               vm.get_mac_address(0))
-
+    ethname = utils_net.get_linux_ifname(session, vm.get_mac_address(0))
     # get ethernet driver from '/sys' directory.
     # ethtool can do the same thing and doesn't care about os type.
     # if we make sure all guests have ethtool, we can make a change here.
     sys_path = params.get("sys_path") % (ethname)
-
     # readlink in RHEL4.8 doesn't have '-e' param, should use '-f' in RHEL4.8.
     readlink_cmd = params.get("readlink_command", "readlink -e")
-    driver = os.path.basename(session_serial.cmd("%s %s" % (readlink_cmd,
-                                                 sys_path)).strip())
+    driver = os.path.basename(session.cmd("%s %s" % (readlink_cmd,
+                                          sys_path)).strip())
+    logging.info("The guest interface %s using driver %s" % (ethname, driver))
 
-    logging.info("driver is %s", driver)
+    error.context("Host test file prepare, create %dMB file on host" %
+                  filesize, logging.info)
+    tmp_dir = data_dir.get_tmp_dir()
+    host_path = os.path.join(tmp_dir, "host_file_%s" %
+                              utils_misc.generate_random_string(8))
+    guest_path = os.path.join("/home", "guest_file_%s" %
+                              utils_misc.generate_random_string(8))
+    cmd = "dd if=/dev/zero of=%s bs=1M count=%d" % (host_path, filesize)
+    utils.run(cmd)
+    file_checksum = utils.hash_file(host_path, "md5")
 
+    error.context("Guest test file prepare, Copy file %s from host to guest"
+                  % host_path, logging.info)
+    vm.copy_files_to(host_path, guest_path, timeout=transfer_timeout)
+    if session.cmd_status("md5sum %s | grep %s" %
+                          (guest_path, file_checksum)):
+        raise error.TestNAError("File MD5SUMs changed after copy to guest")
+    logging.info("Test env prepare successfully")
+
+    error.base_context("Nic driver load/unload testing", logging.info)
+    session_serial = vm.wait_for_serial_login(timeout=timeout)
     try:
+        error.context("Transfer file between host and guest", logging.info)
         threads = []
-        for i in range(int(params.get("sessions_num", "10"))):
-            txt = "File transfer on test interface. Thread %s" % i
-            error.context(txt, logging.info)
-            thread = utils.InterruptedThread(utils_test.run_file_transfer,
-                                             (test, params, env))
-            thread.start()
-            threads.append(thread)
+        file_paths = []
+        host_file_paths = []
+        for sess_index in range(int(params.get("sessions_num", "10"))):
+            sess_path = os.path.join("/home","dst-%s" % sess_index)
+            host_sess_path = os.path.join(tmp_dir,"dst-%s" % sess_index)
 
-        time.sleep(10)
-        logging.info("Repeatedly unload/load NIC driver during file transfer.")
-        while threads[0].isAlive():
-            session_serial.cmd("sleep 10")
-            error.context("Shutdown the driver for NIC interface.", logging.info)
-            session_serial.cmd("ifconfig %s down" % ethname)
+            thread1 = utils.InterruptedThread(vm.copy_files_to,
+                                             (host_path, sess_path),
+                                             {"timeout":transfer_timeout})
+
+            thread2 = utils.InterruptedThread(vm.copy_files_from,
+                                             (guest_path, host_sess_path),
+                                             {"timeout":transfer_timeout})
+            thread1.start()
+            threads.append(thread1)
+            thread2.start()
+            threads.append(thread2)
+            file_paths.append(sess_path)
+            host_file_paths.append(host_sess_path)
+
+        utils_misc.wait_for(lambda: all_threads_alive(threads), 60, 10, 1)
+
+        time.sleep(5)
+        error.context("Repeatedly unload/load NIC driver during file transfer",
+                      logging.info)
+        while not all_threads_done(threads):
+            error.context("Shutdown the driver for NIC interface.",
+                          logging.info)
+            send_cmd_safe(session_serial, "ifconfig %s down" % ethname)
             error.context("Unload  NIC driver.", logging.info)
-            session_serial.cmd("modprobe -r %s" % driver)
+            send_cmd_safe(session_serial, "modprobe -r %s" % driver)
             error.context("Load NIC driver.", logging.info)
-            session_serial.cmd("modprobe %s" % driver)
+            send_cmd_safe(session_serial, "modprobe %s" % driver)
             error.context("Activate NIC driver.", logging.info)
-            session_serial.cmd("ifconfig %s up" % ethname)
+            send_cmd_safe(session_serial, "ifconfig %s up" % ethname)
+            send_cmd_safe(session_serial, "sleep %s" %
+                          random.randint(10, 60))
+        #files md5sums check
+        error.context("File transfer finished, checking files md5sums",
+                      logging.info)
+        err_info = []
+        for copied_file in file_paths:
+            if session_serial.cmd_status("md5sum %s | grep %s" %
+                                         (copied_file, file_checksum)):
+                err_msg = "Guest file %s md5sum changed"
+                err_info.append(err_msg % copied_file)
+        for copied_file in host_file_paths:
+            if utils.system("md5sum %s | grep %s" %
+                            (copied_file, file_checksum)):
+                err_msg = "Host file %s md5sum changed"
+                err_info.append(err_msg % copied_file)
+        if err_info:
+            raise error.TestError("files MD5SUMs changed after copying %s" %
+                                  err_info)
     except Exception:
         for thread in threads:
             thread.join(suppress_exception=True)
@@ -71,3 +157,11 @@ def run_nicdriver_unload(test, params, env):
     else:
         for thread in threads:
             thread.join()
+        for copied_file in file_paths:
+            session_serial.cmd("rm -rf %s" % copied_file)
+        for copied_file in host_file_paths:
+            utils.system("rm -rf %s" % copied_file)
+        session_serial.cmd("%s %s" % ("rm -rf", guest_path))
+        os.remove(host_path)
+        session.close()
+        session_serial.close()


### PR DESCRIPTION
Now this script use utils_test.run_file_transfer to do file transfer,
unfortunately this method is not suitable for this test, because the guest
nic is repeatedly down/up during test, some times the guest will try to ssh
the host when the nic is down, this will cause error like no route.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
