### PR TITLE
Enable AHCI booting and sync Win2008-32 unattended file format

### DIFF
--- a/shared/unattended/win2008-32-autounattend.xml
+++ b/shared/unattended/win2008-32-autounattend.xml
@@ -1,40 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
 	<settings pass="windowsPE">
-		<component name="Microsoft-Windows-International-Core-WinPE"
-			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
-			language="neutral" versionScope="nonSxS"
-			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
-			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<SetupUILanguage>
-				<UILanguage>en-us</UILanguage>
-			</SetupUILanguage>
-			<InputLocale>0409:00010409</InputLocale>
-			<SystemLocale>en-us</SystemLocale>
-			<UILanguage>en-us</UILanguage>
-			<UILanguageFallback>en-us</UILanguageFallback>
-			<UserLocale>en-us</UserLocale>
-		</component>
-		<component name="Microsoft-Windows-PnpCustomizationsWinPE"
-			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
-			language="neutral" versionScope="nonSxS"
-			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
-			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<DriverPaths>
-				<PathAndCredentials wcm:keyValue="1" wcm:action="add">
-					<Path>KVM_TEST_STORAGE_DRIVER_PATH</Path>
-				</PathAndCredentials>
-				<PathAndCredentials wcm:keyValue="2" wcm:action="add">
-					<Path>KVM_TEST_NETWORK_DRIVER_PATH</Path>
-				</PathAndCredentials>
-			</DriverPaths>
-		</component>
 		<component name="Microsoft-Windows-Setup"
 			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
 			language="neutral" versionScope="nonSxS"
 			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 			<DiskConfiguration>
+				<WillShowUI>OnError</WillShowUI>
 				<Disk wcm:action="add">
 					<CreatePartitions>
 						<CreatePartition wcm:action="add">
@@ -57,7 +30,6 @@
 					<DiskID>0</DiskID>
 					<WillWipeDisk>true</WillWipeDisk>
 				</Disk>
-				<WillShowUI>OnError</WillShowUI>
 			</DiskConfiguration>
 			<ImageInstall>
 				<OSImage>
@@ -72,6 +44,7 @@
 						<DiskID>0</DiskID>
 						<PartitionID>1</PartitionID>
 					</InstallTo>
+					<WillShowUI>OnError</WillShowUI>
 				</OSImage>
 			</ImageInstall>
 			<UserData>
@@ -83,19 +56,64 @@
 				<FullName>Autotest Mindless Drone</FullName>
 				<Organization>Autotest</Organization>
 			</UserData>
-			<EnableFirewall>false</EnableFirewall>
-			<EnableNetwork>true</EnableNetwork>
+		</component>
+		<component name="Microsoft-Windows-International-Core-WinPE"
+			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
+			language="neutral" versionScope="nonSxS"
+			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<SetupUILanguage>
+				<UILanguage>en-us</UILanguage>
+			</SetupUILanguage>
+			<InputLocale>0409:00000409</InputLocale>
+			<SystemLocale>en-us</SystemLocale>
+			<UILanguage>en-us</UILanguage>
+			<UserLocale>en-us</UserLocale>
+			<UILanguageFallback>en-us</UILanguageFallback>
+		</component>
+		<component name="Microsoft-Windows-PnpCustomizationsWinPE"
+			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
+			language="neutral" versionScope="nonSxS"
+			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<DriverPaths>
+				<PathAndCredentials wcm:keyValue="1" wcm:action="add">
+					<Path>KVM_TEST_STORAGE_DRIVER_PATH</Path>
+				</PathAndCredentials>
+				<PathAndCredentials wcm:keyValue="2" wcm:action="add">
+					<Path>KVM_TEST_NETWORK_DRIVER_PATH</Path>
+				</PathAndCredentials>
+			</DriverPaths>
 		</component>
 	</settings>
-	<settings pass="oobeSystem">
+	<settings pass="specialize">
 		<component name="Microsoft-Windows-Deployment"
 			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
 			language="neutral" versionScope="nonSxS"
 			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<Reseal>
