### PR TITLE
staging.backports.simplejson: Use all relative imports

### DIFF
--- a/virttest/staging/__init__.py
+++ b/virttest/staging/__init__.py
@@ -3,3 +3,4 @@ import service
 import utils_cgroup
 import utils_koji
 import utils_memory
+import backports

--- a/virttest/staging/backports/simplejson/__init__.py
+++ b/virttest/staging/backports/simplejson/__init__.py
@@ -124,7 +124,7 @@ OrderedDict = _import_OrderedDict()
 
 def _import_c_make_encoder():
     try:
-        from simplejson._speedups import make_encoder
+        from _speedups import make_encoder
         return make_encoder
     except ImportError:
         return None

--- a/virttest/staging/backports/simplejson/decoder.py
+++ b/virttest/staging/backports/simplejson/decoder.py
@@ -4,12 +4,12 @@ import re
 import sys
 import struct
 
-from simplejson.scanner import make_scanner
+from scanner import make_scanner
 
 
 def _import_c_scanstring():
     try:
-        from simplejson._speedups import scanstring
+        from _speedups import scanstring
         return scanstring
     except ImportError:
         return None

--- a/virttest/staging/backports/simplejson/encoder.py
+++ b/virttest/staging/backports/simplejson/encoder.py
@@ -12,7 +12,7 @@ def _import_speedups():
         return None, None
 c_encode_basestring_ascii, c_make_encoder = _import_speedups()
 
-from simplejson.decoder import PosInf
+from decoder import PosInf
 
 ESCAPE = re.compile(r'[\x00-\x1f\\"\b\f\n\r\t]')
 ESCAPE_ASCII = re.compile(r'([\\"]|[^\ -~])')

--- a/virttest/staging/backports/simplejson/scanner.py
+++ b/virttest/staging/backports/simplejson/scanner.py
@@ -5,7 +5,7 @@ import re
 
 def _import_c_make_scanner():
     try:
-        from simplejson._speedups import make_scanner
+        from _speedups import make_scanner
         return make_scanner
     except ImportError:
         return None


### PR DESCRIPTION
Due to the import structure of the staging module, in
order to make importing the simplejson module possible
in systems without python-simplejson installed already,
use only relative imports. This will avoid the error

ImportError: No module named simplejson.scanner

Found by jferlan.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
