### PR TITLE
libvirt-tests: tweak the logic of test for virsh_setmem in negative test...

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -239,8 +239,16 @@ def run_virsh_setmem(test, params, env):
         if status is 0:
             raise error.TestFail("Error test did not result in an error")
         else:  # status != 0
-            if not old_libvirt:  # new libvirt should not have returned error
+            if status_error == "yes":
+                # Pass in negative case.
+                logging.debug("Command failed in negative case.")
+                return
+            if (old_libvirt_fail == "yes") and old_libvirt:
+                # Pass in negative case for older libvirt.
+                logging.debug("Command failed in negative case for older libvirt.")
+                return
+            if (old_libvirt_fail == "yes") and (not old_libvirt):
                 raise error.TestFail("Newer libvirt failed when it should not")
-            else:
-                # Test passes for old_libvirt is True
-                pass
+            # status == "no" and old_libvirt_fail == "no"
+            raise error.TestFail("Command failed in positive case.\n"
+                                 "Detail: %s." % result.stderr)


### PR DESCRIPTION
...s.

In negative tests of virsh_setmem, we need to check the different varialbles
of status_error and old_libvirt_fail.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
