### PR TITLE
cfg: Update cluster_size to image_cluster_size

### DIFF
--- a/qemu/cfg/host-kernel.cfg
+++ b/qemu/cfg/host-kernel.cfg
@@ -33,7 +33,7 @@ variants:
                 monitors = hmp1
                 main_monitor = hmp1
                 machine_type = "rhel5.6.0"
-                cluster_size =
+                image_cluster_size =
                 extra_params += " -usbdevice tablet"
                 enable_x2apic = no
                 netdev_peer_re = "\s{2,}(.*?): .*?\s{2,}(.*?):"

--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -23,15 +23,15 @@
                  - non-preallocated:
                      variants:
                          - cluster_512:
-                             cluster_size = 512
+                             image_cluster_size = 512
                          - cluster_1024:
-                             cluster_size = 1024
+                             image_cluster_size = 1024
                          - cluster_4096:
-                             cluster_size = 4096
+                             image_cluster_size = 4096
                          - cluster_1M:
-                             cluster_size = 1M
+                             image_cluster_size = 1M
                          - cluster_2M:
-                             cluster_size = 2M
+                             image_cluster_size = 2M
                  - preallocated:
                      no raw
                      preallocated = metadata
@@ -52,7 +52,7 @@
                             # Then set A = xx, B = xx in configure
                             qemu_img_options = cluster_size
                             #cluster_size set cluster size used in qemu-img -o cluster_size=, default is 64k.
-                            cluster_size = 2048
+                            image_cluster_size = 2048
                             no Host_RHEL.5
                 - to_raw:
                     dest_image_format = raw

--- a/qemu/tests/cfg/qemu_io_blkdebug.cfg
+++ b/qemu/tests/cfg/qemu_io_blkdebug.cfg
@@ -7,7 +7,7 @@
     image_size_blk = 20G
     image_format_blk = qcow2
     remove_image_blk = yes
-    cluster_size = 512
+    image_cluster_size = 512
     err_command = "write 0 1G"
     err_event = "refblock_alloc"
     errn_list = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28"

--- a/tests/cfg/unattended_install.cfg
+++ b/tests/cfg/unattended_install.cfg
@@ -86,7 +86,7 @@
         - setting_cluster_size:
             # qemu-kvm bug 812705
             no Host_RHEL.5
-            cluster_size = 4096
+            image_cluster_size = 4096
             only qcow2 qcow2v3
     # Way of delivering ks file into the guest
     variants:

--- a/virttest/unittest_data/testcfg.huge/subtests.cfg
+++ b/virttest/unittest_data/testcfg.huge/subtests.cfg
@@ -1429,7 +1429,7 @@ variants:
         image_size_blk = 1G
         image_format_blk = qcow2
         remove_image_blk = yes
-        cluster_size = 512
+        image_cluster_size = 512
         err_command = "write -b 0 1G"
         err_event = "refblock_update_part"
         errn_list = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28"


### PR DESCRIPTION
As the parameter name is changed in qemu_storage.py. Update the cfg file
to fit it.

Signed-off-by: Yiqiao Pu ypu@redhat.com
