### PR TITLE
virt-libvirt: Modify virsh dump test and some testcases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
@@ -1,17 +1,27 @@
 - virsh_dump:
-    virt_test_type = libvirt
     type = virsh_dump
     dump_options = ""
     dump_file = "vm.core"
     dump_image_format = ""
     start_vm = "yes"
+    kill_vm = "yes"
+    kill_vm_befor_test = "yes"
     take_regular_screendumps = "no"
+    timeout = 5
     variants:
         - positive_test:
             status_error = "no"
             variants:
                 - no_option:
-                    dump_options = ""
+                - pause_dump:
+                    paused_after_start_vm = "yes"
+                    variants:
+                        - live:
+                            dump_options = "--live"
+                        - crash:
+                            dump_options = "--crash"
+                        - reset:
+                            dump_options = "--reset"
                 - live_dump:
                     dump_options = "--live"
                 - crash_dump:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -1,11 +1,33 @@
 import os
 import logging
 import commands
-import thread
 import time
-from autotest.client.shared import error
+import signal
+from autotest.client.shared import error, utils
 from virttest import virsh, utils_libvirtd
 
+
+def wait_pid_active(pid, timeout=5):
+    """
+    Wait for pid in running status
+
+    @param: pid: Desired pid
+    @param: timeout: Max time we can wait
+    """
+    cmd = ("cat /proc/%d/stat | awk '{print $3}'" % pid)
+    try:
+        while (True):
+            timeout = timeout -1
+            if not timeout:
+                raise error.TestNAError("Time out for waiting pid!")
+            pid_status = utils.run(cmd, ignore_status=False).stdout.strip()
+            if pid_status != "R":
+                time.sleep(1)
+                continue
+            else:
+                break
+    except Exception, detail:
+        raise error.TestFail(detail)
 
 def check_flag(file_flag):
     """
@@ -14,7 +36,6 @@ def check_flag(file_flag):
     Note, O_DIRECT is defined as:
     #define O_DIRECT        00040000        /* direct disk access hint */
     """
-
     if int(file_flag) == 4:
         logging.info("File flags include O_DIRECT")
         return True
@@ -22,36 +43,34 @@ def check_flag(file_flag):
         logging.error("File flags doesn't include O_DIRECT")
         return False
 
-
 def check_bypass(dump_file):
     """
     Get the file flags of domain core dump file and check it.
     """
 
-    cmd1 = "lsof -w %s >/dev/null 2>&1" % dump_file
+    cmd1 = "lsof -w %s" % dump_file
     while True:
-        if os.path.exists(dump_file):
-            if not os.system(cmd1):
-                cmd2 = ("cat /proc/$(%s |awk '/libvirt_i/{print $2}')/fdinfo/1"
-                        "|grep flags|awk '{print $NF}'" % cmd1)
-                (status, output) = commands.getstatusoutput(cmd2)
-                if status == 0:
-                    if len(output):
-                        logging.debug("The flags of dumped file: %s ", output)
-                        file_flag = output[-5]
-                        if check_flag(file_flag):
-                            logging.info("Bypass file system cache "
-                                         "successfully when dumping")
-                        else:
-                            raise error.TestFail("Bypass file system cache "
-                                                 "fail when dumping")
-                        break
-                else:
-                    logging.error("Fail to get the flags of dumped file")
-                    return 1
-
-    thread.exit_thread()
-
+        if not os.path.exists(dump_file) or os.system(cmd1):
+            continue
+        cmd2 = ("cat /proc/$(%s |awk '/libvirt_i/{print $2}')/fdinfo/1"
+                "|grep flags|awk '{print $NF}'" % cmd1)
+        (status, output) = commands.getstatusoutput(cmd2)
+        if status:
+            raise error.TestFail("Fail to get the flags of dumped file")
+        if not len(output):
+            continue
+        try:
+            logging.debug("The flag of dumped file: %s", output)
+            file_flag = output[-5]
+            if check_flag(file_flag):
+                logging.info("Bypass file system cache "
+                             "successfully when dumping")
+                break
+            else:
+                raise error.TestFail("Bypass file system cache "
+                                     "fail when dumping")
+        except (ValueError, IndexError), detail:
+            raise error.TestFail(detail)
 
 def run_virsh_dump(test, params, env):
     """
@@ -69,22 +88,17 @@ def run_virsh_dump(test, params, env):
     """
 
     vm_name = params.get("main_vm", "vm1")
-    vm = env.get_vm(params["main_vm"])
+    vm = env.get_vm(vm_name)
     options = params.get("dump_options")
     dump_file = params.get("dump_file", "vm.core")
     if os.path.dirname(dump_file) is "":
         dump_file = os.path.join(test.tmpdir, dump_file)
     dump_image_format = params.get("dump_image_format")
-    start_vm = params.get("start_vm")
-    status_error = params.get("status_error", "no")
+    start_vm = params.get("start_vm") == "yes"
+    paused_after_start_vm = params.get("paused_after_start_vm") == "yes"
+    status_error = params.get("status_error", "no") == "yes"
+    timeout = int(params.get("timeout", "5"))
     qemu_conf = "/etc/libvirt/qemu.conf"
