### PR TITLE
qemu.tests.cpuinfo_query: Fix #1198

### DIFF
--- a/qemu/tests/cfg/cpuinfo_query.cfg
+++ b/qemu/tests/cfg/cpuinfo_query.cfg
@@ -7,6 +7,7 @@
             query_cmd = " -cpu ?cpuid"
             cpu_info = "f_edx,f_ecx,extf_edx,extf_ecx"
         - qmachine_type:
+            only Host_RHEL.6.4
             query_cmd = " -M ?"
             cpu_info = "pc,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
         - qcpu_dump:


### PR DESCRIPTION
The test is wired up to check RHEL machine types, that
will not be present on anything that is not strictly
RHEL 6.4, so restrict the test to those hosts.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
