### PR TITLE
virt-libvirt: Fix typo in virsh schedinfo(qemu) test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -27,7 +27,7 @@ def run_virsh_schedinfo_qemu_posix(test, params, env):
     """
     def get_parameter_in_cgroup(domname, controller="cpu",
                                 parameter="cpu.shares",
-                                libvirt_cgroup_path="/libvirt/qemu/"):
+                                libvirt_cgroup_path="libvirt/qemu/"):
         """
         Get vm's cgroup value.
 


### PR DESCRIPTION
os.path.join("/cgroup/cpu", "/libvirt/qemu", "vm1") will
return "/libvirt/qemu/vm1", not "/cgroup/cpu/libvirt/qemu/vm1",
so I modify 'libvirt_cgroup_path' default value from
"/libvirt/qemu" to "libvirt/qemu"

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
