### PR TITLE
qemu: change test entry point method name to 'run(..)'

### DIFF
--- a/qemu/tests/file_copy_stress.py
+++ b/qemu/tests/file_copy_stress.py
@@ -6,7 +6,7 @@ from autotest.client import utils
 from virttest import data_dir, utils_misc
 
 @error.context_aware
-def run_file_copy_stress(test, params, env):
+def run(test, params, env):
     """
     Transfer a file back and forth between host and guest.
 

--- a/qemu/tests/gluster_boot_snap_boot.py
+++ b/qemu/tests/gluster_boot_snap_boot.py
@@ -6,7 +6,7 @@ from virttest import data_dir
 
 
 @error.context_aware
-def run_gluster_boot_snap_boot(test, params, env):
+def run(test, params, env):
     """
     Run an gluster test.
     steps:

--- a/qemu/tests/gluster_create_images.py
+++ b/qemu/tests/gluster_create_images.py
@@ -4,7 +4,7 @@ from virttest import env_process
 
 
 @error.context_aware
-def run_gluster_create_images(test, params, env):
+def run(test, params, env):
     """
     Run an gluster test.
     steps:

--- a/qemu/tests/hypervisor_flag.py
+++ b/qemu/tests/hypervisor_flag.py
@@ -5,7 +5,7 @@ Sanity check for hypervisor flag in guest.
 import logging
 from autotest.client.shared import error
 
-def run_hypervisor_flag(test, params, env):
+def run(test, params, env):
     """
     Test if guest has 'hypervisor' flag in /proc/cpuinfo.
 

--- a/qemu/tests/mq_change_qnum.py
+++ b/qemu/tests/mq_change_qnum.py
@@ -6,7 +6,7 @@ from virttest import utils_net, utils_test, utils_misc
 
 
 @error.context_aware
-def run_mq_change_qnum(test, params, env):
+def run(test, params, env):
     """
     MULTI_QUEUE chang queues number test
 

--- a/qemu/tests/netperf_stress.py
+++ b/qemu/tests/netperf_stress.py
@@ -6,7 +6,7 @@ from virttest import utils_net, utils_netperf, utils_misc
 
 
 @error.context_aware
-def run_netperf_stress(test, params, env):
+def run(test, params, env):
     """
     Run netperf on server and client side, we need run this case on two
     machines. if dsthost is not set will start netperf server on local

--- a/qemu/tests/pktgen.py
+++ b/qemu/tests/pktgen.py
@@ -8,7 +8,7 @@ from virttest import remote, data_dir, utils_net, aexpect
 
 
 @error.context_aware
-def run_pktgen(test, params, env):
+def run(test, params, env):
     """
     Run Pktgen test between host/guest
 

--- a/qemu/tests/qemu_option_check.py
+++ b/qemu/tests/qemu_option_check.py
@@ -6,7 +6,7 @@ from virttest import utils_misc
 
 
 @error.context_aware
-def run_qemu_option_check(test, params, env):
+def run(test, params, env):
     """
     QEMU support options check test
 

--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -39,7 +39,7 @@ def ifup_down_interface(interface, action="up"):
 
 
 @error.context_aware
-def run_sr_iov_sanity(test, params, env):
+def run(test, params, env):
     """
     SR-IOV devices sanity test:
     1) Bring up VFs by following instructions How To in Setup.

--- a/qemu/tests/suspend_under_stress.py
+++ b/qemu/tests/suspend_under_stress.py
@@ -6,7 +6,7 @@ from tests import guest_suspend
 
 
 @error.context_aware
-def run_suspend_under_stress(test, params, env):
+def run(test, params, env):
     """
     Run guest suspend under guest nic stress
 

--- a/qemu/tests/timedrift_adjust_time.py
+++ b/qemu/tests/timedrift_adjust_time.py
@@ -300,7 +300,7 @@ class BackwardtimeTest(TimedriftTest):
 
 
 @error.context_aware
-def run_timedrift_adjust_time(test, params, env):
+def run(test, params, env):
     """
     Time drift after change host/guest sysclock test:
 

--- a/qemu/tests/zero_copy.py
+++ b/qemu/tests/zero_copy.py
@@ -5,7 +5,7 @@ from virttest import env_process, utils_test
 
 
 @error.context_aware
-def run_zero_copy(test, params, env):
+def run(test, params, env):
     """
     Vhost zero copy test
     1) Enable/Disable vhost_net zero copy in host


### PR DESCRIPTION
There's no need to have the name of the "run_" method (main
test entry point) depend on the test name. So, for simplicity sake,
let's just name the test entry point "run".

Note: Related to PR #1196.

Signed-off-by: Ruda Moura rmoura@redhat.com
