### PR TITLE
qemu.tests: make mutli_disk test works for linux guest

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -5,7 +5,7 @@
     remove_image = yes
     remove_image_image1 = no
     cmd_timeout = 1000
-    black_list = C: D:
+    black_list = C:
     start_vm = no
     stg_image_name = "images/%s"
     variants:

--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -53,19 +53,18 @@
         clean_cmd = "\rm -rf /mnt/*"
         cmd_list = "copy_to_command copy_from_command"
         file_system = "ext3 ext2"
-        mount_command = mkdir /mnt/%s && mount /dev/%s /mnt/%s
-        umount_command = umount /dev/%s && rmdir /mnt/%s
-        list_volume_command = cd /dev && \ls [vhs]d*
-        re_str = "[vhs]d[a-z]*"
-        format_command = echo y | mkfs -t %s /dev/%s
-        copy_to_command = \cp -rf /bin/ls /mnt/%s
-        copy_from_command = \cp -rf /mnt/%s/ls /tmp/ls
-        compare_command = md5sum /bin/ls > /tmp/ls.md5 && cd /tmp && md5sum -c ls.md5
+        mount_command = "mkdir /mnt/%s && mount /dev/%s /mnt/%s"
+        umount_command = "umount /dev/%s && rm -rf /mnt/%s"
+        list_volume_command = "cd /dev && \ls [vhs]d* |grep -v [0-9]$"
+        re_str = "[vhs]d[a-z]+"
+        format_command = "yes| mkfs -t %s /dev/%s"
+        copy_to_command = "\cp -rf /bin/ls /mnt/%s"
+        copy_from_command = "\cp -rf /mnt/%s/ls /tmp/ls"
+        compare_command = "cd /bin && md5sum ls > /tmp/ls.md5 && cd /tmp && md5sum -c ls.md5"
         check_result_key_word = OK
         max_disk..virtio_blk:
             stg_image_num = 27
-            list_volume_command = cd /dev && \ls vd*
-            re_str = "[vhs]d[a-z]*[^0-9]"
+            list_volume_command = "cd /dev && \ls vd*"
     usb_multi_disk:
         show_mount_cmd = mount|gawk '/mnt/{print $1}'
         clean_cmd = "\rm -rf /mnt/*"


### PR DESCRIPTION
Fix 'not all disk listed'  issue and get cdrom drive letter with utils_misc.get_winutils_vol();

Signed-off-by: Xu Tian xutian@redhat.com
