### PR TITLE
libvirt: Add test for virsh find-storage-pool-sources

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
@@ -1,0 +1,36 @@
+- virsh.find_storage_pool_sources:
+    type = "virsh_find_storage_pool_sources"
+    vms = ''
+    main_vm = ''
+    source_type = ""
+    source_host = "localhost"
+    source_Spec = ""
+    readonly_mode = "no"
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - local_nfs_source:
+                    source_type = "netfs"
+                - local_iscsi_source:
+                    source_type = "iscsi"
+                - local_logical_source:
+                    source_type = "logical"
+                    vg_name = "virttest_vg_0"
+#                - remoet_iSCSI_source:
+#                    source_type = "iscsi"
+#                    source_host = "REMOTE.EXAMPLE.COM"
+#                - use_spec_file:
+#                    source_type = "netfs"
+#                    source_Spec: = "EXAMPLE.XML"
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - invalid_type:
+                    source_type = "Unknow"
+                - invalid_srcSpec:
+                    source_type = "netfs
+                    source_Spec: = "INVALID.XML"
+                - readonly_test:
+                    source_type = "logical"
+                    readonly_mode = "yes"

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -1,0 +1,91 @@
+import os
+import logging
+from virttest import virsh, xml_utils, utils_test
+from autotest.client import utils, lv_utils
+from autotest.client.shared import error
+
+
+def run_virsh_find_storage_pool_sources(test, params, env):
+    """
+    Test command: virsh find-storage-pool-sources
+
+    1. Prepare env to provide source storage if use localhost:
+       1). For 'netfs' source type, setup nfs server
+       2). For 'iscsi' source type, setup iscsi server
+       3). For 'logcial' type pool, setup iscsi storage to create vg
+       4). Prepare srcSpec xml file if not given
+    2. Find the pool sources by running virsh cmd
+    """
+
+    source_type = params.get("source_type", "")
+    source_host = params.get("source_host", "localhost")
+    srcSpec = params.get("source_Spec", "")
+    vg_name = params.get("vg_name", "virttest_vg_0")
+    ro_flag = "yes" == params.get("readonly_mode", "no")
+    status_error = "yes" == params.get("status_error", "no")
+
+    if not source_type:
+        raise error.TestFail("Command requires <type> value")
+
+    cleanup_nfs = False
+    cleanup_iscsi = False
+    cleanup_logical = False
+
+    # Prepare source storage
+    if source_host == "localhost":
+        if source_type == "netfs":
+            # Set up nfs
+            utils_test.libvirt.setup_or_cleanup_nfs(True)
+            cleanup_nfs = True
+        if source_type in ["iscsi", "logical"]:
+            # Set up iscsi
+            iscsi_device = utils_test.libvirt.setup_or_cleanup_iscsi(True)
+            cleanup_iscsi = True
+            if source_type == "logical":
+                # Create vg by using iscsi device
+                lv_utils.vg_create(vg_name, iscsi_device)
+                cleanup_logical = True
+
+    # Prepare srcSpec xml
+    if not srcSpec or srcSpec == "INVALID.XML":
+        srcSpec = xml_utils.TempXMLFile()
+        if srcSpec == "INVALID.XML":
+            src_xml = "<invalid><host name='#@!'/><?source>"
+        else:
+            src_xml = "<source><host name='%s'/></source>" % source_host
+        srcSpec.write(src_xml)
+        srcSpec.flush()
+    logging.debug("srcSpec file content:\n%s", file(srcSpec.name).read())
+
+    if ro_flag:
+        logging.debug("Readonly mode test")
+
+    # Run virsh cmd
+    try:
+        cmd_result = virsh.find_storage_pool_sources(
+            source_type,
+            srcSpec.name,
+            ignore_status=True,
+            debug=True,
+            readonly=ro_flag)
+        output = cmd_result.stdout.strip()
+        err = cmd_result.stderr.strip()
+        status = cmd_result.exit_status
+        if not status_error:
+            if status:
+                raise error.TestFail(err)
+            else:
+                logging.debug("Command output:\n%s", output)
+        elif status_error and status == 0:
+            raise error.TestFail("Expect fail, but run successfully")
+    finally:
+        # Clean up
+        if cleanup_logical:
+            cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
+            pv_name = utils.system_output(cmd)
+            lv_utils.vg_remove(vg_name)
+            utils.run("pvremove %s" % pv_name)
+        if cleanup_iscsi:
+            utils_test.libvirt.setup_or_cleanup_iscsi(False)
+        if cleanup_nfs:
+            utils_test.libvirt.setup_or_cleanup_nfs(False)

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1709,6 +1709,7 @@ def pool_build(name, options="", **dargs):
     """
     return command("pool-build %s %s" % (name, options), **dargs)
 
+
 def find_storage_pool_sources_as(source_type, options="", **dargs):
     """
     Find potential storage pool sources
@@ -1719,7 +1720,7 @@ def find_storage_pool_sources_as(source_type, options="", **dargs):
     :return: returns the output of the command
     """
     return command("find-storage-pool-sources-as %s %s"
-        % (source_type, options), **dargs)
+                   % (source_type, options), **dargs)
 
 
 def pool_dumpxml(name, extra="", to_file="", **dargs):
@@ -1754,6 +1755,19 @@ def pool_define(xml_path, **dargs):
     """
     cmd = "pool-define --file %s" % xml_path
     return command(cmd, **dargs)
+
+
+def find_storage_pool_sources(source_type, srcSpec, **dargs):
+    """
+     Find potential storage pool sources
+
+    :param source_type: type of storage pool sources to find
+    :param srcSpec: optional file of source xml to qurey for pools
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    return command("find-storage-pool-sources %s %s"
+                   % (source_type, srcSpec), **dargs)
 
 
 def vol_create_as(volume_name, pool_name, capacity,


### PR DESCRIPTION
New test for virsh command: find-storage-pool-sources.
BTW, comment 2 sub-cases in .cfg file as which need replace EXAMPLE values to the correct values.
