### PR TITLE
virsh_create_pool: Fix test error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create.cfg
@@ -4,7 +4,7 @@
     vms =
     main_vm =
     start_vm = "no"
-    pool_create_xml_file = "/tmp/virt-test-pool.xml"
+    pool_create_xml_file = "virt-test-pool.xml"
     pool_create_name = "virt-test-pool"
     pool_create_use_exist_pool = "no"
     pool_create_exist_pool_name = ""

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1413,7 +1413,13 @@ def net_state_dict(only_names=False, virsh_instance=None, **dargs):
         net_list_result = net_list("--all", **dargs)
     # If command failed, exception would be raised here
     netlist = net_list_result.stdout.strip().splitlines()
-    # First two lines contain table header
+    # First two lines contain table header followed by entries
+    # for each pool on the host, such as:
+    #
+    #   Name                 State      Autostart     Persistent
+    #  ----------------------------------------------------------
+    #   default              active     yes           yes
+    #
     # TODO: Double-check first-two lines really are header
     netlist = netlist[2:]
     result = {}
@@ -1421,7 +1427,7 @@ def net_state_dict(only_names=False, virsh_instance=None, **dargs):
         # Split on whitespace, assume 3 columns
         linesplit = line.split(None, 3)
         name = linesplit[0]
-        # Several callers in libvirt_xml only requre defined names
+        # Several callers in libvirt_xml only require defined names
         if only_names:
             result[name] = None
             continue
@@ -1631,6 +1637,51 @@ def pool_list(option="", extra="", **dargs):
     :param extra: to provide extra options(to enter invalid options)
     """
     return command("pool-list %s %s" % (option, extra), **dargs)
+
+
+def pool_state_dict(only_names=False, **dargs):
+    """
+    Return pool name to state/autostart mapping
+
+    :param only_names: When true, return pool names as keys and None values
+    :param dargs: standardized virsh function API keywords
+    :return: dictionary
+    """
+    # Using multiple virsh commands in different ways
+    dargs['ignore_status'] = False  # force problem detection
+    pool_list_result = pool_list("--all", **dargs)
+    # If command failed, exception would be raised here
+    poollist = pool_list_result.stdout.strip().splitlines()
+    # First two lines contain table header followed by entries
+    # for each pool on the host, such as:
+    #
+    #   Name                 State      Autostart
+    #  -------------------------------------------
+    #   default              active     yes
+    #   iscsi-net-pool       active     yes
+    #
+    # TODO: Double-check first-two lines really are header
+    poollist = poollist[2:]
+    result = {}
+    for line in poollist:
+        # Split on whitespace, assume 3 columns
+        linesplit = line.split(None, 3)
+        name = linesplit[0]
+        # Several callers in libvirt_xml only require defined names
+        #  TODO: Copied from net_state_dict where this is true, but
+        #        as of writing only caller is virsh_pool_create test
+        #        which doesn't use this 'feature'.
+        if only_names:
+            result[name] = None
+            continue
+        # Keep search fast & avoid first-letter capital problems
+        active = not bool(linesplit[1].count("nactive"))
+        autostart = bool(linesplit[2].count("es"))
+
+        # Warning: These key names are used by libvirt_xml and test modules!
+        result[name] = {'active': active,
+                        'autostart': autostart}
+    return result
 
 
 def pool_define_as(name, pool_type, target, extra="", **dargs):


### PR DESCRIPTION
The test tried to use a non-existent "/tmp/<file>.xml" - so instead
of doing that - I've created a "tmp/<file>.xml" on the fly using the
data images directory as the pool location (e.g. where the jeos lives)

Secondarily, I found that the test was destroying my running default
pool. So two subsequent runs would have different results. Turns out
there is a positive and negative run for "default" pool copying - in
one instance the pool isn't stopped and a new one is attempted to be
created, resulting in the expected error; however, in the finally path
there was no check to not destroy the "created" pool.
