### PR TITLE
add scsi-target-utils pkg to support migrate.after_extensive_io.iscsi

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/3.9.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/3.9.cfg
@@ -1,7 +1,7 @@
 - 3.9:
     no virtio_net, virtio_blk, e1000
     no setup autotest linux_s3 guest_s4 shutdown multi_disk xfstests
-    no usb_multi_disk, balloon_check
+    no usb_multi_disk, balloon_check migrate.after_extensive_io.iscsi
     mem_chk_cmd = dmidecode | awk -F: '/Maximum Capacity/ {print $2}'
     image_name = images/rhel39
     unattended_install, check_block_size.4096_512, check_block_size.512_512:

--- a/shared/cfg/guest-os/Linux/RHEL/4.7.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/4.7.cfg
@@ -1,5 +1,5 @@
 - 4.7:
-    no setup autotest xfstests
+    no setup autotest xfstests migrate.after_extensive_io.iscsi
     image_name = images/rhel47
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-4-series.ks

--- a/shared/cfg/guest-os/Linux/RHEL/4.8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/4.8.cfg
@@ -1,5 +1,5 @@
 - 4.8:
-    no setup autotest xfstests
+    no setup autotest xfstests migrate.after_extensive_io.iscsi
     image_name = images/rhel48
     unattended_install, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/RHEL-4-series.ks

--- a/shared/unattended/Fedora-16.ks
+++ b/shared/unattended/Fedora-16.ks
@@ -22,6 +22,7 @@ autopart
 @base
 @development-libs
 @development-tools
+scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/Fedora-17.ks
+++ b/shared/unattended/Fedora-17.ks
@@ -23,6 +23,7 @@ autopart
 @development-libs
 @development-tools
 dmidecode
+scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/Fedora-18.ks
+++ b/shared/unattended/Fedora-18.ks
@@ -23,6 +23,7 @@ autopart
 @development-libs
 @development-tools
 dmidecode
+scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/Fedora-19.ks
+++ b/shared/unattended/Fedora-19.ks
@@ -22,6 +22,7 @@ autopart
 @standard
 @development-tools
 dmidecode
+scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/RHEL-5-series.ks
+++ b/shared/unattended/RHEL-5-series.ks
@@ -46,6 +46,7 @@ lsscsi
 libaio-devel
 perl-Time-HiRes
 NetworkManager
+scsi-target-utils
 
 %post
 echo "OS install is completed" > /dev/ttyS0

--- a/shared/unattended/RHEL-6-series.ks
+++ b/shared/unattended/RHEL-6-series.ks
@@ -59,6 +59,7 @@ libaio-devel
 perl-Time-HiRes
 glibc-devel
 glibc-static
+scsi-target-utils
 
 %post
 echo "OS install is completed" > /dev/ttyS0


### PR DESCRIPTION
support RHEL.5/6 Fedora
and disable legacy rhel guests as they dont have such pkg

Signed-off-by: Xiaoqing Wei xwei@redhat.com
