### PR TITLE
virttest.utils_env: Check the whether the key is none before using it.

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -175,7 +175,7 @@ class Env(UserDict.IterableUserDict):
         """
         vm_list = []
         for key in self.data.keys():
-            if key.startswith("vm__"):
+            if key and key.startswith("vm__"):
                 vm_list.append(self.data[key])
         return vm_list
 


### PR DESCRIPTION
When get vm objects from Env object, the key of the data maybe None.
if the key is None, will raise error like:
   'NoneType' object has no attribute 'startswith'.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
