### PR TITLE
qemu.test: add reboot step for pci_hotplug testing

### DIFF
--- a/qemu/tests/cfg/pci_hotplug.cfg
+++ b/qemu/tests/cfg/pci_hotplug.cfg
@@ -20,6 +20,7 @@
             only Host_RHEL
             no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
             services_up_timeout = 30
+            reboot_vm = yes
             variants:
                 - after_plug:
                     #XXX: pci_hotplug script doesn't support S4 after hotplug.

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -17,6 +17,7 @@ def run_pci_hotplug(test, params, env):
     4) Verify whether pci_model is shown in [pci_find_cmd].
     5) Check whether the newly added PCI device works fine.
     6) PCI delete the device, verify whether could remove the PCI device.
+    7) reboot VM after guest wakeup form S3/S4 status (Optional Step).
 
     :param test:   QEMU test object.
     :param params: Dictionary with the test parameters.
@@ -313,3 +314,6 @@ def run_pci_hotplug(test, params, env):
                 error.context(context_msg % (sub_type, "after hotunplug"),
                               logging.info)
                 utils_test.run_virt_sub_test(test, params, env, sub_type)
+
+    if params.get("reboot_vm", "no") == "yes":
+        vm.reboot()


### PR DESCRIPTION
We need step reboot guest after hotplug/unplug pci device to verify guest
not crash or hang when reboot;

Signed-off-by: Xu Tian xutian@redhat.com
