### PR TITLE
use blacklist instead of whitelist to filter out unsupported platform

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -1,5 +1,5 @@
 - watchdog: install setup image_copy unattended_install.cdrom
-    only RHEL.5, RHEL.6
+    no RHEL.3, Windows
     enable_watchdog = yes
     start_vm = no
     type = watchdog


### PR DESCRIPTION
so even there's new release we dont have to modify the cfg
and watchdog device is supported on all Linux distro

Signed-off-by: Xiaoqing Wei xwei@redhat.com
