### PR TITLE
tests.nicdriver_unload: Make the guest nic also named eth0

### DIFF
--- a/tests/cfg/nicdriver_unload.cfg
+++ b/tests/cfg/nicdriver_unload.cfg
@@ -3,5 +3,7 @@
     only Linux
     type = nicdriver_unload
     filesize = 512
+    rules = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="%s", ATTR{type}=="1", KERNEL=="eth*", NAME="eth0"'
+    image_snapshot = yes
     transfer_timeout = 1000
     sessions_num = 5

--- a/tests/nicdriver_unload.py
+++ b/tests/nicdriver_unload.py
@@ -4,7 +4,7 @@ import time
 import random
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_misc, utils_net, aexpect, data_dir
+from virttest import utils_misc, utils_net, data_dir
 
 
 @error.context_aware
@@ -22,7 +22,20 @@ def run_nicdriver_unload(test, params, env):
     :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
+    def reset_guest_udevrules(session, rules_file, rules_content):
+        """
+        Write guest udev rules, then reboot the guest and
+        return the new session
+        """
+        set_cmd = "echo '%s' > %s" % (rules_content, rules_file)
+        session.cmd_output_safe(set_cmd)
+        return vm.reboot()
+
+
     def all_threads_done(threads):
+        """
+        Check whether all threads have finished
+        """
         for thread in threads:
             if thread.isAlive():
                 return False
@@ -30,13 +43,18 @@ def run_nicdriver_unload(test, params, env):
                 continue
         return True
 
+
     def all_threads_alive(threads):
+        """
+        Check whether all threads is alive
+        """
         for thread in threads:
             if not thread.isAlive():
                 return False
             else:
                 continue
         return True
+
 
     timeout = int(params.get("login_timeout", 360))
     transfer_timeout = int(params.get("transfer_timeout", 1000))
@@ -45,6 +63,14 @@ def run_nicdriver_unload(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     session = vm.wait_for_login(timeout=timeout)
+    vm_mac_address = vm.get_mac_address()
+    udev_rules_file = "/etc/udev/rules.d/70-persistent-net.rules"
+    rules = params.get("rules")
+    if not session.cmd_status("[ -e %s ]" % udev_rules_file):
+        if not rules:
+            raise error.TestNAError("You must set udev rules before test")
+        rules = rules % vm_mac_address
+        session = reset_guest_udevrules(session, udev_rules_file, rules)
 
     error.base_context("Test env prepare")
     error.context("Get NIC interface name in guest.", logging.info)


### PR DESCRIPTION
When run nicdriver_unload test, will raise error like:
013-04-16 21:35:55: modprobe virtio_net
2013-04-16 21:35:56: [root@unused ~]#
2013-04-16 21:35:56: echo $?
2013-04-16 21:35:56: 0
2013-04-16 21:35:56: [root@unused ~]#
2013-04-16 21:35:56: ifconfig eth4 up
2013-04-16 21:35:56: eth4: unknown interface: No such device
2013-04-16 21:35:56: [root@unused ~]#
2013-04-16 21:35:56: echo $?
2013-04-16 21:35:56: 255
2013-04-16 21:35:56: [root@unused ~]#
2013-04-16 21:35:56: udev: renamed network interface eth0 to eth4

the root cause of this cause is after the nic driver loaded,
the nic name not changed immediately by udev rules, because
the guest is under heavy working pressure.

This patch modify the guest udev net rules before test,
make guest nic always nemed eth0.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
