### PR TITLE
tools/run_pylint.py: Handle unforseen exceptions running pylint

### DIFF
--- a/tools/run_pylint.py
+++ b/tools/run_pylint.py
@@ -107,9 +107,15 @@ def check_file(file_path):
             return 0
     pylint_opts = get_pylint_opts()
     if pylint_version >= 0.21:
-        runner = pylint.lint.Run(pylint_opts + [file_path], exit=False)
+        try:
+            runner = pylint.lint.Run(pylint_opts + [file_path], exit=False)
+        except Exception, err:
+            print "Unexpected exception checking %s: %s" % (file_path, err)
     else:
-        runner = pylint.lint.Run(pylint_opts + [file_path])
+        try:
+            runner = pylint.lint.Run(pylint_opts + [file_path])
+        except Exception, err:
+            print "Unexpected exception checking %s: %s" % (file_path, err)
 
     return runner.linter.msg_status
 


### PR DESCRIPTION
In some testing scenarios, such as daily pylint checking
on py 2.4, we noticed the attempt to inspect some pygtk
code generated problems such as:

RuntimeError: could not open display

Making the rest of the checks to be aborted. Let's handle
the exceptions and print the messages as we should.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
