### PR TITLE
virsh_edit: Resolve random/obscure timing failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -1,5 +1,6 @@
 import os
 import time
+from virttest import remote
 
 from autotest.client.shared import error
 from virttest import virsh, aexpect, utils_libvirtd
@@ -46,8 +47,7 @@ def run_virsh_edit(test, params, env):
             session.sendline(edit_cmd)
             session.send('\x1b')
             session.send('ZZ')
-            # use sleep(1) to make sure the modify has been completed.
-            time.sleep(1)
+            remote.handle_prompts(session, None, None, r"[\#\$]\s*$")
             session.close()
             return True
         except:
@@ -74,7 +74,8 @@ def run_virsh_edit(test, params, env):
             virsh.destroy(guest_name)
         vcpus = vm.dominfo()["CPU(s)"]
         # Recover cpuinfo
-        status = modify_vcpu(source, dic_mode["recover"])
+        # Use name rather than source, since source could be domid
+        status = modify_vcpu(guest_name, dic_mode["recover"])
         if status and vcpus != expected_vcpu:
             return False
         return status


### PR DESCRIPTION
Periodically I was getting a failure when the first of the sequence
of virsh_edit's are run in one my long runs using the "--tests virsh"
option. The failing test is/was 'virsh.edit.normal_test.id_option'.
When run alone using "--tests virsh.edit" - the error didn't occur.
After looking at the test for a while I noticed that part of the
processing is to shutdown the guest prior to the last modify_vcpu()
call. Doing that means the 'id' is no longer valid - thus a failure
could occur that wasn't expected. Even after changing that I got a few
more failures - so on a whim I changed the sleep() from 1 to 2 and have
not had any failures.
