### PR TITLE
virttest.qemu_devices: Fix cdrom filename

### DIFF
--- a/virttest/qemu_devices.py
+++ b/virttest/qemu_devices.py
@@ -2957,6 +2957,7 @@ class DevContainer(object):
             image_params['image_name'] = os.path.join(data_dir.get_data_dir(),
                                                       image_params.get('cdrom')
                                                       )
+            image_params['image_raw_device'] = 'yes'
         cd_format = image_params.get('cd_format')
         if cd_format is None or cd_format is 'ide':
             if not self.get_buses({'atype': 'ide'}):


### PR DESCRIPTION
CDROM filenames doesn't use suffixes. Use image_raw_device to
get the correct image name.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
