### PR TITLE
Attempt to fix the "RuntimeError"

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -77,7 +77,13 @@ class Env(UserDict.IterableUserDict):
         if filename is None:
             raise EnvSaveError("No filename specified for this env file")
         f = open(filename, "w")
-        pickle.dump(self.data, f)
+
+        tmp_data = self.data.copy()
+        for key,value in tmp_data.iteritems():
+            if type(value) == type(dict()):
+                tmp_data[key] = self.data[key].copy()
+
+        pickle.dump(tmp_data, f)
         f.close()
 
     def get_all_vms(self):


### PR DESCRIPTION
Hi all, this is my second attempt to fix this long known issue.

The root cause of the bug is that we are running another thread with tcpdump and this thread is accessing directly the env["address_cache"] dictionary. If you are on network with a lot of clients, there is a better chance to get this error. The thread is updating/adding a pair of mac:ip records into the "address_cache" dictionary and this could also happens during the "pickle.dump()" operation.

By this patch I'm preventing to happen it again. It's not a fix of the root problem, because it will require to rewrite a lot of code to disable direct access to nested dictionaries inside the ENV dictionary. This is needed to add some locking mechanism into the Env class to prevent this happening anymore.

This patch should be considered as some kind of temporary fix to prevent the pickle to raise the "RuntimeError".
