### PR TITLE
virttest.qemu_vm: Fix issue #381

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2015,17 +2015,21 @@ class VM(virt_vm.BaseVM):
                 proxy_helper_cmd += " -n"
 
                 logging.info("Running Proxy Helper:\n%s", proxy_helper_cmd)
-                self.process = aexpect.run_tail(proxy_helper_cmd, None,
+                self.process = aexpect.run_tail(proxy_helper_cmd,
+                                                None,
                                                 logging.info,
                                                 "[9p proxy helper]",
                                                 auto_close=False)
+            else:
+                logging.info("Running qemu command (reformatted):\n%s",
+                             qemu_command.replace(" -", " \\\n    -"))
+                self.qemu_command = qemu_command
+                self.process = aexpect.run_tail(qemu_command,
+                                                None,
+                                                logging.info,
+                                                "[qemu output] ",
+                                                auto_close=False)
 
-            logging.info("Running qemu command (reformatted):\n%s",
-                         qemu_command.replace(" -", " \\\n    -"))
-            self.qemu_command = qemu_command
-            self.process = aexpect.run_tail(qemu_command, None,
-                                            logging.info, "[qemu output] ",
-                                            auto_close=False)
             logging.info("Created qemu process with parent PID %d",
                          self.process.get_pid())
             self.start_time = time.time()


### PR DESCRIPTION
It was correctly pointed out by ldoktor that, in case
the 9p proxy helper is set, we'll overwrite self.process
with the regular QEMU process. Let's fix this problem.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
