### PR TITLE
virt: Backup vm xml to a desired base directory.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
@@ -19,7 +19,7 @@ def run_virsh_autostart(test, params, env):
     status_error = "yes" == params.get("status_error", "no")
 
     # Prepare transient/persistent vm
-    original_xml = vm.backup_xml()
+    original_xml = vm.backup_to_xml()
     if not persistent_vm and vm.is_persistent():
         vm.undefine()
     elif persistent_vm and not vm.is_persistent():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_desc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_desc.py
@@ -80,7 +80,7 @@ def run_virsh_desc(test, params, env):
         desc_check(vm_name, desc_str, state_switch)
 
     # Prepare transient/persistent vm
-    original_xml = vm.backup_xml()
+    original_xml = vm.backup_to_xml()
     if persistent_vm == "no" and vm.is_persistent():
         vm.undefine()
     elif persistent_vm == "yes" and not vm.is_persistent():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -75,7 +75,7 @@ def run_virsh_migrate(test, params, env):
     vm.verify_alive()
 
     # For safety reasons, we'd better back up  xmlfile.
-    vm_xmlfile_bak = vm.backup_xml()
+    vm_xmlfile_bak = vm.backup_to_xml()
     if not vm_xmlfile_bak:
         logging.error("Backing up xmlfile failed.")
 

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
@@ -64,7 +64,7 @@ def run_virsh_list(test, params, env):
         addition_status_error = "yes"
 
     if vm_ref == "transient":
-        tmp_xml = vm.backup_xml()
+        tmp_xml = vm.backup_to_xml()
         vm.undefine()
     elif vm_ref == "managed-save":
         virsh.managedsave(vm_name, ignore_status=True, print_info=True)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -242,7 +242,7 @@ class VM(virt_vm.BaseVM):
         """
         return virsh.dumpxml(self.name, uri=self.connect_uri)
 
-    def backup_xml(self, tmpdir=None):
+    def backup_to_xml(self, tmpdir=None):
         """
         Backup the guest's xmlfile.
 


### PR DESCRIPTION
Some test use vm.backup_xml() to backup vm's configuration, when test is over, user must remove this xml file, if use 'test.tmpdir' in this function, xml file will be removed automatically.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
