### PR TITLE
qemu.tests.cfg: use absolute path for saving file cmds

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -51,16 +51,16 @@
             use_nodefaults = no
         - qmp_memsave:
             event_cmd_type = host_cmd
-            qmp_cmd = "memsave val=0, size=4096, filename=memsave"
-            pre_cmd = rm -rf memsave
-            post_cmd = "ls memsave; true"
+            qmp_cmd = "memsave val=0, size=4096, filename=/var/tmp/memsave"
+            pre_cmd = "rm -rf /var/tmp/memsave"
+            post_cmd = "ls /var/tmp/memsave; true"
             cmd_result_check = post_contain
             cmd_return_value = memsave
         - qmp_pmemsave:
             event_cmd_type = host_cmd
-            qmp_cmd = "pmemsave val=0, size=4096, filename=pmemsave"
-            pre_cmd = rm -rf pmemsave
-            post_cmd = "ls pmemsave; true"
+            qmp_cmd = "memsave val=0, size=4096, filename=/var/tmp/pmemsave"
+            pre_cmd = "rm -rf /var/tmp/pmemsave"
+            post_cmd = "ls /var/tmp/pmemsave; true"
             cmd_result_check = post_contain
             cmd_return_value = pmemsave
         - qmp_query-cpus:


### PR DESCRIPTION
when launching a testcase the 2nd time w/o kill the alive VM,
the origin pwd dir which boot the VM is removed/differ(the name
could be same, but the inode isn't, lsof -p $PID will show),
thus cases use relevant path would fail as the path is not
longer valid. like qmp_command.memsave qmp_command.pmemsave.

Signed-off-by: Xiaoqing Wei xwei@redhat.com
