### PR TITLE
virsh_setmem: Reduce churn for libvirtd restart

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -161,8 +161,10 @@ def run_virsh_setmem(test, params, env):
     # Prepare libvirtd status
     if libvirt == "off":
         utils_libvirtd.libvirtd_stop()
-    else:  # make sure it's running
-        utils_libvirtd.libvirtd_restart()
+    else:
+        if not utils_libvirtd.libvirtd_is_running() and \
+           not utils_libvirtd.libvirtd_start():
+            raise error.TestFail("Cannot start libvirtd")
 
     if status_error == "yes" or old_libvirt_fail == "yes":
         logging.info("Error Test: Expecting an error to occur!")


### PR DESCRIPTION
Rather than executing a libvirtd_restart each time the test is run
in order to ensure libvirtd is running - perform a check if it is
not running and try to start if not. If the start fails, then cause
test error.

Turns out if executed too quickly - the libvirtd restarts could end
causing the systemd restart to fail due to the underlying code perhaps
believing there's an infinite loop and issuing the following message
to /var/log/messages:

systemd[1]: libvirtd.service start request repeated too quickly,
refusing to start.
