### PR TITLE
virt: Modify self[key] to self.data[key] in utils_env.py

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -79,7 +79,7 @@ class Env(UserDict.IterableUserDict):
         vm_list = []
         for key in self.data.keys():
             if key.startswith("vm__"):
-                vm_list.append(self[key])
+                vm_list.append(self.data[key])
         return vm_list
 
 


### PR DESCRIPTION
Although self identical to self.data, prefer to use self.data like other functions did.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
