### PR TITLE
libvirt: Fix schedinfo cgroup bug

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -36,12 +36,19 @@ def run_virsh_schedinfo_qemu_posix(test, params, env):
         """
         cgroup_path = \
             utils_cgroup.resolve_task_cgroup_path(vm.get_pid(), "cpu")
+
+        # When a VM has an 'emulator' child cgroup present, we must
+        # strip off that suffix when detecting the cgroup for a machine
+        if os.path.basename(cgroup_path) == "emulator":
+            cgroup_path = os.path.dirname(cgroup_path)
         cgroup_file = os.path.join(cgroup_path, parameter)
-        if not os.path.exists(cgroup_file):
-            raise error.TestNAError("Unknown path to cgroups", cgroup_file)
-        get_value_cmd = "cat %s" % cgroup_file
-        result = utils.run(get_value_cmd, ignore_status=True)
-        return result.stdout.strip()
+        try:
+            with open(cgroup_file) as cg_file:
+                result = cg_file.read()
+        except IOError:
+            raise error.TestError("Failed to open cgroup file %s"
+                                  % cgroup_file)
+        return result.strip()
 
     def schedinfo_output_analyse(result, set_ref, scheduler="posix"):
         """


### PR DESCRIPTION
This PR depends on #1253 

This fix use 'open' instead of 'cat' to access cgroup file to prevent
problem if slash ('\') exist in file path.

If the cgroup path has a 'emulator' sub-directory. We need to trim it to
get the desired cgroup file.

Signed-off-by: Hao Liu hliu@redhat.com
