### PR TITLE
virttest: Add new environment methods to start/stop tcpdump

### DIFF
--- a/tests/netperf.py
+++ b/tests/netperf.py
@@ -203,13 +203,7 @@ def run_netperf(test, params, env):
             username = params_tmp["username"]
             env_setup(i, ip_dict[i], username, shell_port, password)
 
-    if "tcpdump" in env and env["tcpdump"].is_alive():
-        # Stop the background tcpdump process
-        try:
-            logging.debug("Stopping the background tcpdump")
-            env["tcpdump"].close()
-        except Exception:
-            pass
+    env.stop_tcpdump()
 
     error.context("Start netperf testing", logging.info)
     start_test(server_ip, server_ctl, host, clients, test.resultsdir,

--- a/tests/netstress_kill_guest.py
+++ b/tests/netstress_kill_guest.py
@@ -96,16 +96,7 @@ def run_netstress_kill_guest(test, params, env):
         guest_netperf_cmd = params.get("netperf_cmd") % ("/tmp", "TCP_STREAM",
                                                          server_ip, params.get("packet_size", "1500"))
 
-        tcpdump = env.get("tcpdump")
-        pid = None
-        if tcpdump:
-            # Stop the background tcpdump process
-            try:
-                pid = int(utils.system_output("pidof tcpdump"))
-                logging.debug("Stopping the background tcpdump")
-                os.kill(pid, signal.SIGSTOP)
-            except Exception:
-                pass
+        env.stop_tcpdump()
 
         try:
             logging.info("Start heavy network load host <=> guest.")
@@ -118,10 +109,7 @@ def run_netstress_kill_guest(test, params, env):
 
         finally:
             utils.run(clean_cmd, ignore_status=True)
-            if tcpdump and pid:
-                logging.debug("Resuming the background tcpdump")
-                logging.info("pid is %s" % pid)
-                os.kill(pid, signal.SIGCONT)
+            env.start_tcpdump()
 
     def netdriver_kill_problem(session_serial):
         modules = get_ethernet_driver(session_serial)

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -20,6 +20,7 @@ import cartesian_config
 import arch
 import funcatexit
 import version
+import aexpect
 
 global GUEST_NAME_LIST
 GUEST_NAME_LIST = None
@@ -900,4 +901,6 @@ def run_tests(parser, options):
     job_elapsed_time = job_end_time - job_start_time
     _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed)
 
+    # Finish any remaining tcpdump threads floating around
+    aexpect.kill_tail_threads()
     return not failed


### PR DESCRIPTION
There is a background tcpdump thread that records DHCP leases
in the env["address_cache"] dictionary. Sometimes, this thread
might write to this dictionary while the environment object is
being saved, triggering a RuntimeError in virt-test.

After discussing for a while and drafting solutions for the
problem, we came to the conclusion that just stopping the
tcpdump thread at the end of test postprocessing is fine,
and significantly simpler than introducing locking to the
environment file.

The decision I made of moving the tcpdump handling to the
env class is because this should be mostly transparent to
test writers, while giving them the option to stop the
thread in special tests that would require it so (netperf
is one example). In fact, the tests in the tree that need
to do that were changed to use the new methods.

I am not 100% happy with how the code turned out, what do you say @ehabkost and @Antique ?
