### PR TITLE
Ubuntu guest system_reset_bootable fix

### DIFF
--- a/shared/unattended/Ubuntu-12-04.preseed
+++ b/shared/unattended/Ubuntu-12-04.preseed
@@ -48,4 +48,8 @@ d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf
+echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+echo "#!/bin/sh -e" > /target/etc/rc.local; \
+echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
+echo "exit 0" >> /target/etc/rc.local

--- a/shared/unattended/Ubuntu-12-10.preseed
+++ b/shared/unattended/Ubuntu-12-10.preseed
@@ -48,4 +48,8 @@ d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf
+echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+echo "#!/bin/sh -e" > /target/etc/rc.local; \
+echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
+echo "exit 0" >> /target/etc/rc.local

--- a/shared/unattended/Ubuntu-13-04.preseed
+++ b/shared/unattended/Ubuntu-13-04.preseed
@@ -48,4 +48,8 @@ d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf
+echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+echo "#!/bin/sh -e" > /target/etc/rc.local; \
+echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
+echo "exit 0" >> /target/etc/rc.local

--- a/shared/unattended/Ubuntu-13-10.preseed
+++ b/shared/unattended/Ubuntu-13-10.preseed
@@ -48,4 +48,8 @@ d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf
+echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+echo "#!/bin/sh -e" > /target/etc/rc.local; \
+echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
+echo "exit 0" >> /target/etc/rc.local


### PR DESCRIPTION
As Ubuntu would make grub stop OS selection screen
when it encountering power loss, thus case after
system_reset_bootable would be blocked, adding
a workaround, OS older then 12.04 are not cared.

Signed-off-by: Xiaoqing Wei xwei@redhat.com
