### PR TITLE
qemu.tests: add enable s3/s4 params for qemu_guest_agent.cfg

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -49,6 +49,8 @@
         - check_suspend:
             type = qemu_guest_agent_suspend
             services_up_timeout = 30
+            extra_params += " -global PIIX4_PM.disable_s3=0"
+            extra_params += " -global PIIX4_PM.disable_s4=0"
             # params: s3_support_chk_cmd, s3_bg_program_setup_cmd,
             # s3_bg_program_chk_cmd, s3_bg_program_kill_cmd, s3_log_chk_cmd,
             # s3_start_cmd, s4_support_chk_cmd, s4_bg_program_setup_cmd,


### PR DESCRIPTION
since miss the enable s3/s4 params when create the qemu-kvm command
for qemu_guest_agent..check_suspend test.

Signed-off-by: Shuping Cui scui@redhat.com
