### PR TITLE
libvirt: rename all libvirt tests from virsh_* to virsh.*

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -1,4 +1,4 @@
-- virsh_attach_detach_disk:
+- virsh.attach_detach_disk:
     type = virsh_attach_detach_disk
     take_regular_screendumps = 'no'
     start_vm = 'no'

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
@@ -1,4 +1,4 @@
-- virsh_attach_detach_interface:
+- virsh.attach_detach_interface:
     type = virsh_attach_detach_interface
     start_vm = "yes"
     at_detach_iface_options_suffix = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_autostart.cfg
@@ -1,4 +1,4 @@
-- virsh_autostart:
+- virsh.autostart:
     type = virsh_autostart
     persistent_vm = "yes"
     readonly_mode = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -1,4 +1,4 @@
-- virsh_change_media:
+- virsh.change_media:
     virt_test_type = libvirt
     type = virsh_change_media
     change_media_update_iso_xml = "update_iso.xml"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
@@ -1,4 +1,4 @@
-- virsh_console:
+- virsh.console:
     type = virsh_console
     # Need to config console in xml
     # So vm should shut off at the beginning of test.

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_baseline.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_baseline.cfg
@@ -1,4 +1,4 @@
-- virsh_cpu_baseline:
+- virsh.cpu_baseline:
     type = virsh_cpu_baseline
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
@@ -1,4 +1,4 @@
-- virsh_cpu_compare:
+- virsh.cpu_compare:
     type = virsh_cpu_compare
     take_regular_screendumps = "no"
     cpu_compare_ref = "file"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_stats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_stats.cfg
@@ -1,4 +1,4 @@
-- virsh_cpu_stats:
+- virsh.cpu_stats:
     type = virsh_cpu_stats
     virt_test_type = libvirt
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_define.cfg
@@ -1,4 +1,4 @@
-- virsh_define: install setup image_copy unattended_install
+- virsh.define: install setup image_copy unattended_install
     type = virsh_define
     take_regular_screendumps = no
     encode_video_files = no

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_desc.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_desc.cfg
@@ -1,4 +1,4 @@
-- virsh_desc:
+- virsh.desc:
     type = virsh_desc
     desc_option = ""
     desc_str = "New Description/title for the vm"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
@@ -1,4 +1,4 @@
-- virsh_destroy:
+- virsh.destroy:
     virt_test_type = libvirt
     type = virsh_destroy
     take_regular_screendumps = no

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkinfo.cfg
@@ -1,4 +1,4 @@
-- virsh_domblkinfo:
+- virsh.domblkinfo:
     type = virsh_domblkinfo
     take_regular_screendumps = "no"
     kill_vm = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
@@ -1,4 +1,4 @@
-- virsh_domid:
+- virsh.domid:
     type = "virsh_domid"
     take_regular_screendumps = no
     domid_extra = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domif_setlink_getlink.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domif_setlink_getlink.cfg
@@ -1,4 +1,4 @@
-- virsh_domif_setlink_getlink:
+- virsh.domif_setlink_getlink:
     type = virsh_domif_setlink_getlink
     if_ifname_re = "\s*\d+:\s+([[a-zA-Z]+\d+):"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiflist.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiflist.cfg
@@ -1,4 +1,4 @@
-- virsh_domiflist:
+- virsh.domiflist:
     type = virsh_domiflist
     kill_vm = no
     kill_vm_on_error = yes

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
@@ -1,4 +1,4 @@
-- virsh_domiftune:
+- virsh.domiftune:
     type = virsh_domiftune
     libvirtd = "on"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobabort.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobabort.cfg
@@ -1,4 +1,4 @@
-- virsh_domjobabort:
+- virsh.domjobabort:
     type = virsh_domjobabort
     take_regular_screendumps = "no"
     jobabort_vm_ref = "name"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
