### PR TITLE
virsh.is_dead(): Resolve timing condition

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -926,10 +926,12 @@ def is_dead(name, **dargs):
         state = domstate(name, **dargs).stdout.strip()
     except error.CmdError:
         return True
-    if state in ('running', 'idle', 'no state', 'paused'):
-        return False
-    else:
+    if state not in ('running', 'idle', 'paused', 'in shutdown', 'shut off', \
+                     'crashed', 'pmsuspended', 'no state'):
+        logging.debug("State '%s' not known", state)
+    if state in ('shut off', 'crashed', 'no state'):
         return True
+    return False
 
 
 def suspend(name, **dargs):


### PR DESCRIPTION
Existing code didn't check for 'in shutdown' condition which led to
odd timing issues in various tests where is_dead() was returning true
during the "Trying to shutdown VM with shell command" path followed
by code attempting a startup which would fail because you cannot start
an already started guest.

Rather than add 'in shutdown' to the list of things to check - I flipped
the check to look for dead states and return true (per the comments).  I
also note that 'no state' was returning False previously which could
have caused false positives.

Since the list of checked states could grow over time, I added a check
for all currently known states and just print a message if a state
is not known.
