### PR TITLE
Tests nic promisc avoid to close serial session

### DIFF
--- a/tests/nic_promisc.py
+++ b/tests/nic_promisc.py
@@ -69,7 +69,5 @@ def run_nic_promisc(test, params, env):
         raise
     else:
         transfer_thread.join()
-        if session_serial:
-            session_serial.close()
         if session:
             session.close()


### PR DESCRIPTION
Serial session should not be closed for it may be used in
next test cases. Also the serial is init when the machine
bootup, so the session not belong any test cases.

 If it was closed, next test case may
fail, in case of the guest hasn't shutdown after
the first test case. Becasue, close() function will close
the serial fifo file description, and remove that file.
The second test case also need to use serial, but it
try to open an un-exist fifo file.

That lead to the second case fail.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
