### PR TITLE
virttest.virsh: Fix error of referenced before defined. 

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -136,10 +136,9 @@ class VirshSession(aexpect.ShellSession):
             self.virsh_exec = ( "%s \"%s -c '%s'\""
                                 % (ssh_cmd, virsh_exec, self.uri) )
         else: # setting up a local session or re-using a session
+            self.virsh_exec = virsh_exec
             if self.uri:
                 self.virsh_exec += " -c '%s'" % self.uri
-            else:
-                self.virsh_exec = virsh_exec
             ssh_cmd = None # flags not-remote session
 
         # aexpect tries to auto close session because no clients connected yet


### PR DESCRIPTION
a += b equals to a = a + b.
So for self.virsh_exec += " -c xxx" in VirshSession.
It will cause problem of referenced before defined.
Now define self.virsh_exec before this line.
