### PR TITLE
virt-libvirt: Add floppy test for virsh change-media

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -1,14 +1,12 @@
 - virsh.change_media:
     type = virsh_change_media
     change_media_update_iso_xml = "update_iso.xml"
-    change_media_disk_device = "hdc"
     change_media_vm_ref = "name"
-    change_media_init_cdrom = "''"
     change_media_old_iso = "change_media_old.iso"
     change_media_new_iso = "change_media_new.iso"
-    libvirtd = "on"
     change_media_source =
     change_media_init_iso = "change_media_old.iso"
+    kill_vm = yes
     variants:
         - positive_test:
             status_error = "no"
@@ -73,9 +71,6 @@
                     change_media_vm_ref = "\#"
                 - invalid_option:
                     change_media_options = "--xyz"
-                - with_libvirtd_stop:
-                    change_media_requires_root = "yes"
-                    libvirtd = "off"
                 - shutoff_guest_with_live:
                     change_media_options = "--live"
             variants:
@@ -85,3 +80,10 @@
                     change_media_action = "--insert "
                 - update:
                     change_media_action = "--update "
+    variants:
+        - cdrom_test:
+            change_media_device_type = "cdrom"
+            change_media_target_device = "hdc"
+        - floppy_test:
+            change_media_device_type = "floppy"
+            change_media_target_device = "fda"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -1,7 +1,8 @@
-import logging
 import os
+import shutil
+import logging
 from autotest.client.shared import error, utils
-from virttest import virsh, utils_libvirtd
+from virttest import virsh, data_dir, virt_vm
 from virttest.libvirt_xml import vm_xml
 
 
@@ -22,66 +23,77 @@ def run_virsh_change_media(test, params, env):
         """
         Prepare ISO image for test
 
-        :param old_iso: sourse file for insert
-        :param new_iso: sourse file for update
+        @param: old_iso: sourse file for insert
+        @param: new_iso: sourse file for update
         """
         error.context("Preparing ISO images")
-        utils.run("dd if=/dev/urandom of=%s/old bs=10M count=1" % cdrom_dir)
-        utils.run("dd if=/dev/urandom of=%s/new bs=10M count=1" % cdrom_dir)
-        utils.run("mkisofs -o %s %s/old" % (old_iso, cdrom_dir))
-        utils.run("mkisofs -o %s %s/new" % (new_iso, cdrom_dir))
+        utils.run("dd if=/dev/urandom of=%s/old bs=1M count=1" % iso_dir)
+        utils.run("dd if=/dev/urandom of=%s/new bs=1M count=1" % iso_dir)
+        utils.run("mkisofs -o %s %s/old" % (old_iso, iso_dir))
+        utils.run("mkisofs -o %s %s/new" % (new_iso, iso_dir))
 
     @error.context_aware
     def check_media(session, target_file, action):
         """
-        Check guest cdrom files
+        Check guest cdrom/floppy files
 
-        :param session: guest session
-        :param target_file: the expected files
+        @param: session: guest session
+        @param: target_file: the expected files
         @action: action: test case action
         """
         if action != "--eject ":
-            error.context("Checking guest cdrom files")
-            session.cmd("mount /dev/cdrom /media || mount /dev/cdrom /media")
+            error.context("Checking guest %s files" % target_device)
+            if target_device == "hdc":
+                mount_cmd = "mount /dev/cdrom /media"
+            else:
+                session.cmd("mknod /dev/fd0 b 2 0")
+                mount_cmd = "mount /dev/fd0 /media"
+            session.cmd(mount_cmd)
             session.cmd("test -f /media/%s" % target_file)
-            session.cmd("umount /dev/cdrom")
+            session.cmd("umount /media")
 
         else:
             error.context("Ejecting guest cdrom files")
-            if session.cmd_status("mount /dev/cdrom /media -o loop") == 32:
-                logging.info("Eject succeeded")
+            if target_device == "hdc":
+                if session.cmd_status("mount /dev/cdrom /media -o loop") == 32:
+                    logging.info("Eject succeeded")
+            else:
+                session.cmd("mknod /dev/fd0 b 2 0")
+                if session.cmd_status("mount /dev/fd0 /media -o loop") == 32:
+                    logging.info("Eject succeeded")
 
-    def add_cdrom_device(vm_name, init_cdrom):
+    def add_device(vm_name, init_source="''"):
         """
-        Add cdrom device for test vm
+        Add device for test vm
 
-        :param vm_name: guest name
-        :param init_cdrom: source file
+        @param: vm_name: guest name
+        @param: init_source: source file
         """
         if vm.is_alive():
             virsh.destroy(vm_name)
 
