### PR TITLE
Rename test from "virsh_" to "virsh."

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_dumpxml.cfg
@@ -1,4 +1,4 @@
-- virsh_snapshot_dumpxml:
+- virsh.snapshot_dumpxml:
     type = virsh_snapshot_dumpxml
     take_regular_screendumps = "no"
     snapshot_name = "snap_test"


### PR DESCRIPTION
Address test that was missed in the 'b5f2911a' commit to change all
tests from "virsh__" to "virsh._"
