### PR TITLE
Minor fix to unattended_install.cdrom.floppy_ks for legacy SLES

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES/10.4.i386.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/10.4.i386.cfg
@@ -14,5 +14,6 @@
         md5sum_cd1 = 277912f7503df68322820c955c8adce8
         md5sum_1m_cd1 = 282453620102c7b9d7386fc623420b91
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-10-32/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/10.4.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/10.4.x86_64.cfg
@@ -14,5 +14,6 @@
         md5sum_cd1 = b07e59b7cba66b995f97eef42e28f5c3
         md5sum_1m_cd1 = ac4963cf50b683972491a3fd1da64cc1
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-10-64/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/11.0.i386.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/11.0.i386.cfg
@@ -13,5 +13,6 @@
         md5sum_cd1 = 4958d4dde2575666355c8a1c5858bab0
         md5sum_1m_cd1 = 1f19d4eff5bcead2a3e5b8b4212b6796
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-11-0-32/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/11.0.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/11.0.x86_64.cfg
@@ -16,5 +16,6 @@
         md5sum_cd1 = 50a2bd45cd12c3808c3ee48208e2586b
         md5sum_1m_cd1 = 00000951cab7c32e332362fc424c1054
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-11-0-64/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/11.1.i386.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/11.1.i386.cfg
@@ -13,5 +13,6 @@
         md5sum_cd1 = 0dd6886858d93501c38854552b9b1b0d
         md5sum_1m_cd1 = a626a3d50813410e3ac42794e05773bb
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-11-1-32/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/11.1.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/11.1.x86_64.cfg
@@ -13,5 +13,6 @@
         md5sum_cd1 = d2e10420f3689faa49a004b60fb396b7
         md5sum_1m_cd1 = f7f67b5da46923a9f01da8a2b6909654
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-11-1-64/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/11.2.i386.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/11.2.i386.cfg
@@ -13,5 +13,6 @@
         md5sum_cd1 = a0b34f6237b2b2a6b2174c82b40ed326
         md5sum_1m_cd1 = e5a629f311cdfa7477880e7349a1f00d
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-11-2-32/autoyast.vfd

--- a/shared/cfg/guest-os/Linux/SLES/11.2.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/11.2.x86_64.cfg
@@ -13,5 +13,6 @@
         md5sum_cd1 = 461d82ae6e15062b0807c1338f040497
         md5sum_1m_cd1 = 2ad34f9d84267e732929ea977c5be47e
     unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autounattend.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"
         floppy_name = images/sles-11-2-64/autoyast.vfd

--- a/shared/unattended/SLES-10.xml
+++ b/shared/unattended/SLES-10.xml
@@ -551,9 +551,11 @@ echo ttyS0 >> /etc/securetty]]>
         <filename>config</filename>
         <source><![CDATA[dhclient eth0
 chkconfig sshd on
+chkconfig NetworkManager on
 sed -i -e 's/\(PasswordAuthentication\s\)no/\1yes/g'  /etc/ssh/sshd_config
 service sshd restart
 service network restart
+service NetworkManager restart
 ]]></source>
       </script>
     </init-scripts>
@@ -565,6 +567,7 @@ service network restart
       <package>lsscsi</package>
       <package>libaio-devel</package>
       <package>perl-Time-HiRes</package>
+      <package>NetworkManager</package>
     </packages>
     <patterns config:type="list">
       <pattern>Basis-Devel</pattern>

--- a/tests/unattended_install.py
+++ b/tests/unattended_install.py
@@ -689,13 +689,13 @@ class UnattendedInstallConfig(object):
         elif self.unattended_file.endswith('.xml'):
             if "autoyast" in self.kernel_params:
                 # SUSE autoyast install
-                dest_fname = "autoinst.xml"
+                dest_fname = "autounattend.xml"
                 if (self.cdrom_unattended and
                         self.params.get('unattended_delivery_method') == 'cdrom'):
                     boot_disk = utils_disk.CdromDisk(self.cdrom_unattended,
                                                      self.tmpdir)
                 elif self.floppy:
-                    autoyast_param = 'autoyast=floppy'
+                    autoyast_param = 'autoyast=device://fd0/autounattend.xml'
                     kernel_params = self.kernel_params
                     if 'autoyast=' in kernel_params:
                         kernel_params = re.sub('autoyast\=[\w\d\:\.\/]+',


### PR DESCRIPTION
1) change dest_fname to "autounattend.xml", as most cfg used.
2) change autoyast_param from floppy to 'autoyast=device://fd0/autounattend.xml'
    for old SLES OS compatibility.
3) add kernel_params for all existing SLES

Signed-off-by: Xiaoqing Wei xwei@redhat.com
