### PR TITLE
virt: Import module from virttest.staging first

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
@@ -8,11 +8,11 @@ from autotest.client.shared import error
 from virttest import virsh, libvirt_vm
 
 try:
-    from autotest.client.shared import utils_memory
-    from autotest.client.shared import utils_cgroup
-except ImportError:
     from virttest.staging import utils_memory
     from virttest.staging import utils_cgroup
+except ImportError:
+    from autotest.client.shared import utils_memory
+    from autotest.client.shared import utils_cgroup
 
 
 def run_virsh_memtune(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
@@ -3,10 +3,10 @@ import logging
 from autotest.client.shared import error, utils
 from virttest import libvirt_xml, virsh, utils_libvirtd
 try:
-    from autotest.client.shared import utils_cgroup
+    from virttest.staging import utils_cgroup
 except ImportError:
     # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from virttest.staging import utils_cgroup
+    from autotest.client.shared import utils_cgroup
 
 
 def num_numa_nodes():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -5,9 +5,9 @@ from autotest.client.shared import utils, error
 from virttest import virsh
 
 try:
-    from autotest.client.shared import utils_cgroup
-except ImportError:
     from virttest.staging import utils_cgroup
+except ImportError:
+    from autotest.client.shared import utils_cgroup
 
 
 def run_virsh_schedinfo_qemu_posix(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -5,9 +5,9 @@ from autotest.client.shared import error
 from virttest import virsh, utils_libvirtd
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 def run_virsh_nodeinfo(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodememstats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodememstats.py
@@ -5,9 +5,9 @@ from virttest import virsh, utils_libvirtd
 
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 def run_virsh_nodememstats(test, params, env):

--- a/qemu/tests/boot_time.py
+++ b/qemu/tests/boot_time.py
@@ -3,9 +3,9 @@ import time
 from autotest.client.shared import error
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -15,19 +15,19 @@ from virttest.aexpect import ExpectTimeoutError
 from virttest.aexpect import ExpectProcessTerminatedError
 from virttest.aexpect import ShellTimeoutError
 try:
-    from autotest.client.shared.utils_cgroup import Cgroup
-    from autotest.client.shared.utils_cgroup import CgroupModules
-    from autotest.client.shared.utils_cgroup import get_load_per_cpu
-except ImportError:
-    # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
     from virttest.staging.utils_cgroup import Cgroup
     from virttest.staging.utils_cgroup import CgroupModules
     from virttest.staging.utils_cgroup import get_load_per_cpu
+except ImportError:
+    # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
+    from autotest.client.shared.utils_cgroup import Cgroup
+    from autotest.client.shared.utils_cgroup import CgroupModules
+    from autotest.client.shared.utils_cgroup import get_load_per_cpu
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/ksm_overcommit.py
+++ b/qemu/tests/ksm_overcommit.py
@@ -9,9 +9,9 @@ from virttest import utils_misc, utils_test, aexpect, env_process, data_dir
 from autotest.client.shared import utils
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 def run_ksm_overcommit(test, params, env):

--- a/qemu/tests/numa_basic.py
+++ b/qemu/tests/numa_basic.py
@@ -3,9 +3,9 @@ from autotest.client.shared import error
 from virttest import env_process, utils_misc, utils_test
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/numa_consistency.py
+++ b/qemu/tests/numa_consistency.py
@@ -4,9 +4,9 @@ from autotest.client.shared import error
 from virttest import env_process, utils_misc, utils_test
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/numa_stress.py
+++ b/qemu/tests/numa_stress.py
@@ -6,9 +6,9 @@ from virttest import utils_misc, funcatexit, utils_test, data_dir
 from tests import autotest_control
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/stress_kernel_compile.py
+++ b/qemu/tests/stress_kernel_compile.py
@@ -4,9 +4,9 @@ from autotest.client.shared import error
 from virttest import utils_test, utils_misc, env_process
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 def run_stress_kernel_compile(tests, params, env):

--- a/qemu/tests/vhost_with_cgroup.py
+++ b/qemu/tests/vhost_with_cgroup.py
@@ -4,10 +4,10 @@ from autotest.client import utils
 from virttest.env_process import preprocess
 
 try:
-    from autotest.client.shared.utils_cgroup import Cgroup, CgroupModules
+    from virttest.staging.utils_cgroup import Cgroup, CgroupModules
 except ImportError:
     # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from virttest.staging.utils_cgroup import Cgroup, CgroupModules
+    from autotest.client.shared.utils_cgroup import Cgroup, CgroupModules
 
 
 @error.context_aware

--- a/shared/control/stress_memory_heavy.control
+++ b/shared/control/stress_memory_heavy.control
@@ -14,10 +14,9 @@ import os
 from autotest.client import utils
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
-
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 # Assemble the parameters specially to stress memory
 

--- a/tests/trans_hugepage_memory_stress.py
+++ b/tests/trans_hugepage_memory_stress.py
@@ -5,9 +5,9 @@ from autotest.client import utils
 from virttest import utils_test
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 @error.context_aware

--- a/tests/trans_hugepage_relocated.py
+++ b/tests/trans_hugepage_relocated.py
@@ -7,9 +7,9 @@ from autotest.client.shared import error
 from virttest import utils_test
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 
 def run_trans_hugepage_relocated(test, params, env):

--- a/virttest/utils_test.py
+++ b/virttest/utils_test.py
@@ -49,15 +49,15 @@ import env_process
 import virttest
 
 try:
-    from autotest.client.shared import utils_cgroup
+    from virttest.staging import utils_cgroup
 except ImportError:
     # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from virttest.staging import utils_cgroup
+    from autotest.client.shared import utils_cgroup
 
 try:
-    from autotest.client.shared import utils_memory
-except ImportError:
     from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
 # Handle transition from autotest global_config (0.14.x series) to
 # settings (0.15.x onwards)


### PR DESCRIPTION
```
As module under virttest.staging may include some functions that is
not in autotest package yet. So we should import them first. Otherwise
the new modification and functions may can not be found during test.
```
