### PR TITLE
JeOS 19 ks: Fill up disk image so empty space can be removed

### DIFF
--- a/shared/unattended/JeOS-19.ks
+++ b/shared/unattended/JeOS-19.ks
@@ -200,6 +200,8 @@ systemctl mask sys-devices-virtual-tty-tty12.device
 yum install -y hdparm ntpdate qemu-guest-agent
 yum clean all
 mkdir -p /var/log/journal
+dd if=/dev/zero of=/fill-up-file bs=1M
+rm -f /fill-up-file
 echo 'Post set up finished' > /dev/ttyS0
 echo Post set up finished > /dev/hvc0
 echo "OS install is completed" > /dev/ttyS0


### PR DESCRIPTION
Add a last step post install that will make the JeOS
image to fill all 10GB of disk, so that we can easily
create an image with no empty space by using qemu-img

qemu-img convert -O qcow2 jeos-19-x86_64.qcow2 jeos-19-x86_64-output.qcow2

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
