### PR TITLE
virsh_vcpucount: Adjust --guest option testing

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpucount.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpucount.cfg
@@ -8,7 +8,7 @@
                 - shutoff_test:
                     vcpucount_pre_vm_state = "shut off"
                     variants:
-                        - wrong_opiton:
+                        - wrong_option:
                             vcpucount_options = "--xyz"
                         - guest_option:
                             vcpucount_options = "--guest"
@@ -25,7 +25,7 @@
                 - running_test:
                     vcpucount_pre_vm_state = "running"
                     variants:
-                        - wrong_opiton:
+                        - wrong_option:
                             vcpucount_options = "--xyz"
                         - config_guest_option:
                             vcpucount_options = "--guest --config"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
@@ -4,7 +4,7 @@ from autotest.client.shared import error
 from virttest import virsh, libvirt_xml
 
 
-def reset_domain(vm, vm_state):
+def reset_domain(vm, vm_state, needs_agent=False):
     """
     Set domain vcpu number to 4 and current vcpu as 1
 
@@ -15,9 +15,28 @@ def reset_domain(vm, vm_state):
         vm.destroy()
     vm_xml = libvirt_xml.VMXML()
     vm_xml.set_vm_vcpus(vm.name, 4, 1)
+    if needs_agent:
+        logging.debug("Attempting to set guest agent channel")
+        vm_xml.set_agent_channel(vm.name)
     if not vm_state == "shut off":
         vm.start()
-        vm.wait_for_login()
+        session = vm.wait_for_login()
+        if needs_agent:
+            # Check if qemu-ga already started automatically
+            cmd = "rpm -q qemu-guest-agent || yum install -y qemu-guest-agent"
+            stat_install = session.cmd_status(cmd, 300)
+            if stat_install != 0:
+                raise error.TestFail("Fail to install qemu-guest-agent, make "
+                                     "sure that you have usable repo in guest")
+
+            # Check if qemu-ga already started
+            stat_ps = session.cmd_status("ps aux |grep [q]emu-ga")
+            if stat_ps != 0:
+                session.cmd("qemu-ga -d")
+                # Check if the qemu-ga really started
+                stat_ps = session.cmd_status("ps aux |grep [q]emu-ga")
+                if stat_ps != 0:
+                    raise error.TestFail("Fail to run qemu-ga in guest")
 
 
 def chk_output_running(output, expect_out, options):
@@ -97,6 +116,12 @@ def chk_output_shutoff(output, expect_out, options):
     else:
         raise error.TestFail("Options %s should failed" % options)
 
+def reset_env(vm_name, xml_file):
+    virsh.destroy(vm_name)
+    virsh.undefine(vm_name)
+    virsh.define(xml_file)
+    if os.path.exists(xml_file):
+        os.remove(xml_file)
 
 def run_virsh_vcpucount(test, params, env):
     """
@@ -144,7 +169,11 @@ def run_virsh_vcpucount(test, params, env):
         raise error.TestNAError("Options exceeds 2 is not supported")
 
     # Prepare domain
-    reset_domain(vm, pre_vm_state)
+    try:
+        reset_domain(vm, pre_vm_state, (options == "--guest"))
+    except Exception, details:
+        reset_env(vm_name, xml_file)
+        error.TestFail(details)
 
     # Perform guest vcpu hotplug
     for i in range(len(set_option)):
@@ -160,7 +189,9 @@ def run_virsh_vcpucount(test, params, env):
         vcpucount_status = result.exit_status
 
         if "--guest" in options:
-            if result.stderr.count("doesn't support option"):
+            if result.stderr.count("doesn't support option") or \
+               result.stderr.count("command guest-get-vcpus has not been found"):
+                reset_env(vm_name, xml_file)
                 raise error.TestNAError("Option %s is not supported" % options)
 
         # Reset domain
@@ -169,11 +200,13 @@ def run_virsh_vcpucount(test, params, env):
         # Check result
         if status_error == "yes":
             if vcpucount_status == 0:
+                reset_env(vm_name, xml_file)
                 raise error.TestFail("Run successfully with wrong command!")
             else:
                 logging.info("Run failed as expected")
         else:
             if vcpucount_status != 0:
+                reset_env(vm_name, xml_file)
                 raise error.TestFail("Run command failed with options %s" %
                                      options)
             elif setvcpus_status == 0:
@@ -185,6 +218,7 @@ def run_virsh_vcpucount(test, params, env):
                         expect_out = [2, 1]
                         chk_output_shutoff(output, expect_out, options)
                     else:
+                        reset_env(vm_name, xml_file)
                         raise error.TestFail("setvcpus should failed")
                 else:
                     if i == 0:
@@ -208,8 +242,4 @@ def run_virsh_vcpucount(test, params, env):
                     chk_output_running(output, expect_out, options)
 
     # Recover env
-    virsh.destroy(vm_name)
-    virsh.undefine(vm_name)
-    virsh.define(xml_file)
-    if os.path.exists(xml_file):
-        os.remove(xml_file)
+    reset_env(vm_name, xml_file)


### PR DESCRIPTION
Couple of issues here. First there was no check to see if the
guest agent was running in the guest. The test would fail as
written with:

stderr: error: argument unsupported: QEMU guest agent is not configured

So borrow from virsh_snapshot_create_as.py and add code to check
and start the guest agent.

Even though the guest agent was running, the underlying QEMU may not
support the 'guest-get-vcpus' option as it was only added as of 1.5.
The error message received is:

 stderr: error: internal error: unable to execute QEMU agent command
  'guest-get-vcpus': The command guest-get-vcpus has not been found

So as a secondary fix - add a check for the stderr check and exit with
SKIP rather than FAIL.

The call to make this check is wrapped inside a try/except so that if
there is a failure, the test can reset the environment back to how it
found it.

Use that reset environment method in other test exit paths as well...

Finally fixed a spelling error in the CFG file from "opiton" to "option"
