### PR TITLE
Setting --qemu_sandbox=on by default

### DIFF
--- a/run
+++ b/run
@@ -303,8 +303,8 @@ class VirtTestRunParser(optparse.OptionParser):
                               " ".join(SUPPORTED_DISK_BUSES) +
                               ". If -c is provided, this will be ignored. "
                               "Default: %default"))
-        qemu.add_option("--qemu_sandbox", action="store", dest="sandbox",
-                        default="off",
+        qemu.add_option("--qemu_sandbox", action="store", dest="qemu_sandbox",
+                        default="on",
                         help=("Enable qemu sandboxing "
                               "(on/off). Default: %default"))
         self.add_option_group(qemu)
@@ -490,10 +490,10 @@ class VirtTestApp(object):
 
     def _process_qemu_sandbox(self):
         if not self.options.config:
-            if self.options.qemu_sandbox == "on":
-                self.cartesian_parser.assign("qemu_sandbox","on")
+            if self.options.qemu_sandbox == "off":
+                self.cartesian_parser.assign("qemu_sandbox","off")
         else:
-            logging.info("Config provided, ignoring \"--sandbox on\" option")
+            logging.info("Config provided, ignoring \"--sandbox <on|off>\" option")
 
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -354,9 +354,13 @@ class VM(virt_vm.BaseVM):
         def add_name(devices, name):
             return " -name '%s'" % name
 
-        def add_sandbox(devices):
-            if devices.has_option("sandbox"):
-                return " -sandbox on "
+        def process_sandbox(devices, action):
+            if action == "add":
+                if devices.has_option("sandbox"):
+                    return " -sandbox on "
+            elif action == "rem":
+                if devices.has_option("sandbox"):
+                    return " -sandbox off "
 
         def add_human_monitor(devices, monitor_name, filename):
             if not devices.has_option("chardev"):
@@ -1063,8 +1067,11 @@ class VM(virt_vm.BaseVM):
         # Add the VM's name
         devices.insert(StrDev('vmname', cmdline=add_name(devices, name)))
 
-        if params.get("sandbox", "off") == "on":
-            devices.insert(StrDev('sandbox', cmdline=add_sandbox(devices)))
+        if params.get("qemu_sandbox", "on") == "on":
+            devices.insert(StrDev('sandbox', cmdline=process_sandbox(devices, "add")))
+        elif params.get("sandbox", "off") == "off":
+            devices.insert(StrDev('qemu_sandbox', cmdline=process_sandbox(devices, "rem")))
+
 
         devs = devices.machine_by_params(params)
         for dev in devs:


### PR DESCRIPTION
This commit sets the Qemu sandboxing to 'on' by default. It allows the
user to run all tests using this feature to catch missing system calls
and providing more feedback to the general security of Qemu.
