### PR TITLE
virttest.virt_vm: Do not check index error by 'self.virtnet < index'.

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2191,7 +2191,7 @@ class VM(virt_vm.BaseVM):
                     session = self.login()
                 else:
                     session = self.serial_login()
-            except (virt_vm.VMInterfaceIndexError), e:
+            except (IndexError), e:
                 try:
                     session = self.serial_login()
                 except (remote.LoginError, virt_vm.VMError), e:

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -614,8 +614,6 @@ class BaseVM(object):
         :raise VMAddressVerificationError: If the MAC-IP address mapping cannot
                 be verified (using arping)
         """
-        if self.virtnet < index:
-            raise VMInterfaceIndexError()
         nic = self.virtnet[index]
         # TODO: Determine port redirection in use w/o checking nettype
         if nic.nettype not in ['bridge', 'macvtap']:


### PR DESCRIPTION
parameter index may be a string or int. When it is a string,
VMInterfaceIndexError() will be raised. It is not what we want.

No matter string or int used, self.virtnet[index] will raise IndexError()
for unavailable index.

So remove
        if self.virtnet < index:
            raise VMInterfaceIndexError()

And catch
IndexError in graceful_shutdown() in qemu_vm.py.

Signed-off-by: Feng Yang fyang@redhat.com
