### PR TITLE
libvirt.get_started: Added non-interactive option

### DIFF
--- a/libvirt/get_started.py
+++ b/libvirt/get_started.py
@@ -17,7 +17,6 @@ base_dir = data_dir.get_data_dir()
 default_userspace_paths = ["/usr/bin/virt-install"]
 check_modules = None
 online_docs_url = None
-interactive = True
 
 if __name__ == "__main__":
     import optparse
@@ -28,8 +27,17 @@ if __name__ == "__main__":
     option_parser.add_option("-r", "--restore-image",
                              action="store_true", dest="restore",
                              help="Restore image from pristine image")
-    option_parser.add_option("--data-dir", action="store", dest="datadir",
-                             help="Path to a data dir (that locates ISOS and images)")
+    option_parser.add_option("-d", "--data-dir",
+                             action="store", dest="datadir",
+                             help="Path to a data dir (that "
+                             "locates ISOS and images)")
+    option_parser.add_option("-s", "--setup-selinux",
+                             action="store_true", dest="selinux",
+                             help="Setup SELinux contexts for "
+                             "shared/data and set them to default")
+    option_parser.add_option("-n", "--non-interactive",
+                             action="store_true", dest="no_interactive",
+                             help="Disable interactive prompt")
     options, args = option_parser.parse_args()
 
     if options.datadir:
@@ -38,8 +46,10 @@ if __name__ == "__main__":
     try:
         bootstrap.bootstrap(test_name, test_dir, base_dir,
                             default_userspace_paths, check_modules,
-                            online_docs_url, interactive=interactive,
+                            online_docs_url,
+                            interactive=not options.no_interactive,
                             restore_image=options.restore,
+                            selinux=options.selinux,
                             verbose=options.verbose)
     except Exception, details:
         logging.error("Setup error: %s", details)


### PR DESCRIPTION
- Added option —-non-interactive to disable yes/no prompt and suppress
  verbose output.
- Added option —-setup-selinux to force setup SELinux contexts for
  shared/data directory and restore them to defaults.

When running libvirt.get_started from scripts such as CI.  It is necessary
to make it non-interactive and keep things under control by using options.

Signed-off-by: Hao Liu hliu@redhat.com
