### PR TITLE
virsh_dumpxml: Need to populate output

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -65,6 +65,7 @@ def run_virsh_dumpxml(test, params, env):
     logging.info("Command:virsh dumpxml %s", vm_ref)
     try:
         cmd_result = virsh.dumpxml(vm_ref, extra=options_ref)
+        output = cmd_result.stdout.strip()
         if cmd_result.exit_status:
             raise error.TestFail("dumpxml %s failed.\n"
                                  "Detail: %s.\n" % (vm_ref, cmd_result))


### PR DESCRIPTION
Commit id '7bdea150' removed the setting of output in the try/except
to call virsh.dumpxml, resulting in the error:

UnboundLocalError: local variable 'output' referenced before assignment.

This change just sets output from the cmd_result
