### PR TITLE
Get rid of the installer registration concept

### DIFF
--- a/tests/build.py
+++ b/tests/build.py
@@ -1,5 +1,5 @@
 from autotest.client.shared import error
-from virttest import installer, base_installer
+from virttest import installer
 
 
 def run_build(test, params, env):
@@ -17,25 +17,16 @@ def run_build(test, params, env):
     minor_failure = False
     minor_failure_reasons = []
 
-    try:
-        for name in params.get("installers", "").split():
-            installer_obj = installer.make_installer(name, params, test)
-            installer_obj.install()
-            installer_obj.write_version_keyval(test)
-            if installer_obj.minor_failure is True:
-                minor_failure = True
-                reason = "%s_%s: %s" % (installer_obj.name,
-                                        installer_obj.mode,
-                                        installer_obj.minor_failure_reason)
-                minor_failure_reasons.append(reason)
-            env.register_installer(installer_obj)
-
-    except Exception, e:
-        # if the build/install fails, don't allow other tests
-        # to get a installer.
-        msg = "Virtualization software install failed: %s" % (e)
-        env.register_installer(base_installer.FailedInstaller(msg))
-        raise
+    for name in params.get("installers", "").split():
+        installer_obj = installer.make_installer(name, params, test)
+        installer_obj.install()
+        installer_obj.write_version_keyval(test)
+        if installer_obj.minor_failure is True:
+            minor_failure = True
+            reason = "%s_%s: %s" % (installer_obj.name,
+                                    installer_obj.mode,
+                                    installer_obj.minor_failure_reason)
+            minor_failure_reasons.append(reason)
 
     if minor_failure:
         raise error.TestWarn("Minor (worked around) failures during build "

--- a/tests/module_probe.py
+++ b/tests/module_probe.py
@@ -8,19 +8,11 @@ def run_module_probe(test, params, env):
     """
     load/unload kernel modules several times.
 
-    The test can run in two modes:
-
-    - based on previous 'build' test: in case kernel modules were installed by a
-      'build' test, we used the modules installed by the previous test.
-
-    - based on own params: if no previous 'build' test was run,
-      we assume pre-installed kernel modules.
+    This tests the kernel pre-installed kernel modules
     """
-    installer_object = env.previous_installer()
-    if installer_object is None:
-        installer_object = base_installer.NoopInstaller('noop',
-                                                        'module_probe',
-                                                        test, params)
+    installer_object = base_installer.NoopInstaller('noop',
+                                                    'module_probe',
+                                                    test, params)
     logging.debug('installer object: %r', installer_object)
 
     # unload the modules before starting:

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -168,19 +168,3 @@ class Env(UserDict.IterableUserDict):
         :param port: Sync Server port.
         """
         return self.data.get("sync__%s" % port)
-
-    def register_installer(self, installer):
-        """
-        Register a installer that was just run
-
-        The installer will be available for other tests, so that
-        information about the installed KVM modules and qemu-kvm can be used by
-        them.
-        """
-        self.data['last_installer'] = installer
-
-    def previous_installer(self):
-        """
-        Return the last installer that was registered
-        """
-        return self.data.get('last_installer')


### PR DESCRIPTION
This is a legacy of the days where the kvm kernel modules would
be installed either by compiling the source code or via "kmod"
like packages, and the loading and unloading of kernel modules
would depend on that.

Nowadays, we can assume that the kvm modules always come from
the kernel packages.

One last piece of refiniment here would be to remove the module
loading/unloading feature from the base installer code.

Signed-off-by: Cleber Rosa crosa@redhat.com
