### PR TITLE
qemu_vm: Remove sandbox off check

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1082,8 +1082,8 @@ class VM(virt_vm.BaseVM):
         devices.insert(StrDev('vmname', cmdline=add_name(devices, name)))
 
         if params.get("qemu_sandbox", "on") == "on":
-            devices.insert(StrDev('sandbox', cmdline=process_sandbox(devices, "add")))
-        elif params.get("sandbox", "off") == "off":
+            devices.insert(StrDev('qemu_sandbox', cmdline=process_sandbox(devices, "add")))
+        else:
             devices.insert(StrDev('qemu_sandbox', cmdline=process_sandbox(devices, "rem")))
 
         devs = devices.machine_by_params(params)


### PR DESCRIPTION
sandbox seems the same as qemu_sandbox, so it is duplicate,
Remove this check.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
