### PR TITLE
run: Fix logic in new run options

### DIFF
--- a/run
+++ b/run
@@ -669,12 +669,12 @@ class VirtTestApp(object):
             logging.info("Config provided, ignoring --tests option")
 
     def _process_restart_vm(self):
-        if not self.options.keep_guest_running:
-            self.cartesian_parser.assign("kill_vm", "yes")
+        if self.options.keep_guest_running:
+            self.cartesian_parser.assign("kill_vm", "no")
 
     def _process_restore_image_between_tests(self):
-        if not self.options.keep_image_between_tests:
-            self.cartesian_parser.assign("restore_image", "yes")
+        if self.options.keep_image_between_tests:
+            self.cartesian_parser.assign("restore_image", "no")
 
     def _process_mem(self):
         self.cartesian_parser.assign("mem", self.options.mem)

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -332,7 +332,7 @@ restore_image_on_check_error = no
 # Enable restore_image = yes globally unconditionally to restore image between
 #    tests. Used when you want to be *extra* careful that you're starting with
 #    a fully clean and pristine image.
-restore_image = no
+restore_image = yes
 # skip_image_processing: if yes, don't do any image processing before or
 # after the test runs (corruption checking, etc.)
 skip_image_processing = no
@@ -345,7 +345,7 @@ kill_vm_before_test = no
 paused_after_start_vm = no
 
 # Some postprocessor params
-kill_vm = no
+kill_vm = yes
 kill_vm_gracefully = yes
 kill_unresponsive_vms = yes
 # Wait time before kill vm


### PR DESCRIPTION
When an option is set, this option will override that is defined in the
cfg file. Otherwise, the behavior is defined by the cfg file.

So when processing options, we should not use negative condition 'if not',
because this will impose the option when it's not set and follow the cfg
file when set. This is not the hehavior we expect.

To set the default behavior, we need to change the shared base cfg file.

Signed-off-by: Hao Liu hliu@redhat.com
