### PR TITLE
libvirt.tests: Add migration test for virsh_migrate_stress.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -8,41 +8,41 @@
     start_migration_vms = "yes"
     # Load vms are used for stress
     load_vms = "load_vm1 load_vm2 load_vm3"
-    remote_host = "REMOTEHOST.EXAMPLE"
-    local_host = "LOCALHOST.EXAMPLE"
-    remote_username = "root"
-    remote_passwd = "REMOTE.PASSWORD"
+    remote_ip = "REMOTEHOST.EXAMPLE"
+    local_ip = "LOCALHOST.EXAMPLE"
+    remote_user = "root"
+    remote_pwd = "REMOTE.PASSWORD"
     shell_prompt = "^.*@.*[\#\$]\s*$"
-    migrate_dest_uri = "qemu+ssh://${remote_host}/system"
-    migrate_src_uri = "qemu+ssh://${local_host}/system"
+    migrate_dest_uri = "qemu+ssh://${remote_ip}/system"
+    migrate_src_uri = "qemu+ssh://${local_ip}/system"
     thread_timeout = 120
     variants:
         - set_vcpu_1:
-            vm_cpu = 2
+            smp = 2
         - set_vcpu_2:
-            vm_cpu = 4
+            smp = 4
         - set_memory_1:
-            vm_memory = 2097152
+            mem = 2048
         - set_memory_2:
-            vm_memory = 4194304
+            mem = 4096
     variants:
         - run_stress_app:
             # This address has been outdated, it should be replaced later.
-            download_link = "http://weather.ou.edu/~apw/projects/stress/stress-1.0.4.tar.gz"
-            md5sum = "9d19b84cbad1e212add26e6c286656ad"
-            install_cmd = "tar -xzvf %s/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install "
-            config_cmd = ""
-            app_check_cmd = "stress --help"
-            check_cmd = "pidof -s stress"
-            stop_cmd = "killall stress"
+            stress_download_link = "http://weather.ou.edu/~apw/projects/stress/stress-1.0.4.tar.gz"
+            stress_md5sum = "9d19b84cbad1e212add26e6c286656ad"
+            stress_install_cmd = "tar -xzvf %s/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install "
+            stress_config_cmd = ""
+            stress_app_check_cmd = "stress --help"
+            stress_check_cmd = "pidof -s stress"
+            stress_stop_cmd = "killall stress"
             # Place stress tool
-            tmp_dir = "/tmp"
+            stress_tmp_dir = "/tmp"
             variants:
                 - cpu_stress:
-                    start_cmd = "stress --cpu 4 --quiet &"
+                    stress_start_cmd = "stress --cpu 4 --quiet &"
                 - memory_stress:
                     # Add timeout option to avoid infinite stress.
-                    start_cmd = "stress --vm 2 --vm-bytes %s --vm-keep --timeout 600 &"
+                    stress_start_cmd = "stress --vm 2 --vm-bytes %s --vm-keep --timeout 600 &"
             variants:
                 - stress_tool_in_vms:
                     migration_stress_type = "stress_in_vms"


### PR DESCRIPTION
Enhancements:

```
* Support migration in thread for expanding.
* Fix bugs and some pylint problems.
```

Cross migration:

```
local     =====      remote
1st time:
vm1        ->
2nd time:
             <-         vm1
vm2        ->
3rd time:
             <-         vm2
vm3        ->
```

Booting migration:
Migrate vms when they are booting(Not load vms).
