### PR TITLE
Fix some small bugs in multi_disk test

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -58,7 +58,7 @@
                     # We need to unload scsi_debug modules used by VM
                     kill_vm = yes
                     force_create_image = no
-                    pre_command = "modprobe scsi_debug && echo 9 > /sys/bus/pseudo/drivers/scsi_debug/add_host"
+                    pre_command = "modprobe -r scsi_debug; modprobe scsi_debug add_host=9"
                     post_command = "rmmod scsi_debug"
                     stg_params += "image_raw_device:yes "
                     stg_params += "image_format:raw "
@@ -67,6 +67,7 @@
                         - block:
                             stg_params += "image_name:/dev/sd* "
                         - generic:
+                            stg_params += "drive_cache:writethrough "
                             stg_params += "drive_format:scsi-generic "
                             stg_params += "image_name:/dev/sg* "
                 - multi_lun:

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -5,7 +5,7 @@ multi_disk test for Autotest framework.
 """
 import logging, re, random, string
 from autotest.client.shared import error, utils
-from virttest import qemu_qtree, env_process, qemu_monitor
+from virttest import qemu_qtree, env_process
 
 _RE_RANGE1 = re.compile(r'range\([ ]*([-]?\d+|n).*\)')
 _RE_RANGE2 = re.compile(r',[ ]*([-]?\d+|n)')
@@ -107,6 +107,7 @@ def run_multi_disk(test, params, env):
     stg_params += _add_param("image_format", params.get("stg_image_format"))
     stg_params += _add_param("image_boot", params.get("stg_image_boot", "no"))
     stg_params += _add_param("drive_format", params.get("stg_drive_format"))
+    stg_params += _add_param("drive_cache", params.get("stg_drive_cache"))
     if params.get("stg_assign_index") != "no":
         # Assume 0 and 1 are already occupied (hd0 and cdrom)
         stg_params += _add_param("drive_index", 'range(2,n)')


### PR DESCRIPTION
1). update pre_command: used scsi_debug parm to add_host instead write
sys filesystem to avoid device create delay issue;

2). fix passthrough scsi device cache to writethrough to avoid fail to
open /dev/sg\* when drive_cache=none; do this because /dev/sg\* is
emulated by scsI_debug module, backend of these device is memery, open
with O_DRIECT is not supported;

3). removed useless import module 'qemu_monitor'

Thanks,
Xu
