### PR TITLE
virttest.aexpect: Do not remove the aexpect dir wholesale

### DIFF
--- a/virttest/aexpect.py
+++ b/virttest/aexpect.py
@@ -707,8 +707,11 @@ class Spawn(object):
         self._close_reader_fds()
         self.reader_fds = {}
         # Remove all used files
-        base_dir = os.path.join(BASE_DIR, self.a_id)
-        shutil.rmtree(base_dir, ignore_errors=True)
+        for filename in (_get_filenames(BASE_DIR, self.a_id)):
+            try:
+                os.unlink(filename)
+            except OSError:
+                pass
 
 
     def set_linesep(self, linesep):


### PR DESCRIPTION
On double .close(), we'll get to a point where there's an
aexpect instance, but its parent directory was already
nuked. This will cause the .close() method to try to open
a log file in a path where the parent directory doesn't
exist anymore.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
