### PR TITLE
qemu_vm, aexpect, utils_misc: attempt to catch qemu in defunct state.

### DIFF
--- a/virttest/aexpect.py
+++ b/virttest/aexpect.py
@@ -685,6 +685,12 @@ class Spawn(object):
         """
         return _locked(self.lock_server_running_filename)
 
+    def is_defunct(self):
+        """
+        Return True if the process is defunct (zombie).
+        """
+        return utils_misc.process_or_children_is_defunct(self.get_pid())
+
     def kill(self, sig=signal.SIGKILL):
         """
         Kill the child process if alive

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2058,6 +2058,12 @@ class VM(virt_vm.BaseVM):
                     except OSError:
                         pass
 
+            # Make sure qemu is not defunct
+            if self.process.is_defunct():
+                logging.error("Bad things happened, qemu process is defunct")
+                self.destroy()
+                raise virt_vm.VMStartError(self.name, "Qemu is defunct")
+
             # Make sure the process was started successfully
             if not self.process.is_alive():
                 status = self.process.get_status()

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -206,6 +206,22 @@ def kill_process_tree(pid, sig=signal.SIGKILL):
     safe_kill(pid, signal.SIGCONT)
 
 
+def process_or_children_is_defunct(ppid):
+    """Verify if any processes from PPID is defunct.
+
+    Attempt to verify if parent process and any children from PPID is defunct
+    (zombie) or not.
+    :param ppid: The parent PID of the process to verify.
+    """
+    defunct = False
+    for pid in utils.get_children_pids(ppid):
+        cmd = "ps --no-headers -o cmd %d" % int(pid)
+        proc_name = utils.system_output(cmd, ignore_status=True)
+        if '<defunct>' in proc_name:
+            defunct = True
+            break
+    return defunct
+
 # The following are utility functions related to ports.
 
 def is_port_free(port, address):


### PR DESCRIPTION
Add support to detect if qemu becomes <defunct> (zombie) after it was started. If qemu is detected defunct, it will raise `virt_vm.VMStartError()`.

Signed-off-by: Ruda Moura rmoura@redhat.com
