### PR TITLE
virttest.qemu_devices: Support for old qemu ide disks

### DIFF
--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -2541,7 +2541,9 @@ class DevContainer(object):
         devices[-1].set_param('serial', serial)
         devices[-1].set_param('x-data-plane', x_data_plane, bool)
         if fmt in ("ide", "ahci"):
-            if media == 'cdrom':
+            if not self.has_device('ide-hd'):
+                devices[-1].set_param('driver', 'ide-drive')
+            elif media == 'cdrom':
                 devices[-1].set_param('driver', 'ide-cd')
             else:
                 devices[-1].set_param('driver', 'ide-hd')


### PR DESCRIPTION
Older qemu versions (RHEL6) doesn't support ide-hd and ide-cd. Use ide-drive instead.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
