### PR TITLE
virsh_update_device: Replace --persistent with --live

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -15,9 +15,8 @@
                         - force_option:
                             updatedevice_flag = "--force"
                             updatedevice_twice = "yes"
-                        - persistent_option:
-                            # Will fail on older libvirt: RH BZ 961443
-                            updatedevice_flag = "--persistent"
+                        - live_option:
+                            updatedevice_flag = "--live"
                         - config_option:
                             updatedevice_flag = "--config"
                         - force_diff_iso_option:
@@ -30,11 +29,16 @@
                     updatedevice_vm_ref = "uuid"
                 - diff_option:
                     updatedevice_diff_file = "yes"
-                - name_persistent_option:
-                    # Will fail on older libvirt: RH BZ 961443
-                    updatedevice_flag = "--persistent"
+                - name_live_option:
+                    updatedevice_flag = "--live"
                 - config_option:
                     updatedevice_flag = "--config"
+                - shut_off_option:
+                    # This may fail on older libvirt, but should work
+                    # on more recent versions
+                    updatedevice_diff_file = "yes"
+                    start_vm = "no"
+                    kill_vm_before_test = "yes"
         - error_test:
             status_error = "yes"
             variants:
@@ -52,3 +56,5 @@
                     updatedevice_extra = xyz
                 - shut_off_option:
                     start_vm = "no"
+                    updatedevice_flag = "--live"
+                    kill_vm_before_test = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -145,9 +145,16 @@ def run_virsh_update_device(test, params, env):
         if status != 0:
             raise error.TestFail("Run failed with right command")
         else:
-            if flag == "--persistent" or flag == "--config":
+            if flag == "--live":
+                if not re.search(tmp_iso, output):
+                    raise error.TestFail("virsh update-device function invalid "
+                                         "didn't see 'attached device' in XML")
+                if re.search(tmp_iso, output_shut):
+                    raise error.TestFail("virsh update-device function invalid "
+                                         "can see 'attached device' in XML")
+            if flag == "--config":
                 if not re.search(tmp_iso, output_shut):
-                    raise error.TestFail("virsh update-device function invalid"
+                    raise error.TestFail("virsh update-device function invalid "
                                          "didn't see 'attached device' in XML")
             else:
                 if params.has_key("updatedevice_diff_file"):
@@ -157,12 +164,13 @@ def run_virsh_update_device(test, params, env):
                                                            context_after)
                     if not re.search(tmp_iso, "\n".join(list(output_diff))):
                         raise error.TestFail("virsh update-device function "
-                                             "invalid; can't see 'attached device'in before/after")
+                                             "invalid; can't see 'attached "
+                                             "device'in before/after")
                 else:
                     if re.search(tmp_iso, output_shut):
                         raise error.TestFail("virsh attach-device without "
-                                             "--persistent/--config function invalid;can see "
-                                             "'attached device'in XML")
+                                             "--live/--config function invalid "
+                                             "can see 'attached device'in XML")
             if diff_iso == "yes":
                 check_attach(tmp2_iso, output)
             if vm_ref == "name":


### PR DESCRIPTION
Adjust the test to use the newer --live option rather than --persistent.

Also fix issue with shut_off_option testing.  When a guest is off, the
failure should only be if someone passed the --live flag.  Add the
shut_off_option testing to the normal_test list and use the diff_file
check to ensure that a shutdown guest would be updated.  The --live
option processing should only affect the running guest and not the
configuration after shutdown

Signed-of-by: John Ferlan jferlan@redhat.com
