### PR TITLE
virttest: Call utils_net.update_mac_ip_address() in vm.create() when mac...

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -134,10 +134,6 @@ def preprocess_vm(test, params, env, name):
                 vm.create(migration_mode=params.get("migration_mode"),
                           migration_fd=params.get("migration_fd"),
                           migration_exec_cmd=params.get("migration_exec_cmd_dst"))
-            # Update mac and IP info for assigned device
-            # NeedFix: Can we find another way to get guest ip?
-            if params.get("mac_changeable") == "yes":
-                utils_net.update_mac_ip_address(vm, params)
     elif not vm.is_alive():    # VM is dead and won't be started, update params
         vm.devices = None
         vm.params = params

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2164,6 +2164,11 @@ class VM(virt_vm.BaseVM):
                         else:
                             raise e
 
+            # Update mac and IP info for assigned device
+            # NeedFix: Can we find another way to get guest ip?
+            if params.get("mac_changeable") == "yes":
+                utils_net.update_mac_ip_address(self, params)
+
         finally:
             fcntl.lockf(lockfile, fcntl.LOCK_UN)
             lockfile.close()


### PR DESCRIPTION
..._changeable set to yes

Sometime we directly call vm.create() to create a VM. mac_changeable could not work
in this situation. As it only used in qemu test so move utils_net.update_mac_ip_address()
to vm.create() function.

If other test need support mac_changeable later, we can call  update_mac_ip_address
in its start() function.

Signed-off-by: Feng Yang fyang@redhat.com
