### PR TITLE
staging.utils_cgroup: change the regexp for finding correct cgroup path

### DIFF
--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -622,7 +622,7 @@ def get_cgroup_mountpoint(controller):
     f_cgcon = open("/proc/mounts", "rU")
     cgconf_txt = f_cgcon.read()
     f_cgcon.close()
-    mntpt = re.findall(r"\s(\S*cgroup/\S*,*%s,*\S*)" % controller, cgconf_txt)
+    mntpt = re.findall(r"\s(\S*cgroup/\S*%s[,\ ]\S*)" % controller, cgconf_txt)
     return mntpt[0]
 
 
@@ -669,7 +669,7 @@ def resolve_task_cgroup_path(pid, controller):
     finally:
         proc_file.close()
 
-    mount_path = re.findall(r":\S*,*%s,*\S*:(\S*)\n" % controller, proc_cgroup_txt)
+    mount_path = re.findall(r":\S*%s(?=[,:])\S*:(\S*)\n" % controller, proc_cgroup_txt)
     return os.path.join(root_path, mount_path[0].strip("/"))
 
 


### PR DESCRIPTION
The current approach will not properly find the path for "cpu"
controller. I've updated the regexp to match the correct "cpu".

In the "get_cgroup_mountpoint" we are searching the system
cgroup mountpoint from "/proc/mounts" where there could be right
now two types of mounts:

```
cgroup on /sys/fs/cgroup/cpuset type cgroup (...)
cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (...)
```

The second one makes thinks a little bit harder and we have to check
if the path ends with comma or space.

In the "resolve_task_cgroup_path" the situation is similar. We are
searching the exact path of specified controller for some guest
and there are also two types of records:

```
4:cpuacct,cpu:/machine/guest.libvirt-qemu/emulator
3:cpuset:/machine/guest.libvirt-qemu/emulator
```

There are thins even harder then the previous case. We need to get
only the 3th part of the record with the path. For the "cpuacct"
we have to consume also the "cpu" and that's why I'm using lookahead
in the regexp instead of the simple match to be able consume always
the remaining controller part until the colon.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
