### PR TITLE
Enhance pci_test_cmd for block_hotplug testing 

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -130,7 +130,9 @@
         wait_secs_for_hook_up = 10
         reference_cmd = wmic diskdrive list brief
         find_pci_cmd = wmic diskdrive list brief
-        pci_test_cmd = "echo select disk %s > dt &&"
+        pci_test_cmd = "echo rescan > dt &&"
+        pci_test_cmd += "echo list disk >> dt &&"
+        pci_test_cmd += "echo select disk %s >> dt &&"
         pci_test_cmd += " echo detail disk >> dt &&"
         pci_test_cmd += " echo exit >> dt &&"
         pci_test_cmd += " diskpart /s dt"


### PR DESCRIPTION
Add rescan  and list disk steps; Do rescan to ensure diskpart read latest disk configuration and it will avoid diskpart report 'The disk you specified is not valid.' error, list disk step will record disk info before check disk drive; 
New steps will helpful for debugging when test failed at pci_test step;

Thanks,
Xu
