### PR TITLE
virt: Add 'timeout' parameter to join() function of BackgroundTest class

### DIFF
--- a/virttest/utils_test.py
+++ b/virttest/utils_test.py
@@ -2494,11 +2494,11 @@ class BackgroundTest(object):
         """
         self.thread.start()
 
-    def join(self):
+    def join(self, timeout=600):
         """
         Wait for the join of thread and raise its exception if any.
         """
-        self.thread.join()
+        self.thread.join(timeout)
         # pylint: disable=E0702
         if self.exception:
             raise self.exception


### PR DESCRIPTION
1. Add 'timeout' parameter to join() function of BackgroundTest class in virttest/utils_test.py, set it to 600s defaultly.
2. Instead time.sleep, use join() to control timeout in qemu/tests/migration.py

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
