### PR TITLE
iometer_windows.performance.msi_on: disable WinXP/2003 as it dont suppor...

### DIFF
--- a/shared/cfg/guest-os/Windows/Win2003.cfg
+++ b/shared/cfg/guest-os/Windows/Win2003.cfg
@@ -15,3 +15,6 @@
         update_cmd = cmd /c D:\whql\WUInstall.exe /install /criteria "IsHidden=0 and IsInstalled=0 and IsAssigned=1"
     physical_resources_check:
         catch_serial_cmd =
+    no iometer_windows.performance.msi_on
+    # MSI is not supported on WinXP/2003
+    # download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/PCI-PCIe_FAQ.doc

--- a/shared/cfg/guest-os/Windows/WinXP.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP.cfg
@@ -11,3 +11,6 @@
         post_snapshot_cmd = {shell:cmd /c D:\wua_update.exe && cmd /c net stop wuauserv && cmd /c net start wuauserv && D:\whql\WUInstall.exe /install}
     physical_resources_check:
         catch_serial_cmd =
+    no iometer_windows.performance.msi_on
+    # MSI is not supported on WinXP/2003
+    # download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/PCI-PCIe_FAQ.doc


### PR DESCRIPTION
WinXP/2003 dont support MSI, so this case
is expected to fail

Signed-off-by: Xiaoqing Wei xwei@redhat.com
