### PR TITLE
storage: fix type convert error

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -379,7 +379,7 @@ class Rawdev(object):
         """
         host_set_flag = params.get("host_setup_flag")
         if host_set_flag is not None:
-            self.exec_cleanup = host_set_flag & 2 == 2
+            self.exec_cleanup = int(host_set_flag) & 2 == 2
         else:
             self.exec_cleanup = False
         if params.get("force_cleanup") == "yes":


### PR DESCRIPTION
force convert host_setup_flag to int before '&' operation;

Signed-off-by: Xu Tian xutian@redhat.com
