### PR TITLE
virt.virtnet : update vm.virtnet when guest reboot

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -94,10 +94,12 @@ def preprocess_vm(test, params, env, name):
         vm.remove()
 
     start_vm = False
+    update_virtnet = False
 
     if params.get("restart_vm") == "yes":
         if vm.is_alive():
             vm.destroy(gracefully=True, free_mac_addresses=False)
+        update_virtnet = True
         start_vm = True
     elif params.get("migration_mode"):
         start_vm = True
@@ -114,6 +116,7 @@ def preprocess_vm(test, params, env, name):
                                     params=params,
                                     basedir=test.bindir):
                     start_vm = True
+                    update_virtnet = True
 
     if start_vm:
         if vm_type == "libvirt" and params.get("type") != "unattended_install":
@@ -123,6 +126,9 @@ def preprocess_vm(test, params, env, name):
             vm.params = params
             vm.start()
         else:
+            if update_virtnet:
+                vm.update_vm_id()
+                vm.virtnet = utils_net.VirtNet(params, name, vm.instance)
             # Start the VM (or restart it if it's already up)
             if params.get("reuse_previous_config", "no") == "no":
                 vm.create(name, params, test.bindir,

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -534,6 +534,13 @@ class BaseVM(object):
             if not glob.glob("/tmp/*%s" % self.instance):
                 break
 
+    def update_vm_id(self):
+        """
+        Update vm identifier, we need do that when force reboot vm, since vm
+        virnet params may be changed.
+        """
+        self._generate_unique_id()
+
     @staticmethod
     def lookup_vm_class(vm_type, target):
         if vm_type == 'qemu':


### PR DESCRIPTION
When starting a guest with one nic device, then
starting a guest with two nics (not removing env),
the second nic can not be initialized correctly.

When booting a guest with nic_extra_params, then
booting another guest without this option, the
second guest will boot with nic_extra_params
unexpectedly.

The root cause of these issues is that we don't
update virtnet when the VM object is preprocessed.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
