### PR TITLE
virsh_list: Adjust test to SKIP remote test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_list.cfg
@@ -59,11 +59,11 @@
                     addition_status_error = "no"
                     remote_ref = "remote"
                     #remote host's IP
-                    remote_ip = "127.0.0.1"
+                    remote_ip = "REMOTE.EXAMPLE.COM"
                     #remote host's password
-                    remote_passwd = "password"
+                    remote_passwd = ""
                     #local host's ip
-                    local_ip = "127.0.0.1"
+                    local_ip = "LOCAL.EXAMPLE.COM"
                 - with_libvirt_off:
                     only with_valid_options
                     addition_status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
@@ -101,9 +101,12 @@ def run_virsh_list(test, params, env):
 
     remote_ref = params.get("remote_ref", "local")
     if remote_ref == "remote":
-        remote_ip = params.get("remote_ip", "none")
-        remote_passwd = params.get("remote_passwd", "none")
-        local_ip = params.get("local_ip", "none")
+        remote_ip = params.get("remote_ip", "REMOTE.EXAMPLE.COM")
+        remote_passwd = params.get("remote_passwd", None)
+        local_ip = params.get("local_ip", "LOCAL.EXAMPLE.COM")
+        if remote_ip.count("EXAMPLE.COM") or local_ip.count("EXAMPLE.COM"):
+            raise error.TestNAError(
+                "Remote test parameters unchanged from default")
         logging.info("Execute virsh command on remote host %s.", remote_ip)
         status, output = list_local_domains_on_remote(
             options_ref, remote_ip, remote_passwd, local_ip)


### PR DESCRIPTION
Following other tests (destroy, domid, reboot, setvcpus, undefine,
vncdisplay, dominfo, dommemstat, domstate) - adjust the defaults for
the local_ip to be "LOCAL.EXAMPLE.COM" and the remote_ip to be
"REMOTE.EXAMPLE.COM" in order to cause the test to be skipped if
the defaults weren't changed.

Signed-off-by: John Ferlan jferlan@redhat.com
