### PR TITLE
libvirt: fix the shutoff tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
@@ -39,5 +39,6 @@
                     destroy_extra = "xyz"
                 - shutdown_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - with_libvirtd_stop:
                     libvirtd = "off"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkinfo.cfg
@@ -19,6 +19,7 @@
                     domblkinfo_vm_ref = "uuid"
                 - shutoff_option:
                     start_vm = "no"
+                    kill_vm_before_test = "yes"
                 - vm_attach_disk:
                     domblkinfo_vm_ref = "test_attach_disk"
                     domblkinfo_front_dev = "vdd"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
@@ -14,6 +14,7 @@
                     domid_vm_ref = "uuid"
                 - shutoff_option:
                     start_vm = "no"
+                    kill_vm_before_test = "yes"
                 - remote:
                     domid_vm_ref = "remote"
                     remote_ip = "REMOTE.EXAMPLE.COM"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
@@ -38,6 +38,7 @@
                     domjobinfo_extra = "xyz"
                 - shutoff_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - save_option:
                     domjobinfo_pre_vm_state = "save"
                 - with_libvirtd_stop:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
@@ -44,3 +44,4 @@
                - shutoff_option:
                    reboot_vm_ref = "name"
                    start_vm = no
+                   kill_vm_before_test = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -38,5 +38,6 @@
                     shutdown_extra = "xyz"
                 - shutdown_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - with_libvirtd_stop:
                     libvirtd = "off"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_suspend.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_suspend.cfg
@@ -36,3 +36,4 @@
                     suspend_extra = "xyz"
                 - shutdown_option:
                     start_vm = "no"
+                    kill_vm_before_test = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpuinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpuinfo.cfg
@@ -17,6 +17,7 @@
                 - name_option:
                 - shutoff_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - paused_option:
                     paused_after_start_vm = yes
                 - uuid_option:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vncdisplay.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vncdisplay.cfg
@@ -24,6 +24,7 @@
             variants:
                 - shutoff_option:
                     start_vm = "no"
+                    kill_vm_before_test = "yes"
                 - no_option:
                     vncdisplay_vm_ref = ""
                 - hex_id_option:

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domifstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domifstat.cfg
@@ -37,6 +37,7 @@
                     domifstat_extra = "xyz"
                 - shutoff_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - no_interface_option:
                     domifstat_nic_ref = ""
                 - error_interface_option:

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dominfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dominfo.cfg
@@ -16,6 +16,7 @@
                     dominfo_vm_ref = "uuid"
                 - shutoff_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - remote:
                     dominfo_vm_ref = "remote"
                     remote_ip = "REMOTE.EXAMPLE.COM"

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dommemstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dommemstat.cfg
@@ -39,5 +39,6 @@
                     dommemstat_extra = "xyz"
                 - shutoff_option:
                     start_vm = no
+                    kill_vm_before_test = "yes"
                 - with_libvirtd_stop:
                     libvirtd = "off"


### PR DESCRIPTION
The shutoff tests need to have the guest in offline state.
Adding this option ensure that the guest will be offline
before test starts.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
