### PR TITLE
block_resize.cfg: RHEL5 need reboot step in block_resize case

### DIFF
--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -48,3 +48,6 @@
         disk_change_ratio = 1.5
     raw:
         disk_change_ratio = 1.5 0.5
+    RHEL:
+        5:
+            need_reboot = yes


### PR DESCRIPTION
Guest RHEL5 could not detect disk change,
assign need_reboot as yes in the cfg file.

Signed-off-by: Xiangmin Han xhan@redhat.com
