### PR TITLE
virttest.qemu_devices: Differentiate between qemu and autotest bus type

### DIFF
--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -2594,9 +2594,9 @@ class DevContainer(object):
                 scsi_hba = "virtio-scsi-pci"
             addr_spec = None
             if scsi_hba == 'lsi53c895a':
-                addr_spec = [['scsi-id', 'lun'], [8, 16384]]
+                addr_spec = [8, 16384]
             elif scsi_hba == 'virtio-scsi-pci':
-                addr_spec = [['scsi-id', 'lun'], [256, 16384]]
+                addr_spec = [256, 16384]
             _, bus, dev_parent = define_hbas('SCSI', scsi_hba, bus, unit, port,
                                               QSCSIBus, addr_spec)
             devices.extend(_)


### PR DESCRIPTION
This patchset changes the way bus type is handled in qemu_devices. This was required as qemu type is often shared between various kind of devices (eg. ide-hd uses IDE bus, which is common to ide and ahci HBA).

Additionally this patch fixes the problem, where device was added in qemu into first qemu-matching-bus, which wasn't autotest matching bus (ide disk was added into ahci bus). In case this should happened autotest sets the bus and full address of the device.

There is still an extra hack for ahci disks, because qemu handles them kind-of weird. I need to check with developer whether this is a bug or very nasty feature.

Kind regards,
Lukáš