@@ -1,4 +1,4 @@
-- virsh_domjobinfo:
+- virsh.domjobinfo:
     virt_test_type = libvirt
     type = virsh_domjobinfo
     take_regular_screendumps = no

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domname.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domname.cfg
@@ -1,4 +1,4 @@
-- virsh_domname:
+- virsh.domname:
     type = virsh_domname
     kill_vm = no
     kill_vm_on_error = yes

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domuuid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domuuid.cfg
@@ -1,4 +1,4 @@
-- virsh_domuuid:
+- virsh.domuuid:
     type = "virsh_domuuid"
     start_vm = "yes"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_from_native.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_from_native.cfg
@@ -1,4 +1,4 @@
-- virsh_domxml_from_native:
+- virsh.domxml_from_native:
     type = virsh_domxml_from_native
     take_regular_screendumps = no
     dfn_guest_args = "guest_args"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
@@ -1,4 +1,4 @@
-- virsh_domxml_to_native:
+- virsh.domxml_to_native:
     type = virsh_domxml_to_native
     take_regular_screendumps = no
     dtn_file_xml = "guest.xml"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
@@ -1,4 +1,4 @@
-- virsh_dump:
+- virsh.dump:
     type = virsh_dump
     dump_options = ""
     dump_file = "vm.core"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
@@ -1,4 +1,4 @@
-- virsh_dumpxml:
+- virsh.dumpxml:
     type = virsh_dumpxml
     start_vm = "yes"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
@@ -1,4 +1,4 @@
-- virsh_edit:
+- virsh.edit:
     virt_test_type = libvirt
     type = virsh_edit
     take_regular_screendumps = no

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
@@ -1,4 +1,4 @@
-- virsh_managedsave:
+- virsh.managedsave:
     type = virsh_managedsave
     managedsave_libvirtd = ""
     managedsave_extra_parame = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
@@ -1,4 +1,4 @@
-- virsh_memtune: install setup image_copy unattended_install.cdrom
+- virsh.memtune: install setup image_copy unattended_install.cdrom
     type = virsh_memtune
     # Values are in kbs
     memtune_base_mem = 1048576

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -1,4 +1,4 @@
-- virsh_migrate: install setup image_copy unattended_install.cdrom
+- virsh.migrate: install setup image_copy unattended_install.cdrom
     type = virsh_migrate
     # Migrating non-started VM causes undefined behavior
     start_vm = yes

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_multi_vms.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_multi_vms.cfg
@@ -1,4 +1,4 @@
-- virsh_migrate_multi_vms:
+- virsh.migrate_multi_vms:
     type = virsh_migrate_multi_vms
     status_error = "no"
     # Please set source and dest host with same password

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
@@ -1,4 +1,4 @@
-- virsh_migrate_setmaxdowntime:
+- virsh.migrate_setmaxdowntime:
     virt_test_type = libvirt
     type = virsh_migrate_setmaxdowntime
     # Execute migration when setting maxdowntime

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -1,4 +1,4 @@
-- virsh_migrate_stress:
+- virsh.migrate_stress:
     type = virsh_migrate_stress
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
@@ -1,4 +1,4 @@
-- virsh_numatune:
+- virsh.numatune:
     type = virsh_numatune
     libvirtd = "on"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
@@ -1,4 +1,4 @@
-- virsh_reboot:
+- virsh.reboot:
    virt_test_type = libvirt
    type = virsh_reboot
    reboot_extra = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -1,4 +1,4 @@
-- virsh_restore:
+- virsh.restore:
     type = virsh_restore
     restore_status_error = "yes"
     # Create a saved file of domain with virsh save by default

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
@@ -1,4 +1,4 @@
-- virsh_resume:
+- virsh.resume:
     type = virsh_resume
     start_vm = yes
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save.cfg
@@ -1,4 +1,4 @@
-- virsh_save:
+- virsh.save:
     type = virsh_save
     save_file = "save.file"
     save_libvirtd = "on"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
@@ -1,4 +1,4 @@
-- virsh_schedinfo_qemu_posix:
+- virsh.schedinfo_qemu_posix:
     type = virsh_schedinfo_qemu_posix
     schedinfo_options = ""
     schedinfo_options_suffix = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_xen_credit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_xen_credit.cfg