-
-    # prepare the vm state
-    if vm.is_alive() and start_vm == "no":
-        vm.destroy()
-
-    if vm.is_dead() and start_vm == "yes":
-        vm.start()
 
     def check_domstate(actual, options):
         """
@@ -95,24 +109,27 @@ def run_virsh_dump(test, params, env):
             domstate = "running"
             if options.find('crash') >= 0 or options.find('reset') > 0:
                 domstate = "running"
+            if paused_after_start_vm:
+                domstate = "paused"
         elif options.find('crash') >= 0:
             domstate = "shut off"
             if options.find('reset') >= 0:
                 domstate = "running"
         elif options.find('reset') >= 0:
             domstate = "running"
+            if paused_after_start_vm:
+                domstate = "paused"
         else:
             domstate = "running"
+            if paused_after_start_vm:
+                domstate = "paused"
 
-        if start_vm == "no":
+        if not start_vm:
             domstate = "shut off"
 
         logging.debug("Domain should %s after run dump %s", domstate, options)
 
-        if domstate == actual:
-            return True
-        else:
-            return False
+        return (domstate == actual)
 
     def check_dump_format(dump_image_format, dump_file):
         """
@@ -131,72 +148,74 @@ def run_virsh_dump(test, params, env):
         else:
             file_cmd = "file %s" % dump_file
             (status, output) = commands.getstatusoutput(file_cmd)
-            if status == 0:
-                logging.debug("Run file %s output: %s", dump_file, output)
-                actual_format = output.split(" ")[1]
-                if actual_format == dump_image_format:
-                    if dump_image_format in valid_format:
-                        logging.info("Compress dumped file to %s successfully",
-                                     dump_image_format)
-                    return True
-                else:
-                    logging.error("Compress dumped file to %s fail",
-                                  dump_image_format)
-                    return False
-            else:
+            if status:
                 logging.error("Fail to check dumped file %s", dump_file)
                 return False
+            logging.debug("Run file %s output: %s", dump_file, output)
+            actual_format = output.split(" ")[1]
+            if actual_format != dump_image_format:
+                logging.error("Compress dumped file to %s fail: %s" %
+                              (dump_image_format, actual_format))
+                return False
+            else:
+                return True
 
     # Configure dump_image_format in /etc/libvirt/qemu.conf.
-    if len(dump_image_format) != 0:
+    if len(dump_image_format):
         conf_cmd = ("echo dump_image_format = \\\"%s\\\" >> %s" %
                     (dump_image_format, qemu_conf))
         if os.system(conf_cmd):
             logging.error("Config dump_image_format to %s fail",
                           dump_image_format)
         utils_libvirtd.libvirtd_restart()
+        if not utils_libvirtd.libvirtd_is_running():
+            raise error.TestNAError("libvirt service is not running!")
 
     # Deal with bypass-cache option
+    child_pid = 0
     if options.find('bypass-cache') >= 0:
-        thread.start_new_thread(check_bypass, (dump_file,))
-        # Guarantee check_bypass function has run before dump
-        time.sleep(5)
+        pid = os.fork()
+        if pid:
+            # Guarantee check_bypass function has run before dump
+            child_pid = pid
+            try:
+                wait_pid_active(pid, timeout)
+            finally:
+                os.kill(child_pid, signal.SIGUSR1)
+        else:
+            check_bypass(dump_file)
+            # Wait for parent process over
+            while True:
+                time.sleep(1)
+
 
     # Run virsh command
     cmd_result = virsh.dump(vm_name, dump_file, options,
                             ignore_status=True, debug=True)
     status = cmd_result.exit_status
 
-    # Check libvirtd status
-    if utils_libvirtd.libvirtd_is_running():
-        if check_domstate(vm.state(), options):
-            if status_error == "yes":
-                if status == 0:
-                    raise error.TestFail("Expect fail, but run successfully")
-            if status_error == "no":
-                if status != 0:
-                    raise error.TestFail("Expect succeed, but run fail")
-                else:
-                    if os.path.exists(dump_file):
-                        if check_dump_format(dump_image_format, dump_file):
-                            logging.info("Successfully dump domain to %s",
-                                         dump_file)
-                        else:
-                            raise error.TestFail("The format of dumped file "
-                                                 "is wrong.")
-                    else:
-                        raise error.TestFail(
-                            "Fail to find domain dumped file.")
-
-        else:
+    try:
+        logging.info("Start check result")
+        if not check_domstate(vm.state(), options):
             raise error.TestFail("Domain status check fail.")
-    else:
-        raise error.TestFail("Libvirtd service is dead.")
-
-    if os.path.isfile(dump_file):
-        os.remove(dump_file)
-
-    if len(dump_image_format) != 0:
-        clean_qemu_conf = "sed -i '$d' %s " % qemu_conf
-        if os.system(clean_qemu_conf):
-            raise error.TestFail("Fail to recover %s", qemu_conf)
+        if status_error:
+            if not status:
+                raise error.TestFail("Expect fail, but run successfully")
+        else:
+            if status:
+                raise error.TestFail("Expect succeed, but run fail")
+            if not os.path.exists(dump_file):
+                raise error.TestFail("Fail to find domain dumped file.")
+            if check_dump_format(dump_image_format, dump_file):
+                logging.info("Successfully dump domain to %s", dump_file)
+            else:
+                raise error.TestFail("The format of dumped file is wrong.")
+    finally:
+        if child_pid:
+            os.kill(child_pid, signal.SIGUSR1)
+        if os.path.isfile(dump_file):
+            os.remove(dump_file)
+        if len(dump_image_format):
+            clean_qemu_conf = "sed -i '$d' %s " % qemu_conf
+            if os.system(clean_qemu_conf):
+                raise error.TestFail("Fail to recover %s", qemu_conf)


### PR DESCRIPTION
1.Instead of thread, use os.fork to create a new process,
  because we cannot get any exception in main process
  from another thread.
2.Add "try...finally" part at the end, because when test
  failed, config file won't be recovered.
3.Add 3 test cases for paused VM test.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
