### PR TITLE
timedrift.cfg: change the ntp, date variants

### DIFF
--- a/tests/cfg/timedrift.cfg
+++ b/tests/cfg/timedrift.cfg
@@ -18,7 +18,7 @@
                     # For now, make sure this test is executed alone
                     used_cpus = 100
                     variants:
-                        - @default:
+                        - @default_load:
                         - full_load:
                             test_duration = 28800
                             interval_gettime = 1800


### PR DESCRIPTION
Change the ntp, date variants to share the same with_load.
And add full_load variant for with_load.
Signed-off-by: Xiangmin Han xhan@redhat.com
