### PR TITLE
virttest.qemu_devices: Set 'serial' parameter only when qemu supports it

### DIFF
--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -1574,6 +1574,8 @@ class DevContainer(object):
         self.__devices = []
         self.__buses = []
         self.__qemu_binary = qemu_binary
+        self.__execute_qemu_last = None
+        self.__execute_qemu_out = ""
         self.allow_hotplugged_vm = allow_hotplugged_vm == 'yes'
 
     def __getitem__(self, item):
@@ -1831,9 +1833,12 @@ class DevContainer(object):
         :return: Output of the qemu
         :rtype: string
         """
-        return str(utils.run("%s %s 2>&1" % (self.__qemu_binary, options),
-                         timeout=timeout, ignore_status=True,
-                         verbose=False).stdout)
+        if self.__execute_qemu_last != options:
+            cmd = "%s %s 2>&1" % (self.__qemu_binary, options)
+            self.__execute_qemu_out = str(utils.run(cmd, timeout=timeout,
+                                                    ignore_status=True,
+                                                    verbose=False).stdout)
+        return self.__execute_qemu_out
 
     def get_buses(self, bus_spec):
         """


### PR DESCRIPTION
Hi guys,

older qemu version (RHEL6) doesn't support setting disk serial number using -device serial=xxx, which is now the preferred method. This pull request check what parameters are supported for the current device and than ignores the 'serial' parameter in case it's unsupported. It shouldn't affect the test as the serial number is set in -drive serial=xxx thus the drive will also have the correct serial number.

To be able to do this change I added another function to DevContainer, which executes the qemu command with some extra options.

Last but not least I added cashing of the last execution in order to speed-up some tests. If you don't like it, you can accept this pull request without it. But I believe it will save time as most devices are added in loops, so the last execution might be reused multiple times.
