### PR TITLE
virsh_uri: Change TestError to TestNAError

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -21,7 +21,7 @@ def run_virsh_uri(test, params, env):
     remote_ref = params.get("uri_remote_ref", "")
     if target_uri:
         if target_uri.count('EXAMPLE.COM'):
-            raise error.TestError(
+            raise error.TestNAError(
                 'target_uri configuration set to sample value')
         logging.info("The target_uri: %s", target_uri)
         cmd = "virsh -c %s uri" % target_uri


### PR DESCRIPTION
Following lead of similar tests that use the EXAMPLE.COM
checking, use TestNAError rather than TestError to result
in SKIP instead of ERROR for test
