### PR TITLE
cfg: Fix tcpdump kill command to work on a wider variety of hosts

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -3,7 +3,7 @@
     migration_test_command = help
     migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
     migration_bg_check_command = pgrep tcpdump
-    migration_bg_kill_command = pkill --signal 9 tcpdump
+    migration_bg_kill_command = pkill -9 tcpdump
     kill_vm_on_error = yes
     iterations = 2
     used_mem = 1024

--- a/qemu/tests/cfg/multi_host.cfg
+++ b/qemu/tests/cfg/multi_host.cfg
@@ -17,7 +17,7 @@
             migration_test_command = help
             migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
             migration_bg_check_command = pgrep tcpdump
-            migration_bg_kill_command = pkill --signal 9 tcpdump
+            migration_bg_kill_command = pkill -9 tcpdump
             kill_vm_on_error = yes
             iterations = 2
             used_mem = 1024

--- a/qemu/tests/cfg/spice.cfg
+++ b/qemu/tests/cfg/spice.cfg
@@ -43,7 +43,7 @@
             migration_test_command = help
             #migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
             #migration_bg_check_command = pgrep tcpdump
-            #migration_bg_kill_command = pkill --signal 9 tcpdump
+            #migration_bg_kill_command = pkill -9 tcpdump
             kill_vm_on_error = yes
             iterations = 2
             used_mem = 1024

--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -118,7 +118,7 @@
         test_s4_cmd = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
         check_s4_cmd = pgrep tcpdump
         set_s4_cmd = echo disk > /sys/power/state
-        kill_test_s4_cmd = pkill --signal 9 tcpdump
+        kill_test_s4_cmd = pkill -9 tcpdump
         services_up_timeout = 30
     guest_s4, check_suspend, balloon_fix_value, timedrift_adjust_time.guest_s4_time_drift..adjust_host_clock:
         s4_support_chk_cmd = "dmesg -c > /dev/null && grep -q disk /sys/power/state"


### PR DESCRIPTION
Using 'pkill -9 tcpdump' works on both new and older
distros.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
