### PR TITLE
virt: Ignore exception detail if debug is False

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1098,7 +1098,9 @@ def domain_exists(name, **dargs):
         command("domstate %s" % name, **dargs)
         return True
     except error.CmdError, detail:
-        logging.warning("VM %s does not exist:\n%s", name, detail)
+        logging.warning("VM %s does not exist", name)
+        if dargs.get('debug', False):
+            logging.warning(str(detail))
         return False
 
 


### PR DESCRIPTION
For now, when use virsh.domain_exists() or vm.exists()
to check a guest, if it's not exist, there will be some
exception details printed in log, this may confuse users,
this will make them think there is an error happened.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
