### PR TITLE
 tests.cfg: Set up the lowest_mem for unattended_install

### DIFF
--- a/tests/cfg/unattended_install.cfg
+++ b/tests/cfg/unattended_install.cfg
@@ -29,6 +29,13 @@
     # images_good =
     # Mount point for your back up images
     # dst_dir =
+    #
+    # This value is setup for huge page set up.
+    # Lowest memory size for on vm to finish install test based on the
+    # anaconda memory check size. Tested it with RHEL, Windows and newest
+    # Fedora guests. For other guests like ubuntu if your install failed with
+    # don't have enough RAM error from anaconda, please enlarge this value.
+    lowest_mem = 512
     variants:
         - aio_native:
             image_aio = native


### PR DESCRIPTION
Tested with RHEL, Fedora and Windows guests, they can finish install with 512M memory.
