### PR TITLE
adding qemu sandboxing option

### DIFF
--- a/run
+++ b/run
@@ -303,6 +303,10 @@ class VirtTestRunParser(optparse.OptionParser):
                               " ".join(SUPPORTED_DISK_BUSES) +
                               ". If -c is provided, this will be ignored. "
                               "Default: %default"))
+        qemu.add_option("--qemu_sandbox", action="store", dest="sandbox",
+                        default="off",
+                        help=("Enable qemu sandboxing "
+                              "(on/off). Default: %default"))
         self.add_option_group(qemu)
 
 
@@ -484,6 +488,13 @@ class VirtTestApp(object):
         else:
             logging.info("Config provided, ignoring --vhost option")
 
+    def _process_qemu_sandbox(self):
+        if not self.options.config:
+            if self.options.qemu_sandbox == "on":
+                self.cartesian_parser.assign("qemu_sandbox","on")
+        else:
+            logging.info("Config provided, ignoring \"--sandbox on\" option")
+
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
                                      self.options.malloc_perturb)
@@ -505,6 +516,7 @@ class VirtTestApp(object):
         self._process_disk_buses()
         self._process_vhost()
         self._process_malloc_perturb()
+        self._process_qemu_sandbox()
 
     def _process_lvsb_specific_options(self):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -354,6 +354,10 @@ class VM(virt_vm.BaseVM):
         def add_name(devices, name):
             return " -name '%s'" % name
 
+        def add_sandbox(devices):
+            if devices.has_option("sandbox"):
+                return " -sandbox on "
+
         def add_human_monitor(devices, monitor_name, filename):
             if not devices.has_option("chardev"):
                 return " -monitor unix:'%s',server,nowait" % filename
@@ -1058,6 +1062,9 @@ class VM(virt_vm.BaseVM):
         devices.insert(StrDev('-S', cmdline="-S"))
         # Add the VM's name
         devices.insert(StrDev('vmname', cmdline=add_name(devices, name)))
+
+        if params.get("sandbox", "off") == "on":
+            devices.insert(StrDev('sandbox', cmdline=add_sandbox(devices)))
 
         devs = devices.machine_by_params(params)
         for dev in devs:


### PR DESCRIPTION
Adding new command line argument to "./run" script: "-s,--qemu_sandbox".
It enables the Qemu command line argument "-sandbox on", running all
tests with the system call filter turned on.

Signed-off-by: Eduardo Otubo otubo@linux.vnet.ibm.com
