### PR TITLE
Add catch_serial_cmd for virtio_scsi and ide block device

### DIFF
--- a/qemu/tests/cfg/physical_resources_check.cfg
+++ b/qemu/tests/cfg/physical_resources_check.cfg
@@ -22,3 +22,6 @@
     virtio_blk:
         start_vm = no
         catch_serial_cmd = cat /sys/block/vda/serial; echo
+    virtio_scsi, ide, ahci:
+        start_vm = no
+        catch_serial_cmd = sginfo -s /dev/sda || hdparm -i /dev/hda


### PR DESCRIPTION
For scsi and sata disk we can get serial commands by sginfo -s /dev/sda, and for IDE disk we can ready it easy from hdparm -i /dev/hda;

thanks,
Xu
