### PR TITLE
libvirt_vm: fix for setup_serial_console.

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -825,11 +825,10 @@ class VM(virt_vm.BaseVM):
                 self.params.objects("isa_serials")]
 
     def setup_serial_ports(self):
-        if self.serial_ports is not None:
-            return   # Assume they're already set up
-        self.serial_ports = []
-        for serial in self.params.objects("isa_serials"):
-            self.serial_ports.append(serial)
+        if self.serial_ports is None:
+            self.serial_ports = []
+            for serial in self.params.objects("isa_serials"):
+                self.serial_ports.append(serial)
         if self.serial_console is None:
             # Attempt to setup serial0
             try:


### PR DESCRIPTION
Sometimes, VM.serial_ports is not None, but the VM.serial_console is None,
then we need to setup a serial_console in VM.setup_serial_console() method,
instead of returning immediatly.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
