### PR TITLE
share.cfg.guest-os.Windows.cfg : Modify the regex of e1000 Description

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -110,7 +110,7 @@
         find_pci_cmd = ipconfig /all | find "Description"
         wait_secs_for_hook_up = 10
         nic_e1000:
-            match_string = "Intel(R) PRO/1000 MT Network Connection"
+            match_string = "Intel\(R\) PRO/1000 MT Network Connection"
         nic_virtio:
             match_string = "VirtIO Ethernet"
     jumbo:


### PR DESCRIPTION
This patch modify the regex of e1000 Description for windowns guest
nic_hotplug test.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
