### PR TITLE
virt.tests: fix no ip address for extra nics

### DIFF
--- a/tests/cfg/ping.cfg
+++ b/tests/cfg/ping.cfg
@@ -8,6 +8,7 @@
         - multi_nics:
             no Windows
             nics += ' nic2'
+            pre_cmd = "for nic in `ls /sys/class/net|grep -v lo`;do arp -a|grep -v $nic && dhclient $nic;done"
         - ext_host:
             ping_ext_host = "yes"
             ext_host_get_cmd = "ip route | awk '/default/ { print $3 }'"

--- a/tests/ping.py
+++ b/tests/ping.py
@@ -35,6 +35,11 @@ def run_ping(test, params, env):
     error.context("Login to guest", logging.info)
     session = vm.wait_for_login(timeout=timeout)
 
+    # most of linux distribution don't add IP configuration for extra nics,
+    # so get IP for extra nics via pre_cmd;
+    if params.get("pre_cmd"):
+        session.cmd(params["pre_cmd"], timeout=600)
+
     if ping_ext_host:
         default_host = "www.redhat.com"
         ext_host_get_cmd = params.get("ext_host_get_cmd", "")


### PR DESCRIPTION
Some guest (eg, sles, ubt) don't configure IP address for extra nics and
ping.multi_nic always failed because no IP for extra nic; fix this issue
by send pre_cmd to guest for asking IP from dhcp server before start test;

Signed-off-by: Xu Tian xutian@redhat.com
