### PR TITLE
quick fix to Fedora - remove a no in compose pkg from ks

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora.cfg
@@ -1,5 +1,5 @@
 - Fedora:
-    no setup
+    no setup, migrate.after_extensive_io.iscsi
     shell_prompt = "^\[.*\][\#\$]\s*$"
     os_variant = virtio26
     unattended_install:

--- a/shared/unattended/Fedora-16.ks
+++ b/shared/unattended/Fedora-16.ks
@@ -22,7 +22,6 @@ autopart
 @base
 @development-libs
 @development-tools
-scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/Fedora-17.ks
+++ b/shared/unattended/Fedora-17.ks
@@ -23,7 +23,6 @@ autopart
 @development-libs
 @development-tools
 dmidecode
-scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/Fedora-18.ks
+++ b/shared/unattended/Fedora-18.ks
@@ -23,7 +23,6 @@ autopart
 @development-libs
 @development-tools
 dmidecode
-scsi-target-utils
 %end
 
 %post

--- a/shared/unattended/Fedora-19.ks
+++ b/shared/unattended/Fedora-19.ks
@@ -22,7 +22,6 @@ autopart
 @standard
 @development-tools
 dmidecode
-scsi-target-utils
 %end
 
 %post


### PR DESCRIPTION
```
as migrate.after_extensive_io.iscsi needs scsi-target-utils
and actually Fedora didn't include it in the compose,
so the previous adding of it is a mistake, now remove it.
also gray out the case for Fedora.

CC: Jiri Zupka <jzupka@redhat.com>
```
