### PR TITLE
libvirt: Add 2 new test cases for virsh change-media

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -55,6 +55,15 @@
                     change_media_options = " "
                 - no_name:
                     change_media_vm_ref = " "
+                - no_source_path_running:
+                    change_media_source_path = "no"
+                    change_media_source = "change_media_old.iso"
+                    change_media_init_iso =
+                    start_vm = yes
+                - no_source_path_shutoff:
+                    change_media_source_path = "no"
+                    change_media_source = "change_media_old.iso"
+                    change_media_init_iso =
                 - unexpect_option:
                     change_media_vm_ref = "\#"
                 - invalid_option:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -110,6 +110,7 @@ def run_virsh_change_media(test, params, env):
     init_iso_name = params.get("change_media_init_iso")
     old_iso_name = params.get("change_media_old_iso")
     new_iso_name = params.get("change_media_new_iso")
+    source_path = params.get("change_media_source_path", "yes")
     cdrom_dir = os.path.join(test.tmpdir, "tmp")
 
     old_iso = os.path.join(cdrom_dir, old_iso_name)
@@ -151,10 +152,20 @@ def run_virsh_change_media(test, params, env):
         source = ""
     else:
         source = os.path.join(cdrom_dir, source_name)
+        if source_path == "no":
+            source = source_name
 
     all_options = action + options + " " + source
     result = virsh.change_media(vm_ref, disk_device,
                                 all_options, ignore_status=True, debug=True)
+    if status_error == "yes":
+        if start_vm == "no" and vm.is_dead():
+            try:
+                vm.start()
+            except Exception, detail:
+                result.exit_status = 1
+                result.stderr = str(detail)
+
     status = result.exit_status
 
     if status_error == "no":


### PR DESCRIPTION
1.When a guest is shutoff, user can insert/update a source file
without source path, but the guest cannot be started
2.When a guest is started, user cannot insert/update a source file
 without source path.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
