### PR TITLE
tests.qemu.test: Seabios test only support linux guest

### DIFF
--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -1,4 +1,5 @@
 - seabios: install setup image_copy unattended_install.cdrom
+    only Linux
     no Host_RHEL.5
     type = seabios
     start_vm = no


### PR DESCRIPTION
Currently seabios test only support linux guest, this patch
add "only Linux" in seabios test configration.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
