### PR TITLE
virt.test: modify vhost config for file_transfer test

### DIFF
--- a/tests/cfg/file_transfer.cfg
+++ b/tests/cfg/file_transfer.cfg
@@ -7,8 +7,17 @@
         - remote:
             transfer_type = remote
     variants:
-        - no_vhostforce:
-        - vhostforce_off:
-            netdev_extra_params_nic1 += ',vhostforce=off'
-        - vhostforce_on:
-            netdev_extra_params_nic1 += ',vhostforce=on'
+        - @default_setting:
+        - vhost_force:
+            only virtio_net
+            nettype = bridge
+            vhost = "vhost=on"
+            variants:
+                - @force_default:
+                    #vhost=on only has effect for virtio guests which use MSIX
+                    #for non-MSIX guests vhost_net will disabled automatically
+                - vhostforce_on:
+                    #only for non-MSIX guests, for these guests using
+                    #vhostforce=on, force enable vhost.
+                    only RHEL.5, Windows
+                    netdev_extra_params_nic1 += ',vhostforce=on'


### PR DESCRIPTION
Currently for non-MSIX guest, qemu will disable vhost_net automatically,
even vhost is enabled. using vhostfoce=on to force enable vhost-net.
This patch modify the test configuration, only test "vhostforce=on"
on non-MSIX guest.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
