### PR TITLE
qemu.tests: Use qemu-kvm -M ? to get machine type for physical resource ...

### DIFF
--- a/qemu/tests/cfg/physical_resources_check.cfg
+++ b/qemu/tests/cfg/physical_resources_check.cfg
@@ -10,7 +10,6 @@
     # useless for linux guest.
     vio_driver_chk_cmd = ""
     mem_chk_re_str = (\b[0-9]+\b)
-    mtype_pattern = '\d.\d.\d'
     cpu_cores_chk_cmd = "lscpu | grep '^Core'"
     cpu_sockets_chk_cmd = "lscpu | grep -E '(^Socket|^CPU socket)'"
     cpu_threads_chk_cmd = "lscpu | grep '^Thread'"


### PR DESCRIPTION
...check

The old method to get expect machine type can not fit machine type check for
q35 and pc. So update it by get the machine type string from the output
of qemu-kvm -M ?.
