### PR TITLE
disable cases used netsh on WinXP

### DIFF
--- a/shared/cfg/guest-os/Windows/WinXP.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP.cfg
@@ -14,3 +14,7 @@
     no iometer_windows.performance.msi_on
     # MSI is not supported on WinXP/2003
     # download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/PCI-PCIe_FAQ.doc
+    no jumbo, mac_change
+    # netsh interface set interface name="Local Area Connection" admin=DISABLED
+    # this cmd works since Win2003
+    # http://support.microsoft.com/kb/262265 http://forum.sysinternals.com/command-used-to-disable-network-interface_topic9483_page1.html


### PR DESCRIPTION
As WinXP is buggy on 'netsh interface set' sub commands,
not worth to fix on such out of date OS, disabling.

Signed-off-by: Xiaoqing Wei xwei@redhat.com
