### PR TITLE
device_bit_check.cfg: replace scsi_extra_params_hda with blk_extra_params

### DIFF
--- a/qemu/tests/cfg/device_bit_check.cfg
+++ b/qemu/tests/cfg/device_bit_check.cfg
@@ -27,10 +27,10 @@
                 pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio block device"
                 dev_type = virtio-blk-pci
             virtio_scsi:
-                dev_param_name = scsi_extra_params_hda
-                pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Device 1004"
+                dev_param_name = blk_extra_params
+                blk_extra_params = ""
+                pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio SCSI"
                 dev_type = virtio-scsi-pci
-                scsi_extra_params_hda = ""
         - nic_device:
             only virtio_net
             nic_extra_params = ""


### PR DESCRIPTION
change the parameter name scsi_extra_params_hda to blk_extra_params.

Signed-off-by: Xiangmin Han xhan@redhat.com
