### PR TITLE
virsh_start: Need to ensure stopped before run

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
@@ -8,6 +8,7 @@
     variants:
         - status_error_no:
             status_error = "no"
+            kill_vm_before_test = "yes"
             variants:
                 - normal_start:
                 - vm_named_by_num:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -30,7 +30,7 @@ def do_virsh_start(vm_name):
     cmd_result = virsh.command("start %s" % vm_name)
 
     if cmd_result.exit_status:
-        raise StartError(vm_name, cmd_result.stdout)
+        raise StartError(vm_name, cmd_result.stderr)
 
 
 def run_virsh_start(test, params, env):


### PR DESCRIPTION
When run after virsh.shutdown, the first virsh.start was failing with
because the domain was already started.  Adjusted the .cfg file to
ensure setting of the 'kill_vm_before_test' in the status_error_no
variant.

Also, changed the error returned from using 'stdout' to 'stderr' so that
"Domain is already active" would be displayed.