@@ -1,4 +1,4 @@
-- virsh_schedinfo_xen_credit:
+- virsh.schedinfo_xen_credit:
     type = virsh_schedinfo_xen_credit
     schedinfo_options = ""
     schedinfo_options_suffix = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmaxmem.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmaxmem.cfg
@@ -1,4 +1,4 @@
-- virsh_setmaxmem:
+- virsh.setmaxmem:
     type = virsh_setmaxmem
     start_vm = "yes"
     # TODO: Add variants for --config, --live, --current

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
@@ -1,4 +1,4 @@
-- virsh_setmem:
+- virsh.setmem:
     type = virsh_setmem
     kill_vm_on_error = "no"
     # TODO: Add variants for --config, --live, --current

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -1,4 +1,4 @@
-- virsh_setvcpus:
+- virsh.setvcpus:
     type = virsh_setvcpus
     setvcpus_command = "setvcpus"
     setvcpus_xml_file = "vm.xml"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -1,4 +1,4 @@
-- virsh_shutdown:
+- virsh.shutdown:
     type = virsh_shutdown
     shutdown_vm_ref = "name"
     shutdown_extra = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
@@ -1,4 +1,4 @@
-- virsh_start:
+- virsh.start:
     virt_test_type = libvirt
     type = virsh_start
     libvirtd = "on"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_suspend.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_suspend.cfg
@@ -1,4 +1,4 @@
-- virsh_suspend:
+- virsh.suspend:
     type = virsh_suspend
     kill_vm = "yes"
     suspend_vm_ref = "name"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_ttyconsole.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_ttyconsole.cfg
@@ -1,4 +1,4 @@
-- virsh_ttyconsole:
+- virsh.ttyconsole:
     type = virsh_ttyconsole
     # xml file need to be configured, do not start vm
     start_vm = no

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
@@ -1,4 +1,4 @@
-- virsh_undefine:
+- virsh.undefine:
     type = virsh_undefine
     take_regular_screendumps = no
     undefine_extra = ""

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -1,4 +1,4 @@
-- virsh_update_device:
+- virsh.update_device:
     type = virsh_update_device
     kill_vm = "yes"
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpuinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpuinfo.cfg
@@ -1,4 +1,4 @@
-- virsh_vcpuinfo:
+- virsh.vcpuinfo:
     type = virsh_vcpuinfo
     take_regular_screendumps = no
     vcpuinfo_vm_ref = "name"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
@@ -1,2 +1,2 @@
-- virsh_vcpupin: install setup image_copy unattended_install.cdrom
+- virsh.vcpupin: install setup image_copy unattended_install.cdrom
     type = virsh_vcpupin

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vncdisplay.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vncdisplay.cfg
@@ -1,4 +1,4 @@
-- virsh_vncdisplay:
+- virsh.vncdisplay:
     type = virsh_vncdisplay
     take_regular_screendumps = "no"
     vncdisplay_vm_ref = "name"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_capabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_capabilities.cfg
