### PR TITLE
 tests.cfg.netperf.cfg : Make test support different types of network apapters

### DIFF
--- a/tests/cfg/netperf.cfg
+++ b/tests/cfg/netperf.cfg
@@ -2,7 +2,6 @@
     virt_test_type = qemu libvirt
     no JeOS
     only Linux
-    only virtio_net
     type = netperf
     kill_vm = yes
     image_snapshot = yes
@@ -11,6 +10,7 @@
     netdst_nic1 = private
     nic_model_nic1 = virtio
     netdst_nic2 = switch
+    #Configure different types of network adapters.
     nic_model_nic2 = e1000
     netperf_files = netperf-2.6.0.tar.bz2
     setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --enable-burst --enable-demo=yes && make"


### PR DESCRIPTION
Remove the limit of virtio_net, make the test support different types of
network adapters like e1000 and rtl8139

Signed-off-by: Yunping Zheng yunzheng@redhat.com
