### PR TITLE
virsh_vcpucount: Adjust --guest option testing

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpucount.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpucount.cfg
@@ -8,7 +8,7 @@
                 - shutoff_test:
                     vcpucount_pre_vm_state = "shut off"
                     variants:
-                        - wrong_opiton:
+                        - wrong_option:
                             vcpucount_options = "--xyz"
                         - guest_option:
                             vcpucount_options = "--guest"
@@ -25,7 +25,7 @@
                 - running_test:
                     vcpucount_pre_vm_state = "running"
                     variants:
-                        - wrong_opiton:
+                        - wrong_option:
                             vcpucount_options = "--xyz"
                         - config_guest_option:
                             vcpucount_options = "--guest --config"


### PR DESCRIPTION
Couple of issues here. First there was no check to see if the
guest agent was running in the guest. The test would fail as
written with:

stderr: error: argument unsupported: QEMU guest agent is not configured

So borrow from virsh_snapshot_create_as.py and add code to check
and start the guest agent.

Even though the guest agent was running, the underlying QEMU may not
support the 'guest-get-vcpus' option as it was only added as of 1.5.
The error message received is:

 stderr: error: internal error: unable to execute QEMU agent command
 'guest-get-vcpus': The command guest-get-vcpus has not been found

So as a secondary fix - add a check for the stderr check and exit with
SKIP rather than FAIL.

Finally fixed a spelling error in the CFG file from "opiton" to "option"
