### PR TITLE
libvirt.tests: Support multiple devices for multifunction test.

### DIFF
--- a/libvirt/tests/cfg/multifunction.cfg
+++ b/libvirt/tests/cfg/multifunction.cfg
@@ -24,12 +24,13 @@
                 - function_7:
                     mf_addr_function = "0x7"
                     # Although attaching device is ok,
-                    # it can not be found in vm
+                    # it can not be found in vm, same to 1-6
                     mf_check_disk_error = "yes"
                 - function_8:
                     mf_addr_function = "0x8"
                     status_error = "yes"
         - multi_devices:
+            # It should be less then 6
             mf_added_devices_count = 2
             variants:
                 - increased_slot:
@@ -42,6 +43,13 @@
                         - with_others:
                             no set_multifunction_on
                             status_error = "yes"
+                    variants:
+                        # multifunction is useful only when set on function 0.
+                        - from_0x0:
+                            mf_addr_function = "0x0"
+                        - from_0x1:
+                            mf_addr_function = "0x1"
+                            mf_check_disk_error = "yes"
                 - no_increase:
                 # Default is no increase
                     status_error = "yes"

--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -272,7 +272,7 @@ def run_multifunction(test, params, env):
                     raise error.TestFail("Attach device %s failed."
                                          % target_dev)
             else:
-                if status_error:
+                if status_error and not check_disk_error:
                     fail_info.append("Attach %s successfully "
                                      "but not expected." % target_dev)
         if len(fail_info):


### PR DESCRIPTION
Add testcases for multifunction of vm.
1.Add single device with pci slot
2.Add multi devices with pci slots
