### PR TITLE
staging.utils.cgroup: Match controller more exactly.

### DIFF
--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -623,6 +623,10 @@ def get_cgroup_mountpoint(controller):
     cgconf_txt = f_cgcon.read()
     f_cgcon.close()
     mntpt = re.findall(r"\s(\S*cgroup/\S*,*%s,*\S*)" % controller, cgconf_txt)
+    for mnt in mntpt:
+        ctlers = mnt.strip().split('/')[-1].split(',')
+        if controller in ctlers:
+            return mnt
     return mntpt[0]
 
 


### PR DESCRIPTION
Controller cpu and cpuacct may be mounted as cpu,cpuacct,
and get_cgroup_mountpoint("cpu") will get cpuset because
no exact matched controller("cpuset" will be in the front of
matched list).

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
