### PR TITLE
live_snapshot code cleanup

### DIFF
--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -3,9 +3,8 @@
     type = live_snapshot
     no raw vmdk qed
     kill_vm = yes
-    create_sn_cmd = snapshot_blkdev
     create_cmd = "dd if=/dev/urandom of=%s bs=1M count=1024"
-    file_create = /tmp/file
+    file_create = /var/tmp/file
     clean_cmd = rm -f
     snapshot_name = live_snapshot_img
     variants:
@@ -20,7 +19,7 @@
             filesize = 2000
             transfer_timeout = 1200
             transfer_type = remote
-            tmp_dir = /tmp/
+            tmp_dir = /var/tmp/
         - base:
             type = live_snapshot_base
             backup_image_before_testing = yes


### PR DESCRIPTION
Use live_snapshot function in framework to instead some duplicate code and drop utils_misc module since it imported but not used really; update tmp dir in test configuration to avoid file lost after reboot when tmp used tmpfs;

Thanks,
Xu  
