### PR TITLE
virttest.qemu_devices: Add default value to drive_format

### DIFF
--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -2049,7 +2049,8 @@ class DevContainer(object):
                            == 'scsi')
             _scsi_without_device = (not self.has_option('device') and
                                     params.object_params(image_name)
-                                    .get('drive_format').startswith('scsi'))
+                                    .get('drive_format', 'virtio_blk')
+                                    .startswith('scsi'))
             if _is_oldscsi or _scsi_without_device:
                 i += 1
 
@@ -2058,7 +2059,8 @@ class DevContainer(object):
                            == 'scsi')
             _scsi_without_device = (not self.has_option('device') and
                                     params.object_params(image_name)
-                                    .get('cd_format').startswith('scsi'))
+                                    .get('cd_format', 'virtio_blk')
+                                    .startswith('scsi'))
             if _is_oldscsi or _scsi_without_device:
                 i += 1
 


### PR DESCRIPTION
Apperently drive_format doesn't have to be defined. Add default
value 'virtio_blk' to avoid using .startswith on a None object.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
