### PR TITLE
virt.storage: Fix bug when checking for backup directory

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -317,7 +317,7 @@ class QemuImg(object):
             return bkp_set
 
         image_filename = self.image_filename
-        backup_dir = params.get("backup_dir")
+        backup_dir = params.get("backup_dir", "")
         if not os.path.isabs(backup_dir):
             backup_dir = os.path.join(root_dir, backup_dir)
         if params.get('image_raw_device') == 'yes':


### PR DESCRIPTION
By default, .get() on a dict will return None. Using None
in a os.path related function is going to throw an error.

So we can fix that issue by using an appropriate default
value that won't break os.path.isabs().

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
