### PR TITLE
run: Fix bug in commit efadf86

### DIFF
--- a/run
+++ b/run
@@ -99,8 +99,9 @@ def _import_autotest_modules():
     2) Import the libraries system wide. For this to work, the
        autotest-framework package for the given distro must be installed.
     """
-    autotest_dir = os.path.abspath(os.environ.get('AUTOTEST_PATH'))
+    autotest_dir = os.environ.get('AUTOTEST_PATH')
     if autotest_dir is not None:
+        autotest_dir = os.path.abspath(autotest_dir)
         client_dir = os.path.join(autotest_dir, 'client')
         setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
         import imp


### PR DESCRIPTION
So, turns out that, when not running under autotest,
the AUTOTEST_PATH directory will be None, and that will
make os.path.abspath to fail. Let's apply the abspath
function only if that value is not None.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
