### PR TITLE
Remove "no 486" line from qemu_cpu.cfg

### DIFF
--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -114,8 +114,6 @@
             no (qemu_flavor = unknown)
         # CPUID data tests:
         - cpuid:
-            # 486 is excluded due to not supporting cpuid
-            no 486
             variants:
                 - full_dump:
                     # machine types:


### PR DESCRIPTION
I don't know why 486 was being excluded, as the CPUID instruction really works, and QEMU has CPUID data being set for 486, too. The tests keep working after removing the "no 486" line from the config file.
