### PR TITLE
libvirt: Add virsh net-info command test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_netinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_netinfo.cfg
@@ -1,0 +1,33 @@
+- virsh.netinfo:
+    type = virsh_netinfo
+    vms = ""
+    main_vm = ""
+    status_error = "no"
+    encode_video_files = "no"
+    skip_image_processing = "yes"
+    take_regular_screendumps = "no"
+    net_uuid_network = "default"
+    net_uuid_net_ref = "name"
+    variants:
+        - normal_test:
+            status_error = "no"
+            variants:
+                - name_option:
+                    netinfo_net_ref = name
+                - uuid_option:
+                    netinfo_net_ref = uuid
+        - error_test:
+            status_error = "yes"
+            variants:
+                - space_option:
+                    netinfo_net_ref = "''"
+                - no_option:
+                    netinfo_net_ref = ""
+                - invalid_name_option:
+                    netinfo_net_ref = "netinfo_invalid_name"
+                    netinfo_invalid_name = "invalid_name"
+                - invalid_uuid_option:
+                    netinfo_net_ref = "netinfo_invalid_uuid"
+                    netinfo_invalid_uuid = "99999999-9999-9999-9999-9999999999"
+                - additional_option:
+                    netinfo_options_extra = "xyz"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_netinfo.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_netinfo.py
@@ -1,0 +1,55 @@
+import logging
+from autotest.client.shared import error
+from virttest import virsh, libvirt_vm
+from virttest.libvirt_xml import network_xml
+
+def run_virsh_netinfo(test, params, env):
+    """
+    Test command: virsh net-info <network>
+
+    The command returns basic information about virtual network.
+    """
+
+    # Gather test parameters
+    uri = libvirt_vm.normalize_connect_uri(params.get("connect_uri",
+                                                      "default"))
+    status_error = params.get("status_error", "no")
+    net_ref = params.get("netinfo_net_ref", "name")
+    extra = params.get("netinfo_options_extra", "")
+
+    virsh_dargs = {'uri': uri, 'debug': False, 'ignore_status': True}
+    virsh_instance = virsh.VirshPersistent(**virsh_dargs)
+
+    # Get all network instance
+    origin_nets = network_xml.NetworkXML.new_all_networks_dict(virsh_instance)
+
+    # Prepare default network for following test.
+    try:
+        default_netxml = origin_nets['default']
+    except KeyError:
+        virsh_instance.close_session()
+        raise error.TestNAError("'default' virtual network is required.")
+
+    if net_ref == "name":
+        net_ref = default_netxml.name
+    elif net_ref == "uuid":
+        net_ref = default_netxml.uuid
+    elif net_ref.find("invalid") != -1:
+        net_ref = params.get(net_ref)
+
+    # Run test case
+    result = virsh.net_info(net_ref, extra, **virsh_dargs)
+    logging.debug(result)
+    status = result.exit_status
+    output = result.stdout.strip()
+    err = result.stderr.strip()
+
+    virsh_instance.close_session()
+
+    # Check status_error
+    if status_error == "yes":
+        if status == 0 or err == "":
+            raise error.TestFail("Run successfully with wrong command!")
+    elif status_error == "no":
+        if status != 0 or output == "":
+            raise error.TestFail("Run failed with right command")

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1496,6 +1496,18 @@ def net_autostart(network, extra="", **dargs):
     return command("net-autostart %s %s" % (network, extra), **dargs)
 
 
+def net_info(network, extra="", **dargs):
+    """
+    Get network infomation
+
+    :param network: name/parameter for network option/argument
+    :param extra: extra parameters to pass to command.
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult instance
+    """
+    return command("net-info %s %s" % (network, extra), **dargs)
+
+
 def pool_info(name, **dargs):
     """
     Returns basic information about the storage pool.


### PR DESCRIPTION
New testcase: virsh_netinfo.py
virttest.virsh: virsh net-info function
net_info(network, extra="", **dargs)
