### PR TITLE
virsh_volume: Adjust for upstream change

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
@@ -115,7 +115,7 @@ def run_virsh_volume(test, params, env):
         volume_detail = None
         found = False
         for line in output.stdout.splitlines():
-            match = re.search(rg, line)
+            match = re.search(rg, line.lstrip())
             if match is not None:
                 vol['name'] = match.group(1)
                 vol['path'] = match.group(2)


### PR DESCRIPTION
Upstream change adjusted the output of the virsh vol-list command
output to have a space in the front of the line, see:

https://www.redhat.com/archives/libvir-list/2013-November/msg00380.html

Add a strategic ".lstrip()" to the re.search() on the output
