### PR TITLE
virsh_shutdown: Adjust test to SKIP remote test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -16,9 +16,9 @@
                     shutdown_vm_ref = "uuid"
                 - remote_option:
                     shutdown_vm_ref = "remote"
-                    local_ip = 193.168.221.194
-                    remote_ip = 193.168.221.166
-                    remote_pwd = password
+                    local_ip = "LOCAL.EXAMPLE.COM"
+                    remote_ip = "REMOTE.EXAMPLE.COM"
+                    remote_pwd = ""
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -42,9 +42,12 @@ def run_virsh_shutdown(test, params, env):
     if vm_ref != "remote":
         status = virsh.shutdown(vm_ref, ignore_status=True).exit_status
     else:
-        remote_ip = params.get("remote_ip", None)
+        remote_ip = params.get("remote_ip", "REMOTE.EXAMPLE.COM")
         remote_pwd = params.get("remote_pwd", None)
-        local_ip = params.get("local_ip", None)
+        local_ip = params.get("local_ip", "LOCAL.EXAMPLE.COM")
+        if remote_ip.count("EXAMPLE.COM") or local_ip.count("EXAMPLE.COM"):
+            raise error.TestNAError(
+                "Remote test parameters unchanged from default")
         status = 0
         try:
             remote_uri = libvirt_vm.complete_uri(local_ip)


### PR DESCRIPTION
Following other tests (destroy, domid, reboot, setvcpus, undefine,
vncdisplay, dominfo, dommemstat, domstate) - adjust the defaults for
the local_ip to be "LOCAL.EXAMPLE.COM" and the remote_ip to be
"REMOTE.EXAMPLE.COM" in order to cause the test to be skipped if
the defaults weren't changed.
