### PR TITLE
virt.virtnet : update vm.virtnet when guest reboot

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -524,6 +524,13 @@ class BaseVM(object):
             if not glob.glob("/tmp/*%s" % self.instance):
                 break
 
+    def update_vm_id(self):
+        """
+        Update vm identifier, we need do that when force reboot vm, since vm
+        virnet params may be changed.
+        """
+        self._generate_unique_id()
+
     @staticmethod
     def lookup_vm_class(vm_type, target):
         if vm_type == 'qemu':


### PR DESCRIPTION
When start a guest with one nic device, then start a guest with two
nics(don't remove env), the second nic can not be init correctly.
When boot guest with nic_extra_params, then boot another guest w/o
this option, the second guest will boot with nic_extra_params
unexpectedly.
The root cause of these issues is we don't update virtnet when
preprocess VM object

Signed-off-by: Yunping Zheng yunzheng@redhat.com
