### PR TITLE
Make tools/utils scripts generic

### DIFF
--- a/tools/check_patch.py
+++ b/tools/check_patch.py
@@ -403,7 +403,6 @@ class FileChecker(object):
         if "python" in self.first_line:
             self.is_python = True
 
-        self.corrective_actions = []
         self.indent_exceptions = INDENT_BLACKLIST.get(PROJECT_NAME, [])
         self.check_exceptions = FILE_BLACKLIST.get(PROJECT_NAME, [])
 


### PR DESCRIPTION
We've had some utility scripts slightly out of sync between `virt-test` and `autotest`. This is an attempt to unify them.
