### PR TITLE
Bridge fd

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -548,7 +548,7 @@ class PrivateBridgeConfig(object):
         ip_fwd = open(ip_fwd_path, "w")
         ip_fwd.write("1\n")
         utils.system("brctl stp %s on" % self.brname)
-        utils.system("brctl setfd %s 0" % self.brname)
+        utils.system("brctl setfd %s 4" % self.brname)
         if self.physical_nic:
             utils.system("brctl addif %s %s" % (self.brname,
                                                 self.physical_nic))


### PR DESCRIPTION
  Currently our script set bridge forward to 0, it cann't work
    in some os. checking bridge doc 802.1D-1998 and latest
    802.1D-2004, in these docs Bridege Forward Delay range time
    is 4.0-30.0 seconds. so modify the value to 4
