### PR TITLE
virttest: Add disable for warning color

### DIFF
--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -297,6 +297,7 @@ class Bcolors(object):
         self.SKIP = ''
         self.FAIL = ''
         self.ERROR = ''
+        self.WARN = ''
         self.ENDC = ''
 
 # Instantiate bcolors to be used in the functions below.


### PR DESCRIPTION
Warning color is added but missed in disable. This will cause trouble
when pipe stdout into file.

Signed-off-by: Hao Liu hliu@redhat.com
