### PR TITLE
virsh_emulatorpin: Fix syntax error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -236,5 +236,5 @@ def run_virsh_emulatorpin(test, params, env):
 
     # Recover cgconfig and libvirtd service
     if not cg.cgconfig_is_running():
-        cg.cgconfig_restart()()
+        cg.cgconfig_restart()
         utils_libvirtd.service_libvirtd_control("restart")


### PR DESCRIPTION
Commit id '80a1cd7b2' called cgconfig_restart()(), this resulted in
a python syntax error:

TypeError: 'bool' object is not callable

Just removed the extraneous ().
