### PR TITLE
virsh_migrate_multi_vms: SKIP if srcuri and desturi not defined

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -207,6 +207,12 @@ def run_virsh_migrate_multi_vms(test, params, env):
     srcuri = libvirt_vm.get_uri_with_transport(transport="ssh",
                                                dest_ip=local_host)
 
+    # Don't allow the defaults.
+    if srcuri.count('///') or src_uri.count('EXAMPLE'):
+        raise error.TestNAError("The srcuri '%s' is invalid", srcuri)
+    if desturi.count('///') or dest_uri.count('EXAMPLE'):
+        raise error.TestNAError("The desturi '%s' is invalid", desturi)
+
     # Prepare MigrationHelper instance
     helpers = []
     for vm_name in vm_names:


### PR DESCRIPTION
Issue #1014, SKIP this test if we haven't adjusted the cfg to have
real source and destination URI's
