### PR TITLE
virt: Fix ./run vhost params. 

### DIFF
--- a/run
+++ b/run
@@ -459,10 +459,10 @@ class VirtTestApp(object):
             if self.options.nettype == "bridge":
                 if self.options.vhost == "on":
                     self.cartesian_parser.assign("netdev_extra_params",
-                                                 '"vhost=on"')
+                                                 '",vhost=on"')
                 elif self.options.vhost == "force":
                     self.cartesian_parser.assign("netdev_extra_params",
-                                                 '"vhostforce=on"')
+                                                 '",vhostforce=on"')
             else:
                 if self.options.vhost in ["on", "force"]:
                     _restore_stdout()


### PR DESCRIPTION
run uses for setting vhost to network netdev_extra_params.
This param has to be used with ',' in-front of network param when
it is used for standard thinks. In future it should be replaced by
new vhost virt_net interface.