-				<ForceShutdownNow>false</ForceShutdownNow>
-			</Reseal>
+			<RunSynchronous>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>EnableAdmin</Description>
+					<Order>1</Order>
+					<Path>cmd /c net user Administrator /active:yes</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>UnfilterAdministratorToken</Description>
+					<Order>2</Order>
+					<Path>cmd /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v FilterAdministratorToken /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>3</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Msahci /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>4</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\IastorV /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+			</RunSynchronous>
 		</component>
 		<component name="Microsoft-Windows-International-Core"
 			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
@@ -103,11 +121,12 @@
 			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 			<InputLocale>0409:00000409</InputLocale>
-			<SystemLocale>en-us</SystemLocale>
-			<UILanguage>en-us</UILanguage>
-			<UILanguageFallback>en-us</UILanguageFallback>
-			<UserLocale>en-us</UserLocale>
+			<SystemLocale>en-US</SystemLocale>
+			<UILanguage>en-US</UILanguage>
+			<UserLocale>en-US</UserLocale>
 		</component>
+	</settings>
+	<settings pass="oobeSystem">
 		<component name="Microsoft-Windows-Shell-Setup"
 			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
 			language="neutral" versionScope="nonSxS"
@@ -124,33 +143,33 @@
 					<Value>1q2w3eP</Value>
 					<PlainText>true</PlainText>
 				</Password>
-				<Username>Administrator</Username>
-				<LogonCount>5</LogonCount>
 				<Enabled>true</Enabled>
+				<LogonCount>1000</LogonCount>
+				<Username>Administrator</Username>
 			</AutoLogon>
 			<FirstLogonCommands>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c KVM_TEST_VIRTIO_NETWORK_INSTALLER"</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c echo OS install is completed > COM1</CommandLine>
 					<Order>1</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c start /w pkgmgr /iu:"TelnetServer"</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c KVM_TEST_VIRTIO_NETWORK_INSTALLER</CommandLine>
 					<Order>2</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c sc config TlntSvr start= auto</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c start /w pkgmgr /iu:"TelnetServer"</CommandLine>
 					<Order>3</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c netsh firewall set opmode disable</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c sc config TlntSvr start= auto</CommandLine>
 					<Order>4</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c net start telnet</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c netsh firewall set opmode disable</CommandLine>
 					<Order>5</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c E:\autoit3.exe E:\git\git.au3</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c net start telnet</CommandLine>
 					<Order>6</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
@@ -158,55 +177,56 @@
 					<Order>7</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c netsh interface ip set address "Local Area Connection" dhcp</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c E:\autoit3.exe E:\git\git.au3</CommandLine>
 					<Order>8</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c KVM_TEST_VIRTIO_BALLOON_INSTALLER</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c netsh interface ip set address "Local Area Connection" dhcp</CommandLine>
 					<Order>9</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c KVM_TEST_VIRTIO_QXL_INSTALLER</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c KVM_TEST_VIRTIO_BALLOON_INSTALLER</CommandLine>
 					<Order>10</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c E:\setuprss.bat</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c KVM_TEST_VIRTIO_QXL_INSTALLER</CommandLine>
 					<Order>11</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c E:\setupsp.bat</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c E:\setuprss.bat</CommandLine>
 					<Order>12</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c E:\software_install_32.bat</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c E:\setupsp.bat</CommandLine>
 					<Order>13</Order>
 				</SynchronousCommand>
 				<SynchronousCommand wcm:action="add">
-					<CommandLine>%WINDIR%\System32\cmd /c A:\finish.bat PROCESS_CHECK</CommandLine>
+					<CommandLine>%WINDIR%\System32\cmd /c E:\software_install_32.bat</CommandLine>
 					<Order>14</Order>
+				</SynchronousCommand>
+				<SynchronousCommand wcm:action="add">
+					<CommandLine>%WINDIR%\System32\cmd /c A:\finish.bat PROCESS_CHECK</CommandLine>
+					<Order>15</Order>
 				</SynchronousCommand>
 			</FirstLogonCommands>
 			<OOBE>
