### PR TITLE
env_process: Fix behavior of convert_ppm_files_to_png param

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -352,7 +352,7 @@ kill_unresponsive_vms = yes
 kill_timeout = 60
 
 # Screendump thread params
-convert_ppm_files_to_png_on_error = yes
+convert_ppm_files_to_png = no
 keep_ppm_files = no
 keep_ppm_files_on_error = no
 screendump_quality = 30

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -691,7 +691,7 @@ def postprocess(test, params, env):
             logging.warn("Found corrupt PPM file: %s", f)
 
     # Should we convert PPM files to PNG format?
-    if params.get("convert_ppm_files_to_png") == "yes":
+    if params.get("convert_ppm_files_to_png", "no") == "yes":
         try:
             for f in glob.glob(os.path.join(test.debugdir, "*.ppm")):
                 if ppm_utils.image_verify_ppm_file(f):


### PR DESCRIPTION
Due to a mistake of the feature authors, the param
convert_ppm_files_to_png is not set in base.cfg. Let's
fix this mistake, and set the behavior more explicitly.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
