### PR TITLE
virsh_net_create: Remove incorrect redundant test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_create.cfg
@@ -65,8 +65,6 @@
                             net_create_options_ref = "no_file"
                         - no_exist_file:
                             net_create_options_ref = "no_exist_file"
-                        - existing_network:
-                            net_create_remove_existing = "no"
                 - bad_contents:
                     # These may actually define some networks
                     net_create_remove_existing = "yes"


### PR DESCRIPTION
Remove the 'variant' for 'existing_network' within the variants for
bad_command_line.  Since each of the error_test variants already has
a 'no_existing_removal' and 'existing_removal' option, the removed
code would was redundant. Additionally, since the existing_network
option didn't have a net_create_options_ref, net_create_options_extra,
or net_create_corrupt_xml parameter, the test went through the high
level test code which was not expected for error_test code unless
the net_create_remove_existing is set to yes.