-        virsh.attach_disk(vm_name, init_cdrom,
-                          disk_device, " --type cdrom --sourcetype file --config",
+        virsh.attach_disk(vm_name, init_source,
+                          target_device,
+                          " --type %s --sourcetype file --config" % device_type,
                           debug=True)
 
-    def update_cdrom(vm_name, init_iso, options, start_vm):
+    def update_device(vm_name, init_iso, options, start_vm):
         """
-        Update cdrom iso file for test case
+        Update device iso file for test case
 
-        :param vm_name: guest name
-        :param init_iso: source file
-        :param options: update-device option
-        :param start_vm: guest start flag
+        @param: vm_name: guest name
+        @param: init_iso: source file
+        @param: options: update-device option
+        @param: start_vm: guest start flag
         """
         snippet = """
-<disk type='file' device='cdrom'>
+<disk type='file' device='%s'>
 <driver name='qemu' type='raw'/>
 <source file='%s'/>
-<target dev='%s' bus='ide'/>
+<target dev='%s'/>
 <readonly/>
 </disk>
-""" % (init_iso, disk_device)
+""" % (device_type, init_iso, target_device)
         update_iso_file = open(update_iso_xml, "w")
         update_iso_file.write(snippet)
         update_iso_file.close()
@@ -101,39 +113,41 @@ def run_virsh_change_media(test, params, env):
     action = params.get("change_media_action")
     start_vm = params.get("start_vm")
     options = params.get("change_media_options")
-    disk_device = params.get("change_media_disk_device")
-    libvirtd = params.get("libvirtd", "on")
+    device_type = params.get("change_media_device_type", "cdrom")
+    target_device = params.get("change_media_target_device", "hdc")
     source_name = params.get("change_media_source")
-    status_error = params.get("status_error", "no")
+    status_error =  params.get("status_error", "no")
     check_file = params.get("change_media_check_file")
-    init_cdrom = params.get("change_media_init_cdrom")
     update_iso_xml_name = params.get("change_media_update_iso_xml")
     init_iso_name = params.get("change_media_init_iso")
     old_iso_name = params.get("change_media_old_iso")
     new_iso_name = params.get("change_media_new_iso")
     source_path = params.get("change_media_source_path", "yes")
-    cdrom_dir = os.path.join(test.tmpdir, "tmp")
 
-    old_iso = os.path.join(cdrom_dir, old_iso_name)
-    new_iso = os.path.join(cdrom_dir, new_iso_name)
-    update_iso_xml = os.path.join(cdrom_dir, update_iso_xml_name)
-    if not os.path.exists(cdrom_dir):
-        os.mkdir(cdrom_dir)
-    if not init_iso_name:
+    if device_type not in ['cdrom', 'floppy']:
+        raise error.TestNAError("Got a invalid device type:/n%s") % device_type
+
+    iso_dir = os.path.join(data_dir.get_tmp_dir(), "tmp")
+    old_iso = os.path.join(iso_dir, old_iso_name)
+    new_iso = os.path.join(iso_dir, new_iso_name)
+    update_iso_xml = os.path.join(iso_dir, update_iso_xml_name)
+    if not os.path.exists(iso_dir):
+        os.mkdir(iso_dir)
+    if not init_iso_name :
         init_iso = ""
     else:
-        init_iso = os.path.join(cdrom_dir, init_iso_name)
+        init_iso = os.path.join(iso_dir, init_iso_name)
 
     if vm_ref == "name":
         vm_ref = vm_name
 
     env_pre(old_iso, new_iso)
     # Check domain's disk device
-    disk_blk = vm_xml.VMXML.get_disk_blk(vm_name)
+    disk_blk =  vm_xml.VMXML.get_disk_blk(vm_name)
     logging.info("disk_blk %s" % disk_blk)
-    if disk_device not in disk_blk:
-        logging.info("Adding cdrom device")
-        add_cdrom_device(vm_name, init_cdrom)
+    if target_device not in  disk_blk:
+        logging.info("Adding device")
+        add_device(vm_name)
 
     if vm.is_alive() and start_vm == "no":
         logging.info("Destroying guest...")
@@ -143,34 +157,32 @@ def run_virsh_change_media(test, params, env):
         logging.info("Starting guest...")
         vm.start()
 
-    update_cdrom(vm_name, init_iso, options, start_vm)
-
-    if libvirtd == "off":
-        utils_libvirtd.libvirtd_stop()
+    # If test target is floppy, you need to set selinux to Permissive mode.
+    update_device(vm_name, init_iso, options, start_vm)
 
     # Libvirt will ignore --source when action is eject
     if action == "--eject ":
         source = ""
     else:
-        source = os.path.join(cdrom_dir, source_name)
+        source = os.path.join(iso_dir, source_name)
         if source_path == "no":
             source = source_name
 
     all_options = action + options + " " + source
-    result = virsh.change_media(vm_ref, disk_device,
+    result = virsh.change_media(vm_ref, target_device,
                                 all_options, ignore_status=True, debug=True)
     if status_error == "yes":
         if start_vm == "no" and vm.is_dead():
             try:
                 vm.start()
-            except error.CmdError, detail:
+            except virt_vm.VMStartError, detail:
                 result.exit_status = 1
                 result.stderr = str(detail)
         if start_vm == "yes" and vm.is_alive():
+            vm.destroy(gracefully=False)
             try:
-                vm.destroy(gracefully=False)
                 vm.start()
-            except error.CmdError, detail:
+            except virt_vm.VMStartError, detail:
                 result.exit_status = 1
                 result.stderr = str(detail)
 
@@ -182,18 +194,15 @@ def run_virsh_change_media(test, params, env):
         if vm.is_dead():
             vm.start()
         session = vm.wait_for_login()
+        #pdb.set_trace()
         check_media(session, check_file, action)
         session.close()
 
-    # Recover libvirtd service start
-    if libvirtd == "off":
-        utils_libvirtd.libvirtd_start()
-
-    # Clean the cdrom dir  and clean the cdrom device
-    update_cdrom(vm_name, "", options, start_vm)
+    # Clean the iso dir  and clean the device
+    update_device(vm_name, "", options, start_vm)
+    shutil.rmtree(iso_dir)
 
     # Check status_error
-
     # Negative testing
     if status_error == "yes":
         if status:


### PR DESCRIPTION
Since "change-media" command is for cdrom and floppy,
only test cdrom is not enough, so I added test cases
for floppy.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
