### PR TITLE
virttest.qemu_vm: Log information about the parent PID and the monitor n...

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -122,6 +122,7 @@ def create_monitor(vm, monitor_name, monitor_params):
             monitor_creator = HumanMonitor
 
     monitor_filename = get_monitor_filename(vm, monitor_name)
+    logging.info("Connecting to monitor '%s'", monitor_name)
     monitor = monitor_creator(vm, monitor_name, monitor_filename)
     monitor.verify_responsive()
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1996,6 +1996,8 @@ class VM(virt_vm.BaseVM):
             self.process = aexpect.run_bg(qemu_command, None,
                                           logging.info, "[qemu output] ",
                                           auto_close=False)
+            logging.info("Created qemu process with parent PID %d",
+                         self.process.get_pid())
             self.start_time = time.time()
 
             # test doesn't need to hold tapfd's open


### PR DESCRIPTION
When starting the qemu process, there is not much information about
the running parent PID (the autotest shell script that starts qemu) or
the monitor name that we are trying to connect (for example, hmp1).

So with this commit we're logging this information when qemu is started,
in order to provide information for debugging. Example:

When running  `./run -t qemu --tests=uptime --qemu_sandbox=on` (uptime is just a random test I created),
from debug.log:

<pre>
11:43:17 INFO | Created qemu process with parent PID 15592
11:43:17 INFO | Connecting to monitor 'hmp1'
11:44:17 WARNI| Could not find (qemu) prompt after connecting to monitor. Output so far: ''
11:44:18 ERROR| Could not connect to monitor 'hmp1'
11:44:18 DEBUG| Destroying VM virt-tests-vm1 (PID 15594)
</pre>


Parent PID is 15592, now we are trying to find what is wrong...

<pre>
ps -ef | grep 15592
rmoura   15592 15591  0 11:43 pts/3    00:00:00 /bin/bash -c source /tmp/autotestbMRLRL.sh
rmoura   15594 15592  0 11:43 pts/3    00:00:00 [qemu-system-x86] <defunct>
</pre>


In this situation, it's clear that qemu-system-x86_64 goes bad.
