### PR TITLE
qemu.tests.cfg: add remove_image_stg for usb_storage

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -167,6 +167,7 @@
             image_boot_stg = no
             drive_index_stg = 1
             create_image_stg = yes
+            remove_image_stg = yes
             image_size_stg = 10M
             fdisk_string = "10 MB, 10485760 bytes"
             format_timeout = 400


### PR DESCRIPTION
need to remove the origin image and create a new image for format_disk
when running every usb_storage subcase.

Signed-off-by: Shuping Cui scui@redhat.com
