### PR TITLE
virsh_net_autostart: Rework test to not use 'default'

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
@@ -5,6 +5,7 @@
     encode_video_files = no
     skip_image_processing = yes
     take_regular_screendumps = no
+    net_autostart_net_name = "autotest"
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_autostart.py
@@ -1,6 +1,6 @@
 import logging
 from autotest.client.shared import error
-from virttest import virsh, libvirt_vm, utils_libvirtd
+from virttest import virsh, libvirt_vm, xml_utils, utils_libvirtd
 from virttest.libvirt_xml import network_xml, xcepts
 
 
@@ -15,6 +15,7 @@ def run_virsh_net_autostart(test, params, env):
     net_ref = params.get("net_autostart_net_ref", "netname")
     disable = "yes" == params.get("net_autostart_disable", "no")
     extra = params.get("net_autostart_extra", "")  # extra cmd-line params.
+    net_name = params.get("net_autostart_net_name", "autotest")
 
     # Make easy to maintain
     virsh_dargs = {'uri': uri, 'debug': False, 'ignore_status': True}
@@ -25,41 +26,73 @@ def run_virsh_net_autostart(test, params, env):
     backup_state = virsh_instance.net_state_dict()
     logging.debug("Backed up network(s): %s", backup_state)
 
+    # Generate our own bridge
+    # First check if a bridge of this name already exists
     try:
-        default_xml = backup['default']
+        check_xml = backup[net_name]
     except (KeyError, AttributeError):
-        raise error.TestNAError("Test requires default network to exist")
+        pass  # Not found - good
+    else:
+        raise error.TestNAError("Found network bridge '%s' - skipping" %
+                                (net_name))
+
+    # Define a very bare bones bridge, don't provide UUID - use whatever
+    # libvirt ends up generating.  We need to define a persistent network
+    # since we'll be looking to restart libvirtd as part of this test.
+    #
+    # This test cannot use the 'default' bridge (virbr0) since undefining
+    # it causes issues for libvirtd restart since it's expected that a
+    # default network is defined
+    #
+    temp_bridge = """
+<network>
+   <name>%s</name>
+   <bridge name="vir%sbr0"/>
+</network>
+""" % (net_name, net_name)
+    test_xml = xml_utils.TempXMLFile()  # temporary file
+    try:
+        # LibvirtXMLBase.__str__ returns XML content
+        test_xml.write(temp_bridge)
+        test_xml.flush()
+    except (KeyError, AttributeError):
+        raise error.TestNAError("Test requires create temporary network file")
 
     # To guarantee cleanup will be executed
     try:
-        # Remove all network before test
-        for netxml in backup.values():
-            netxml.orbital_nuclear_strike()
+        # Run test case
+        define_result = virsh.net_define(test_xml.name, "", **virsh_dargs)
+        logging.debug(define_result)
+        define_status = define_result.exit_status
 
-        # Prepare default property for network
-        # Transeint network can not be set autostart
-        # So confirm persistent is true for test
-        default_xml['persistent'] = True
-        netname = "default"
-        netuuid = default_xml.uuid
-
-        # Set network 'default' to inactive
-        # Since we do not reboot host to check(instead of restarting libvirtd)
-        # If default network is active, we cann't check "--disable".
-        # Because active network will not be inactive after restarting libvirtd
-        # even we set autostart to False. While inactive network will be active
-        # after restarting libvirtd if we set autostart to True
-        default_xml['active'] = False
-
+        # Get the updated list and make sure our new bridge exists
         currents = network_xml.NetworkXML.new_all_networks_dict(virsh_instance)
         current_state = virsh_instance.net_state_dict()
         logging.debug("Current network(s): %s", current_state)
+        try:
+            testbr_xml = currents[net_name]
+        except (KeyError, AttributeError):
+            raise error.TestError("Did not find newly defined bridge '%s'" %
+                                  (net_name))
+
+        # Prepare default property for network
+        # Transient network can not be set autostart
+        # So confirm persistent is true for test
+        testbr_xml['persistent'] = True
+
+        # Set network to inactive
+        # Since we do not reboot host to check(instead of restarting libvirtd)
+        # If default network is active, we cannot check "--disable".
+        # Because active network will not be inactive after restarting libvirtd
+        # even we set autostart to False. While inactive network will be active
+        # after restarting libvirtd if we set autostart to True
+        testbr_xml['active'] = False
 
         # Prepare options and arguments
         if net_ref == "netname":
-            net_ref = netname
+            net_ref = testbr_xml.name
         elif net_ref == "netuuid":
-            net_ref = netuuid
+            net_ref = testbr_xml.uuid
 
         if disable:
             net_ref += " --disable"
@@ -79,38 +112,31 @@ def run_virsh_net_autostart(test, params, env):
         #       we'd better check it with host reboot.
         utils_libvirtd.libvirtd_restart()
 
-        # Reopen default_xml
+        # Reopen testbr_xml
         virsh_instance = virsh.VirshPersistent(**virsh_dargs)
         currents = network_xml.NetworkXML.new_all_networks_dict(virsh_instance)
         current_state = virsh_instance.net_state_dict()
         logging.debug("Current network(s): %s", current_state)
-        default_xml = currents['default']
-        is_active = default_xml['active']
+        testbr_xml = currents[net_name]
+        is_active = testbr_xml['active']
 
     finally:
-        # Recover environment
-        leftovers = network_xml.NetworkXML.new_all_networks_dict(
-            virsh_instance)
-        for netxml in leftovers.values():
-            netxml.orbital_nuclear_strike()
+        if is_active:
+            # Stop network for undefine test anyway
+            destroy_result = virsh.net_destroy(net_name, extra="",
+                                               **virsh_dargs)
+            logging.debug(destroy_result)
 
-        # Recover from backup
-        for netxml in backup.values():
-            # If network is transient
-            if ((not backup_state[netxml.name]['persistent'])
-               and backup_state[netxml.name]['active']):
-                netxml.create()
-                continue
-            # autostart = True requires persistent = True first!
-            for state in ['persistent', 'autostart', 'active']:
-                try:
-                    netxml[state] = backup_state[netxml.name][state]
-                except xcepts.LibvirtXMLError:
-                    pass
+        # Undefine network
+        undefine_result = virsh.net_undefine(net_name, "", **virsh_dargs)
+        logging.debug(undefine_result)
 
         # Close down persistent virsh session (including for all netxml copies)
         if hasattr(virsh_instance, 'close_session'):
             virsh_instance.close_session()
+
+    # Delete temporary file
+    del test_xml
 
     # Check Result
     if status_error:


### PR DESCRIPTION
Reworked the code to not use the 'default' network bridge since
doing so may result in issues with the target system expectations
that virbr0 (the 'default' network bridge) exists and is running
when the libvirtd is restarted as part of the test.

Instead, create our own network bridge using a new configuration
option 'net_autostart_net_name', then apply the same logic regarding
being able to set or disable the autostart flag.
