### PR TITLE
qemu.test: add support mirror image to nfs/iscsi

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -54,6 +54,30 @@
                     variants:
                         - block_job_complete:
                            type = drive_mirror_complete
+                           variants:
+                               - target_in_localfs:
+                                   open_target_image = yes
+                                   boot_target_image = no
+                               - target_in_nfs:
+                                   target_image_type = nfs
+                                   nfs_mount_dir = "/mnt/nfs"
+                                   target_image_image1 = "${nfs_mount_dir}/target1"
+                                   nfs_mount_options = "rw"
+                                   export_dir = "/home/nfs"
+                                   export_options = "rw,no_root_squash,async"
+                                   setup_local_nfs = yes
+                                   boot_target_image = yes
+                                   open_target_image = no
+                               - target_to_iscsi:
+                                   # target_image will ingore, target_image will generate automaticly
+                                   target_image_type = iscsi
+                                   open_target_image = no
+                                   boot_target_image = yes
+                                   # Please replace below iscsi connection params before start your testing
+                                   portal_ip = "192.168.1.2"
+                                   initiator = "iqn.2010-07.test.org:kvmautotest"
+                                   target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
+                                   # End
                         - continuous_backup:
                            type = drive_mirror_continuous_backup
                            clean_cmd = "rm -f tmp*.file"

--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from autotest.client.shared import error
-from virttest import qemu_storage, data_dir
+from virttest import qemu_storage, data_dir, env_process
 from qemu.tests import drive_mirror
 
 
@@ -10,7 +10,11 @@ def run_drive_mirror_complete(test, params, env):
     """
     Test block mirroring functionality
 
-    1) Mirror the guest and switch to the mirrored one
+    1). boot vm, then mirror $source_image to $target_image
+    2). wait for mirroring job go into ready status
+    3). compare $source image and $target_image file
+    4). reopen $target_image file if $open_target_image is 'yes'
+    5). boot vm from $target_image , and check guest alive
 
     "qemu-img compare" is used to verify disk is mirrored successfully.
     """
@@ -23,13 +27,30 @@ def run_drive_mirror_complete(test, params, env):
         mirror_test.start()
         mirror_test.wait_for_steady()
         mirror_test.vm.pause()
-        mirror_test.reopen()
-        device_id = mirror_test.vm.get_block({"file": target_image})
-        if device_id != mirror_test.device:
-            raise error.TestError("Mirrored image not being used by guest")
         time.sleep(5)
+        if params.get("open_target_image", "no") == "yes":
+            mirror_test.reopen()
+            device_id = mirror_test.vm.get_block({"file": target_image})
+            if device_id != mirror_test.device:
+                raise error.TestError("Mirrored image not being used by guest")
         error.context("Compare fully mirrored images", logging.info)
         qemu_img.compare_images(source_image, target_image)
+        mirror_test.vm.resume()
         mirror_test.vm.destroy()
+        if params.get("boot_target_image", "no") == "yes":
+            params = params.object_params(tag)
+            if params.get("target_image_type") == "iscsi":
+                params["image_name"] = mirror_test.target_image
+                params["image_raw_device"] = "yes"
+            else:
+                params["image_name"] = params["target_image"]
+                params["image_format"] = params["target_format"]
+            env_process.preprocess_vm(test, params, env, params["main_vm"])
+            vm = env.get_vm(params["main_vm"])
+            timeout=int(params.get("login_timeout", 600))
+            session = vm.wait_for_login(timeout=timeout)
+            session.cmd(params.get("alive_check_cmd", "dir"), timeout=120)
+            session.close()
+            vm.destroy()
     finally:
         mirror_test.clean()


### PR DESCRIPTION
New test to mirroring block device to nfs server/iscsi disk

Signed-off-by: Xu Tian xutian@redhat.com
