### PR TITLE
unattended_install.cfg: limit disk num to 6 in multi_disk_install when sing ahci

### DIFF
--- a/tests/cfg/unattended_install.cfg
+++ b/tests/cfg/unattended_install.cfg
@@ -77,6 +77,8 @@
             image_name_stg24 = images/storage24
             image_name_stg25 = images/storage25
             image_size_equal = 1G
+            ahci:
+                images = "image1 stg stg2 stg3 stg4 stg5"
         - large_image:
             only unattended_install.cdrom
             only qcow2 qcow2v3


### PR DESCRIPTION
An ahci controller can have up to 6 downstream devices,
so need to limit disk num to 6.

history:
  V2:
    add image1 in the images value
  V1:
    assign 6 stg name as the images value

Signed-off-by: Xiangmin Han xhan@redhat.com
