### PR TITLE
openvswitch: Fix due to moving with python modules.

### DIFF
--- a/openvswitch/tests/load_module.py
+++ b/openvswitch/tests/load_module.py
@@ -1,7 +1,10 @@
 import sys
 import traceback
 import logging
-from autotest.client.shared import openvswitch, error, utils
+from virttest import openvswitch
+from virttest import versionable_class
+from autotest.client.shared import error
+from autotest.client.shared import utils
 
 
 @error.context_aware
@@ -14,7 +17,7 @@ def run_load_module(test, params, env):
     try:
         try:
             error.context("Remove all bridge from OpenVSwitch.")
-            ovs = openvswitch.OpenVSwitch(test.tmpdir)
+            ovs = versionable_class.factory(openvswitch.OpenVSwitchSystem)(test.tmpdir)
             ovs.init_system()
             ovs.check()
             for br in ovs.list_br():


### PR DESCRIPTION
makes load_module test working again

Signed-off-by: Jiří Župka jzupka@redhat.com
