### PR TITLE
virttest: Make cert-subject in spice related comand works with hmp/qmp monitor

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1574,7 +1574,11 @@ class QMPMonitor(Monitor):
 
                     cmdargs = " ".join(cmdline.split()[1:]).split(",")
                     for arg in cmdargs:
-                        command += " " + arg.split("=")[-1]
+                        value = "=".join(arg.split("=")[1:])
+                        if arg.split("=")[0] == "cert-subject":
+                            value = value.replace('/',',')
+
+                        command += " " + value
                 else:
                     command = cmdline
                 cmd_output.append(self.human_monitor_cmd(command))
@@ -1583,17 +1587,20 @@ class QMPMonitor(Monitor):
                 args = {}
                 for arg in cmdargs:
                     opt = arg.split('=')
+                    value = "=".join(opt[1:])
                     try:
-                        if re.match("^[0-9]+$", opt[1]):
-                            value = int(opt[1])
-                        elif re.match("^[0-9]+\.[0-9]*$", opt[1]):
-                            value = float(opt[1])
-                        elif "True" in opt[1] or "true" in opt[1]:
+                        if re.match("^[0-9]+$", value):
+                            value = int(value)
+                        elif re.match("^[0-9]+\.[0-9]*$", value):
+                            value = float(value)
+                        elif re.findall("true", value, re.I):
                             value = True
-                        elif "false" in opt[1] or "False" in opt[1]:
+                        elif re.findall("false", value, re.I):
                             value = False
                         else:
-                            value = opt[1].strip()
+                            value = value.strip()
+                        if opt[0] == "cert-subject":
+                            value = value.replace('/',',')
                         args[opt[0].strip()] = value
                     except:
                         logging.debug("Fail to create args, please check cmd")

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2877,7 +2877,7 @@ class VM(virt_vm.BaseVM):
                                                             "")
                     cert_s = clone.spice_options.get("spice_x509_server_subj",
                                                      "")
-                    cert_subj = "%s" % cert_s.replace('/', ',')[1:]
+                    cert_subj = "%s" % cert_s[1:]
                     cert_subj += host_ip
                     cert_subj = "\"%s\"" % cert_subj
                 else:
@@ -2895,17 +2895,17 @@ class VM(virt_vm.BaseVM):
                         continue
                     # spice_migrate_info requires host_ip, dest_port
                     # client_migrate_info also requires protocol
-                    cmdline = "%s %s" % (command, host_ip)
+                    cmdline = "%s hostname=%s" % (command, host_ip)
                     if command == "client_migrate_info":
-                        cmdline += " %s" % self.params['display']
+                        cmdline += " ,protocol=%s" % self.params['display']
                     if dest_port:
-                        cmdline += " %s" % dest_port
+                        cmdline += ",port=%s" % dest_port
                     if dest_tls_port:
-                        cmdline += " %s" % dest_tls_port
+                        cmdline += ",tls-port=%s" % dest_tls_port
                     if cert_subj:
-                        cmdline += " %s" % cert_subj
+                        cmdline += ",cert-subject=%s" % cert_subj
                     break
-                self.monitor.send_args_cmd(cmdline, convert=False)
+                self.monitor.send_args_cmd(cmdline)
 
             if protocol in ["tcp", "rdma", "x-rdma"]:
                 if local:


### PR DESCRIPTION
Now command 'client_migrate_info hostname=10.66.72.60,protocol=spice,port=3001,
tls-port=3201,cert-subject="C=CZ/L=BRNO/O=SPICE/CN=my Server10.66.72.60"'
could not works in qmp/hmp monitor.
We can not use "=" in cert-subjec parameter.
This patch fix this issue both in qmp/hmp monitor

Signed-off-by: Feng Yang fyang@redhat.com
