### PR TITLE
 virt.test.vlan : make the script support add/remove vlan by ip link

### DIFF
--- a/tests/cfg/vlan.cfg
+++ b/tests/cfg/vlan.cfg
@@ -13,3 +13,6 @@
     image_snapshot = yes
     kill_vm_vm2 = yes
     kill_vm_gracefully_vm2 = no
+    cmd_type = ip
+    RHEL.5:
+        cmd_type = vconfig


### PR DESCRIPTION
Now in some os only support add/remove vlan by 'ip link',
this patch make the script support them.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
