### PR TITLE
virt-libguestfs: add 'no nic_custom' to tests.cfg

### DIFF
--- a/libguestfs/cfg/tests.cfg
+++ b/libguestfs/cfg/tests.cfg
@@ -18,6 +18,7 @@ no spapr-vlan
 no 9p_export
 no vf_assignable
 no pf_assignable
+no nic_custom
 
 
 #only build


### PR DESCRIPTION
When you execute a libguestfs testcase, there will be 2 testcases running:
1. **_.raw.ide.smp2.rtl8139.**_*
2. **_.raw.ide.smp2.nic_custom.**_*
Now add 'no nic_custom' to filter the second case

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
