### PR TITLE
block_resize.cfg: RHEL5 need reboot step in block_resize case

### DIFF
--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -1,6 +1,7 @@
 - block_resize:
     # As XP and 2003 guest disk manager not support disk shrink. So don't test them for this feature
     no WinXP Win2003
+    no RHEL.4
     only qcow2 raw
     type = block_resize
     images += " stg"
@@ -48,3 +49,5 @@
         disk_change_ratio = 1.5
     raw:
         disk_change_ratio = 1.5 0.5
+    RHEL.5:
+        need_reboot = yes


### PR DESCRIPTION
Guest RHEL5 could not detect disk change,
assign need_reboot as yes in the cfg file.

history:
  V2:
    change to RHEL.5 condition
  V1:
    add RHEL and 5 condition lines

Signed-off-by: Xiangmin Han xhan@redhat.com
