### PR TITLE
virttest.remote: Update password and login prompt in handle_prompts function

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -121,7 +121,7 @@ def handle_prompts(session, username, password, prompt, timeout=10, debug=False)
     while True:
         try:
             match, text = session.read_until_last_line_matches(
-                [r"[Aa]re you sure", r"[Pp]assword:\s*$", r"[Ll]ogin:\s*$",
+                [r"[Aa]re you sure", r"[Pp]assword:\s*", r"[Ll]ogin:\s*",
                  r"[Cc]onnection.*closed", r"[Cc]onnection.*refused",
                  r"[Pp]lease wait", r"[Ww]arning", prompt],
                 timeout=timeout, internal_timeout=0.5)


### PR DESCRIPTION
```
some kernel msg makes autotest confusing:
"Password: mtrr: type mismatch for c0000000,1000000 old: uncachable new: write-combining"

Then we may got error
"Unhandled LoginAuthenticationError: Got username prompt twice"

This update just want to make password and login prompt still works in this situation.
```