@@ -1,4 +1,4 @@
-- virsh_capabilities:
+- virsh.capabilities:
     type = virsh_capabilities
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_freecell.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_freecell.cfg
@@ -1,4 +1,4 @@
-- virsh_freecell:
+- virsh.freecell:
     type = virsh_freecell
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_hostname.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_hostname.cfg
@@ -1,4 +1,4 @@
-- virsh_hostname: install setup image_copy unattended_install.cdrom
+- virsh.hostname: install setup image_copy unattended_install.cdrom
     type = virsh_hostname
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_maxvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_maxvcpus.cfg
@@ -1,4 +1,4 @@
-- virsh_maxvcpus:
+- virsh.maxvcpus:
     type = virsh_maxvcpus
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_node_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_node_memtune.cfg
@@ -1,4 +1,4 @@
-- virsh_node_memtune:
+- virsh.node_memtune:
     type = virsh_node_memtune
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpustats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpustats.cfg
@@ -1,4 +1,4 @@
-- virsh_nodecpustats:
+- virsh.nodecpustats:
     type = virsh_nodecpustats
     vms = ''
 

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
@@ -1,4 +1,4 @@
-- virsh_nodeinfo:
+- virsh.nodeinfo:
     type = virsh_nodeinfo
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodememstats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodememstats.cfg
@@ -1,4 +1,4 @@
-- virsh_nodememstats:
+- virsh.nodememstats:
     type = virsh_nodememstats
     vms = ''
 

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -1,4 +1,4 @@
-- virsh_uri: install setup image_copy unattended_install.cdrom
+- virsh.uri: install setup image_copy unattended_install.cdrom
     type = virsh_uri
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_version.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_version.cfg
@@ -1,4 +1,4 @@
-- virsh_version: install setup image_copy unattended_install.cdrom
+- virsh.version: install setup image_copy unattended_install.cdrom
     type = virsh_version
     vms = ''
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domblkstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domblkstat.cfg
@@ -1,4 +1,4 @@
-- virsh_domblkstat:
+- virsh.domblkstat:
     type =virsh_domblkstat
     take_regular_screendumps = no
     domblkstat_vm_ref = "name"

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domifstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domifstat.cfg
@@ -1,4 +1,4 @@
-- virsh_domifstat:
+- virsh.domifstat:
     type = virsh_domifstat
     domifstat_vm_ref = "name"
     virt_test_type = libvirt

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dominfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dominfo.cfg
@@ -1,4 +1,4 @@
-- virsh_dominfo:
+- virsh.dominfo:
     type = virsh_dominfo
     take_regular_screendumps = no
     dominfo_extra = ""

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dommemstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_dommemstat.cfg
@@ -1,4 +1,4 @@
-- virsh_dommemstat:
+- virsh.dommemstat:
     type = "virsh_dommemstat"
     virt_test_type = "libvirt"
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -1,4 +1,4 @@
-- virsh_domstate:
+- virsh.domstate:
     virt_test_type = libvirt
     take_regular_screendumps = no
     type =virsh_domstate

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_list.cfg
@@ -1,4 +1,4 @@
-- virsh_list:
+- virsh.list:
     type = virsh_list
     vm_start = yes
     kill_vm = yes

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
@@ -1,4 +1,4 @@
-- virsh_net_autostart:
+- virsh.net_autostart:
     type = virsh_net_autostart
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_create.cfg
@@ -1,4 +1,4 @@
-- virsh_net_create:
+- virsh.net_create:
     type = virsh_net_create
     virt_test_type = libvirt
     # VM is not needed for this test

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
@@ -1,4 +1,4 @@
-- virsh_net_define_undefine:
+- virsh.net_define_undefine:
     type = virsh_net_define_undefine
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
@@ -1,4 +1,4 @@
-- virsh_net_destroy:
+- virsh.net_destroy:
     type = virsh_net_destroy
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dumpxml.cfg
@@ -1,4 +1,4 @@
-- virsh_net_dumpxml:
+- virsh.net_dumpxml:
     type = virsh_net_dumpxml
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_list.cfg
@@ -1,4 +1,4 @@
-- virsh_net_list:
+- virsh.net_list:
     type = virsh_net_list
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_name.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_name.cfg
@@ -1,4 +1,4 @@
-- virsh_net_name:
+- virsh.net_name:
     type = virsh_net_name
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
@@ -1,4 +1,4 @@
-- virsh_net_start:
+- virsh.net_start:
     vms = ""
     main_vm = ""
     type = virsh_net_start

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_uuid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_uuid.cfg
@@ -1,4 +1,4 @@
-- virsh_net_uuid:
+- virsh.net_uuid:
     type = virsh_net_uuid
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
@@ -1,4 +1,4 @@
-- virsh_nodedev_detach_reattach:
+- virsh.nodedev_detach_reattach:
     virt_test_type = libvirt
     type = virsh_nodedev_detach_reattach
     start_vm = "no"

