### PR TITLE
JeOS 19: Add qemu-guest-agent

### DIFF
--- a/shared/unattended/JeOS-19.ks
+++ b/shared/unattended/JeOS-19.ks
@@ -197,7 +197,7 @@ systemctl mask sys-devices-virtual-tty-tty9.device
 systemctl mask sys-devices-virtual-tty-tty10.device
 systemctl mask sys-devices-virtual-tty-tty11.device
 systemctl mask sys-devices-virtual-tty-tty12.device
-yum install -y hdparm ntpdate
+yum install -y hdparm ntpdate qemu-guest-agent
 yum clean all
 mkdir -p /var/log/journal
 echo 'Post set up finished' > /dev/ttyS0


### PR DESCRIPTION
It was argued that the agent is closely related to
virtualization testing, and it is small enough to
justify inclusion.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
