### PR TITLE
virttest.env_process: Remove restart_vm option

### DIFF
--- a/qemu/tests/pxe_query_cpus.py
+++ b/qemu/tests/pxe_query_cpus.py
@@ -48,7 +48,6 @@ def run_pxe_query_cpus(test, params, env):
 
     params["start_vm"] = "yes"
     params["kvm_vm"] = "yes"
-    params["restart_vm"] = "no"
     env_process.preprocess_vm(test, params, env, params["main_vm"])
     vm = env.get_vm(params["main_vm"])
     bg = utils.InterruptedThread(utils_test.run_virt_sub_test,

--- a/run
+++ b/run
@@ -651,7 +651,7 @@ class VirtTestApp(object):
 
     def _process_restart_vm(self):
         if self.options.restart_vm:
-            self.cartesian_parser.assign("restart_vm", "yes")
+            self.cartesian_parser.assign("kill_vm", "yes")
 
     def _process_restore_image_between_tests(self):
         if self.options.restore_image_between_tests:

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -96,12 +96,7 @@ def preprocess_vm(test, params, env, name):
     start_vm = False
     update_virtnet = False
 
-    if params.get("restart_vm") == "yes":
-        if vm.is_alive():
-            vm.destroy(gracefully=True, free_mac_addresses=False)
-        update_virtnet = True
-        start_vm = True
-    elif params.get("migration_mode"):
+    if params.get("migration_mode"):
         start_vm = True
     elif params.get("start_vm") == "yes":
         # need to deal with libvirt VM differently than qemu


### PR DESCRIPTION
The restart_vm option, that will restart a vm at the beginning
of postprocessing, is unnecessary, given that you could
simply shut down all the VMs at the end of each test,
forcing new vms to be started.

So get rid of this option, and replace --restart-vm
in ./run to use kill_vm = yes instead.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