-				<ProtectYourPC>1</ProtectYourPC>
+				<HideEULAPage>true</HideEULAPage>
 				<NetworkLocation>Work</NetworkLocation>
+				<ProtectYourPC>1</ProtectYourPC>
+				<SkipUserOOBE>true</SkipUserOOBE>
+				<SkipMachineOOBE>true</SkipMachineOOBE>
 			</OOBE>
 		</component>
-	</settings>
-	<settings pass="auditSystem">
-		<component name="Microsoft-Windows-Shell-Setup"
+		<component name="Microsoft-Windows-International-Core"
 			processorArchitecture="x86" publicKeyToken="31bf3856ad364e35"
 			language="neutral" versionScope="nonSxS"
 			xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<AutoLogon>
-				<Password>
-					<Value>1q2w3eP</Value>
-					<PlainText>true</PlainText>
-				</Password>
-				<Username>Administrator</Username>
-				<LogonCount>1000</LogonCount>
-				<Enabled>true</Enabled>
-			</AutoLogon>
+			<InputLocale>0409:00000409</InputLocale>
+			<SystemLocale>en-us</SystemLocale>
+			<UILanguage>en-us</UILanguage>
+			<UILanguageFallback>en-us</UILanguageFallback>
+			<UserLocale>en-us</UserLocale>
 		</component>
 	</settings>
 	<cpi:offlineImage

--- a/shared/unattended/win2008-64-autounattend.xml
+++ b/shared/unattended/win2008-64-autounattend.xml
@@ -103,6 +103,16 @@
 					<Order>2</Order>
 					<Path>cmd /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v FilterAdministratorToken /t REG_DWORD /d 0 /f</Path>
 				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>3</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Msahci /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>4</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\IastorV /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
 			</RunSynchronous>
 		</component>
 		<component name="Microsoft-Windows-International-Core"

--- a/shared/unattended/win2008-r2-autounattend.xml
+++ b/shared/unattended/win2008-r2-autounattend.xml
@@ -99,6 +99,16 @@
 					<Order>2</Order>
 					<Path>cmd /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v FilterAdministratorToken /t REG_DWORD /d 0 /f</Path>
 				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>3</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Msahci /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>4</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\IastorV /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
 			</RunSynchronous>
 		</component>
 		<component name="Microsoft-Windows-International-Core"

--- a/shared/unattended/win7-32-autounattend.xml
+++ b/shared/unattended/win7-32-autounattend.xml
@@ -93,6 +93,16 @@
 					<Order>2</Order>
 					<Path>cmd /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v FilterAdministratorToken /t REG_DWORD /d 0 /f</Path>
 				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>3</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Msahci /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>4</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\IastorV /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
 			</RunSynchronous>
 		</component>
 		<component name="Microsoft-Windows-International-Core"

--- a/shared/unattended/win7-64-autounattend.xml
+++ b/shared/unattended/win7-64-autounattend.xml
@@ -93,6 +93,16 @@
 					<Order>2</Order>
 					<Path>cmd /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v FilterAdministratorToken /t REG_DWORD /d 0 /f</Path>
 				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>3</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Msahci /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Description>SataBootable</Description>
+					<Order>4</Order>
+					<Path>cmd /c reg add HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\IastorV /v Start /t REG_DWORD /d 0 /f</Path>
+				</RunSynchronousCommand>
 			</RunSynchronous>
 		</component>
 		<component name="Microsoft-Windows-International-Core"


### PR DESCRIPTION
As NT 6.X OS has a limitation that install on non-AHCI hard drive
would result further booting on AHCI BSOD, this is the solution
to fix, per http://support.microsoft.com/kb/922976
and found that Win2008-32 lacks some cmd to update registry(64 has)
so sync it to same as 64bits, replaced some cmd(software install).

Signed-off-by: Xiaoqing Wei xwei@redhat.com
