### PR TITLE
virttest.qemu_devices: Set port of the last usb device 

### DIFF
--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -1148,6 +1148,7 @@ class QUSBBus(QSparseBus):
         super(QUSBBus, self).__init__('bus', [['port'], [length + 1]], busid,
                                       bus_type, aobject)
         self.__port_prefix = port_prefix
+        self.__length = length
 
     def _set_first_addr(self, addr_pattern):
         """ First addr is not 0 but 1 """
@@ -1214,6 +1215,9 @@ class QUSBBus(QSparseBus):
                 addr = ['%s.%s' % (self.__port_prefix, addr[0])]
         self.__hook_child_bus(device, addr)
         device['bus'] = True    # Force bus item to be updated
+        if addr[0] == self.__length:
+            # Force port on the last device, otherwise qemu adds usb-hub
+            device['port'] = True
         super(QUSBBus, self)._update_device_props(device, addr)
 
 


### PR DESCRIPTION
When last device should be appended to usb bus, qemu automatically add usb-hub to keep free ports for additional devices. We don't want this in autotest as all tests use strict amount of usb buses. By enforcing the last item's port we avoid this behavior.
