### PR TITLE
virt: Fix run sandbox=>qemu_sandbox.

### DIFF
--- a/run
+++ b/run
@@ -303,7 +303,7 @@ class VirtTestRunParser(optparse.OptionParser):
                               " ".join(SUPPORTED_DISK_BUSES) +
                               ". If -c is provided, this will be ignored. "
                               "Default: %default"))
-        qemu.add_option("--qemu_sandbox", action="store", dest="sandbox",
+        qemu.add_option("--qemu_sandbox", action="store", dest="qemu_sandbox",
                         default="off",
                         help=("Enable qemu sandboxing "
                               "(on/off). Default: %default"))


### PR DESCRIPTION
repairs missing option in run

Signed-off-by: Jiří Župka jzupka@redhat.com