--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
@@ -1,4 +1,4 @@
-- virsh_nodedev_dumpxml:
+- virsh.nodedev_dumpxml:
     virt_test_type = libvirt
     type = virsh_nodedev_dumpxml
     vms = ""

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
@@ -1,4 +1,4 @@
-- virsh_pool: install setup image_copy unattended_install.cdrom
+- virsh.pool: install setup image_copy unattended_install.cdrom
     virt_test_type = libvirt
     type = virsh_pool
     vms = ''

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create_as.cfg
@@ -1,4 +1,4 @@
-- virsh_pool_create_as:
+- virsh.pool_create_as:
     type = virsh_pool_create_as
     vms = ""
     # type in [ 'dir', 'fs', 'netfs', 'disk', 'iscsi', 'logical' ]

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot.cfg
@@ -1,4 +1,4 @@
-- virsh_snapshot:
+- virsh.snapshot:
     type = virsh_snapshot
     # Switching screendumps off as creating can pause guest for long time
     # and cause error messages

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -1,4 +1,4 @@
-- virsh_snapshot_create_as:
+- virsh.snapshot_create_as:
     type = virsh_snapshot_create_as
     virt_test_type = libvirt
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -1,4 +1,4 @@
-- virsh_snapshot_disk:
+- virsh.snapshot_disk:
     virt_test_type = libvirt
     type = virsh_snapshot_disk
     kill_vm = "no"

--- a/libvirt/tests/cfg/virsh_cmd/virsh_connect.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_connect.cfg
@@ -1,4 +1,4 @@
-- virsh_connect:
+- virsh.connect:
     virt_test_type = libvirt
     type = virsh_connect
     # VM is not needed for this test

--- a/libvirt/tests/cfg/virsh_cmd/virsh_help.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_help.cfg
@@ -1,4 +1,4 @@
-- virsh_help:
+- virsh.help:
     type = virsh_help
     vms = ""
     main_vm = ""

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create_from.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create_from.cfg
@@ -1,4 +1,4 @@
-- virsh_vol_create_from:
+- virsh.vol_create_from:
     type = virsh_vol_create_from
     start_vm = no
     prealloc_option = ""

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume.cfg
@@ -1,4 +1,4 @@
-- virsh_volume: install setup image_copy unattended_install.cdrom
+- virsh.volume: install setup image_copy unattended_install.cdrom
     virt_test_type = libvirt
     type = virsh_volume
     vms = ''

--- a/run
+++ b/run
@@ -320,7 +320,7 @@ DEFAULT_GUEST_OS = "JeOS.19"
 QEMU_DEFAULT_SET = "migrate..tcp, migrate..unix, migrate..exec, migrate..fd"
 LIBVIRT_DEFAULT_SET = (
     "unattended_install.import.import.default_install.aio_native, "
-    "virsh_domname, "
+    "virsh.domname, "
     "remove_guest.without_disk")
 LVSB_DEFAULT_SET = ("lvsb_date")
 OVS_DEFAULT_SET = ("load_module, ovs_basic")

--- a/v2v/cfg/tests.cfg
+++ b/v2v/cfg/tests.cfg
@@ -18,7 +18,7 @@ no pf_assignable
 # Install virt-v2v and ovirt-engine-sdk.
 #only build
 # Simple testing for automatically converting/importing an existing foreign VM into libvirt.
-only virsh_pool_create_as convert_libvirt linux_vm_check_local
+only virsh.pool_create_as convert_libvirt linux_vm_check_local
 
 # Simple testing for automatically converting/importing an existing foreign VM into oVirt.
 #only convert_ovirt ovirt linux_vm_check_remote


### PR DESCRIPTION
This rename is useful for testers who wants to run only virsh tests
and don't wan't to write list of all available tests. Now to run
all virsh tests just execute './run -t libvirt --tests=virsh'.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
