### PR TITLE
libvirt-virsh: Remove SESSION_COUNTER from VirshPersistent.

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -271,9 +271,6 @@ class VirshPersistent(Virsh):
 
     __slots__ = Virsh.__slots__ + ('session_id', )
 
-    # Help detect leftover sessions
-    SESSION_COUNTER = 0
-
     # B/c the auto_close of VirshSession is False, we
     # need to manager the ref-count of it manully.
     COUNTERS = {}
@@ -340,9 +337,7 @@ class VirshPersistent(Virsh):
                 try:
                     existing = VirshSession(a_id=session_id)
                     if existing.is_alive():
-                        if self.counter_decrease():
-                            # Keep count
-                            self.__class__.SESSION_COUNTER -= 1
+                        self.counter_decrease()
                 except aexpect.ShellStatusError:
                     # session was already closed
                     pass # don't check is_alive or update counter
@@ -361,8 +356,6 @@ class VirshPersistent(Virsh):
         self.close_session()
         # Always create new session
         new_session = VirshSession(virsh_exec, uri, a_id=None)
-        # Keep count
-        self.__class__.SESSION_COUNTER += 1
         session_id = new_session.get_id()
         self.dict_set('session_id', session_id)
 
@@ -410,8 +403,6 @@ class VirshConnectBack(VirshPersistent):
                                    remote_ip=remote_ip,
                                    remote_user=remote_user,
                                    remote_pwd=remote_pwd)
-        # Keep count
-        self.__class__.SESSION_COUNTER += 1
         session_id = new_session.get_id()
         self.dict_set('session_id', session_id)
 

--- a/virttest/virsh_unittest.py
+++ b/virttest/virsh_unittest.py
@@ -148,9 +148,7 @@ class ConstructorsTest(ModuleLoad):
         else:
             logging.disable(logging.INFO)
             vp = self.virsh.VirshPersistent()
-            self.assertEqual(self.virsh.VirshPersistent.SESSION_COUNTER, 1)
             vp.close_session() # Make sure session gets cleaned up
-            self.assertEqual(self.virsh.VirshPersistent.SESSION_COUNTER, 0)
 
 
     def TestVirshClosure(self):
@@ -295,9 +293,7 @@ class VirshPersistentClassHasHelpCommandTest(VirshHasHelpCommandTest):
         logging.disable(logging.INFO)
         super(VirshPersistentClassHasHelpCommandTest, self).setUp()
         self.VirshPersistent = self.virsh.VirshPersistent
-        self.assertEqual(self.VirshPersistent.SESSION_COUNTER, 0)
         self.virsh = self.VirshPersistent(debug=False)
-        self.assertEqual(self.VirshPersistent.SESSION_COUNTER, 1)
         self.assertTrue(utils.process_is_alive(self.virsh.virsh_exec))
 
 
@@ -308,10 +304,8 @@ class VirshPersistentClassHasHelpCommandTest(VirshHasHelpCommandTest):
 
 
     def tearDown(self):
-        self.assertEqual(self.VirshPersistent.SESSION_COUNTER, 1)
         self.assertTrue(utils.process_is_alive(self.virsh.virsh_exec))
         self.virsh.close_session()
-        self.assertEqual(self.VirshPersistent.SESSION_COUNTER, 0)
         self.assertFalse(utils.process_is_alive(self.virsh.virsh_exec))
 
 


### PR DESCRIPTION
As we use COUNTERS to manager VirshSession in VirshPersistent.
SESSION_COUNTER is no needed any more.
- remove SESSION_COUNTER from VirshPersistent.
- update virsh_unittest related with SESSION_COUNTER.

Signed-off-by: yangdongsheng yangds.fnst@cn.fujitsu.com
