### PR TITLE
libvirt_xml: Shutdown vm before sync

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -343,6 +343,10 @@ class VMXML(VMXMLBase):
     def sync(self, options=None):
         """Rebuild VM with the config file."""
         backup = self.new_from_dumpxml(self.vm_name)
+        if self.virsh.is_alive(self.vm_name):
+            if not self.virsh.destroy(self.vm_name):
+                raise xcepts.LibvirtXMLError("Failed to destroy %s.",
+                                             self.vm_name)
         if not self.undefine(options):
             raise xcepts.LibvirtXMLError("Failed to undefine %s.", self.vm_name)
         if not self.define():


### PR DESCRIPTION
If a VM is sync when it's alive, it's live changes will be passed
to next test if the vm accidentally not reboot between the tests,
causing unexpected behavior.

Signed-off-by: Hao Liu hliu@redhat.com
