### PR TITLE
virt: tools/run_pylint: output format option bug

### DIFF
--- a/tools/run_pylint.py
+++ b/tools/run_pylint.py
@@ -79,7 +79,16 @@ def get_pylint_opts():
         else:
             opts = disable_old
 
-    return opts + ['--reports=no', '--include-ids=y', '--rcfile=/dev/null', '--good-names=i,j,k,Run,_,vm']
+    opts += ['--reports=no', '--rcfile=/dev/null',
+             '--good-names=i,j,k,Run,_,vm']
+
+    if pylint_version < 1.0:
+        fmt_opt = '--include-ids=y'
+    else:
+        fmt_opt = '--msg-template="{msg_id}:{line:3d},{column}: {obj}: {msg}"'
+    opts.append(fmt_opt)
+
+    return opts
 
 
 def check_file(file_path):


### PR DESCRIPTION
Long story short, pylint 1.0 drops some options and adds new ones.
This patch checks the pylint version and adds the formatting option
accordingly.

Unfortunately, pylint's documentation is really broken. The default
message format template is documented as:

--msg-template='{sigle}:{line:3d},{column}: {obj}: {msg}'

But the 'sigle' parameter simply does not exist. This patch uses
'{msg_id}' istead.

One thing this patch does not solve, though, is the conditional
formatting for the '{obj}' parameter, so you may notice a white
space followed by ':' in some of the messages (the ones that lack
reference to an object).

CC: Chris Evich cevich@redhat.com
Signed-off-by: Cleber Rosa crosa@redhat.com
