### PR TITLE
shared.scripts.virtio_console_guest: Fix problem with async mode

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -303,11 +303,6 @@ def run_virtio_console(test, params, env):
         @param cfg: virtio_console_params - which type of virtio port to test
         @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        # When the GW is already running and the thread only connects,
-        # every signal destroys the daemon. Fresh start solves the problem.
-        error.context("Reloading the GuestWorker before sigio test.",
-                      logging.info)
-        test_delete_guest_script()
         (vm, guest_worker, port) = get_vm_with_single_port(
                                         params.get('virtio_console_params'))
         if port.is_open():

--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -722,16 +722,17 @@ class VirtioGuestPosix(VirtioGuest):
 
             self.use_config.clear()
             if mode:
+                self.catch_signal = True
+                os.kill(os.getpid(), signal.SIGUSR1)
+                self.use_config.wait()
                 fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_ASYNC)
                 self.poll_fds[fd] = [exp_val, 0]
-                self.catch_signal = True
             else:
                 del self.poll_fds[fd]
                 fcntl.fcntl(fd, fcntl.F_SETFL, fl & ~os.O_ASYNC)
                 self.catch_signal = False
-
-            os.kill(os.getpid(), signal.SIGUSR1)
-            self.use_config.wait()
+                os.kill(os.getpid(), signal.SIGUSR1)
+                self.use_config.wait()
 
         except Exception, inst:
             print "FAIL: Setting (a)sync mode: " + str(inst)


### PR DESCRIPTION
Hi guys,

finally I took a second look on sigio test and (hopefully) found the problem. The sigio test uses async mode and from time to time when we set the port to async mode, the guest worker finished without any (sane) output. The problem was, that signals are handled with the background daemon, which was killed by unhandled SIGIO signal, thus no output was passed to the executed guest_worker.

The previous workflow:
1) port set to async
2) set custom SIGIO handler

Sometimes between 1 and 2 signal arrived
1) port set to async
2) signal arrived and was handled by SIG_DFL => background daemon was shoot to death (into the head)

New workflow:
1) set custom SIGIO handler
2) set port to async
3) enjoy the life with bullet-proof SIGIO handler

Kind regards,
Lukáš

**NOTE: You have to remove the previous /tmp/virtio_console_guest.py\* in order to let virtio_console test to copy this updated one!**
NOTE2: The test passes in +- 30%, because the closed and unused port returns "IN HUP". (which is a virtio_console bug).
