### PR TITLE
Add missed parm 'tmp_dir' for mirroring test in windows guest

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -274,8 +274,9 @@
         post_snapshot_cmd = {shell:D:\whql\WUInstall.exe /install}
     live_snapshot_chain.oops:
         post_snapshot_cmd = {monitor:nmi 0}
-    drive_mirror.with_stress.dd:
+    block_stream, drive_mirror:
         tmp_dir = "C:\"
+    drive_mirror.with_stress.dd:
         #if this link not available, please download from http://www.chrysocome.net/downloads/dd-0.5.zip
         download_link = "http://www.chrysocome.net/downloads/dd.exe"
         pkg_md5sum = 168b73cc0f3d8c92c98c5028aec770df
@@ -286,7 +287,6 @@
         stop_cmd = 'taskkill /F /T /IM dd.exe & del /f /s /q "c:\test.img"'
         check_cmd = 'tasklist | findstr /I  "dd.exe"'
     drive_mirror.with_stress.heavyload, drive_mirror.with_powerdown, block_stream.with_stress:
-        tmp_dir = "C:\"
         download_link = "http://www.jam-software.com/heavyload/HeavyLoadSetup.exe"
         pkg_md5sum = 5bf187bd914ac8ce7f79361d7b56bc15
         install_cmd = 'start /wait %s\HeavyLoadSetup.exe /verysilent'


### PR DESCRIPTION
'tmp_dir' used by stream/mirroring test script, so move out it as global parm for block_stream/drive_mirroring testing;

Thanks,
Xu 
