### PR TITLE
virttest/qemu_monitor.py: Allow '=' in parameter string for HMP

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -740,7 +740,10 @@ class HumanMonitor(Monitor):
                 command = cmdline.split()[0]
                 cmdargs = " ".join(cmdline.split()[1:]).split(",")
                 for arg in cmdargs:
-                    command += " " + arg.split("=")[-1]
+                    value = "=".join(arg.split("=")[1:])
+                    if arg.split("=")[0] == "cert-subject":
+                        value = value.replace('/',',')
+                    command += " " + value
             else:
                 command = cmdline
             cmd_output.append(self.cmd(command, timeout))


### PR DESCRIPTION
Pull request #818 introduced a possibility to have "=" chars in parameters of send_args_cmd() method in HMP/QMP monitor.
But the code of parsing such parametres with "=" was added only to QMPMonitor and not to HumanMonitor class which causes SSL Spice migration with qemu monitor parameter "C=CZ/L=BRNO/O=SPICE/CN=my Server" to fail since obviously It uses HumanMonitor, instead of QMP Monitor (whatever the difference is).

Signed-off-by: Marian Krcmarik mkrcmari@redhat.com
