### PR TITLE
Shell prompt

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -6,7 +6,7 @@
     shutdown_command = shutdown /s /f /t 0
     reboot_command = shutdown /r /f /t 0
     status_test_command = echo %errorlevel%
-    shell_prompt = "^\w:\\.*>\s*$"
+    shell_prompt = "^\w:\\.*\w*\\?\w*>\s*$"
     username = Administrator
     # Attention: Changing the password in this file is not supported,
     # since files in winutils.iso use it.


### PR DESCRIPTION
share.cfg.Windows.cfg: Make shell_prompt works with telnet.

```
telnet prompt in widows is "C:\Users\Administrator>".
So update shell_prompt to make it works with both "C:\Users\Administrator>"
and "C:\>"
```
