### PR TITLE
virsh_domfstrim: Check for existence of lsscsi first

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -23,6 +23,12 @@ def run_virsh_domfstrim(test, params, env):
         raise error.TestNAError("This version of libvirt does not support "
                                 "the domfstrim test")
 
+    try:
+        utils_misc.find_command("lsscsi")
+    except ValueError:
+        raise error.TestNAError("Command 'lsscsi' is missing. You must "
+                                "install it.")
+
     vm_name = params.get("main_vm", "virt-tests-vm1")
     status_error = ("yes" == params.get("status_error", "no"))
     minimum = params.get("domfstrim_minimum")


### PR DESCRIPTION
Need to check if the 'lsscsi' command exists before running; otherwise,
scsi_disk variable cannot be populated leading to failure to run the
fdisk command that follows.
