### PR TITLE
virttest: Add nfs set up and clean up code in env_process

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -181,6 +181,22 @@ image_unbootable_pattern = "Hard Disk.*not a bootable disk"
 # force_cleanup: if need logout and cleanup after the case. The value should
 #                be yes or no
 # emulated_file_remove(emulated iscsi only): If remove the file after logout
+
+# Nfs support related params. Please fill them depends on your environment
+# For both nfs and local export nfs, following parammeters should be set:
+# storage_type = nfs
+# nfs_mount_dir: the local dir your want to mount to
+# nfs_mount_options: mount options
+# For nfs you also need set this one:
+# nfs_mount_src: the nfs resource you use
+# For nfs export in local these options need be set:
+# export_dir: the dir export to users
+# nfs_mount_src: the nfs resource you use
+# At least one of the above parameters should be set. And id export_dir is
+# set, it will cover the value set in nfs_mount_src.
+# export_ip: optional.
+# export_options: optional.
+
 #
 # List of hypervisor-monitor object names (one per guest),
 #    used to communicate with hypervisor to control guests.


### PR DESCRIPTION
Add some nfs setup and cleanup related code in env_process.py to
let user can easily run cases with nfs by update cfg files. Also
update the nfs useage comments in base.cfg

Signed-off-by: Yiqiao Pu ypu@redhat.com
