### PR TITLE
virt: Set spapr-vscsi for default in ppc64

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -23,7 +23,7 @@
         stress_kill_cmd = "rm -f /tmp/disk_stress"
     variants:
         - all_types:
-            stg_params = "fmt:virtio,virtio_scsi,lsi_scsi,usb2"
+            stg_params = "fmt:virtio,virtio_scsi,lsi_scsi,spapr_vscsi,usb2"
             usbs += " ehci"
             usb_type_ehci = usb-ehci
         - single_type:

--- a/qemu/tests/multi_disk_random_hotplug.py
+++ b/qemu/tests/multi_disk_random_hotplug.py
@@ -7,7 +7,7 @@ import logging
 import random
 from autotest.client.shared import error
 from virttest import qemu_devices, qemu_qtree, utils_test, env_process
-from virttest import funcatexit
+from virttest import funcatexit, arch
 import time
 
 
@@ -140,6 +140,9 @@ def run_multi_disk_random_hotplug(test, params, env):
             elif fmt == 'lsi_scsi':
                 args['fmt'] = 'scsi-hd'
                 args['scsi_hba'] = 'lsi53c895a'
+            elif fmt == 'spapr_vscsi':
+                args['fmt'] = 'scsi-hd'
+                args['scsi_hba'] = 'spapr-vscsi'
             else:
                 args['fmt'] = fmt
             # Other params

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -2,7 +2,7 @@ import re
 import logging
 import string
 from autotest.client.shared import error
-from virttest import utils_misc, aexpect, storage, utils_test, data_dir
+from virttest import utils_misc, aexpect, storage, utils_test, data_dir, arch
 
 
 @error.context_aware
@@ -104,7 +104,10 @@ def run_pci_hotplug(test, params, env):
 
         if pci_model == "scsi":
             pci_model = "scsi-disk"
-            controller_model = "lsi53c895a"
+            if arch.ARCH == 'ppc64':
+                controller_model = "spapr-vscsi"
+            else:
+                controller_model = "lsi53c895a"
             verify_supported_device(controller_model)
             controller_id = "controller-" + device_id
             controller_add_cmd = ("device_add %s,id=%s" %

--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -10,6 +10,7 @@ import re
 import storage
 import data_dir
 import utils_misc
+import arch
 
 
 OFFSET_PER_LEVEL = 2
@@ -475,7 +476,10 @@ class QtreeDisksContainer(object):
             """ checks the drive format according to qtree info """
             expected = params.get('drive_format')
             if expected == 'scsi':
-                expected = 'lsi53c895a'
+                if arch.ARCH == 'ppc64':
+                    expected = 'spapr-vscsi'
+                else:
+                    expected = 'lsi53c895a'
             elif expected.startswith('scsi'):
                 expected = params.get('scsi_hba', 'virtio-scsi-pci')
             elif expected.startswith('usb'):


### PR DESCRIPTION
The default scsi hba is lsi53c895a, but in ppc64, it is spapr-vscsi.

This patch to enable spapr-vscsi in ppc64 platform.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
