### PR TITLE
virttest.libvirt_vm: Raise stderr of virsh.start after starting failed.

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1460,8 +1460,7 @@ class VM(virt_vm.BaseVM):
             if autoconsole:
                 self.setup_serial_ports()
         else:
-            raise virt_vm.VMStartError(self.name, "libvirt domain failed "
-                                                  "to start")
+            raise virt_vm.VMStartError(self.name, result.stderr)
 
     def wait_for_shutdown(self, count=60):
         """


### PR DESCRIPTION
Double "VM failed to start." will be printed out here.
It's not easy to know what's the real reason, so replacing one with result.stderr.

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
