### PR TITLE
libvirt: Fix attach-device itertools backports

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -5,13 +5,12 @@ Module to exercize virsh attach-device command with various devices/options
 import os
 import os.path
 import logging
-from itertools import product, islice, count
 from string import ascii_lowercase
 from autotest.client.shared import error
 from virttest import virt_vm, virsh, remote, aexpect, utils_misc
 from virttest.libvirt_xml.vm_xml import VMXML
 # The backports module will take care of using the builtins if available
-from virttest.staging.backports.itertools import product, islice, count
+from virttest.staging.backports import itertools
 
 # TODO: Move all these helper classes someplace else
 class TestParams(object):
@@ -446,10 +445,10 @@ class VirtIODiskBasic(AttachDeviceBase):
         # python-pair-alphabets-after-loop-is-completed/14382997#14382997
         def multiletters():
             """Generator of count-by-letter strings"""
-            for num in count(1):
-                for prod in product(ascii_lowercase, repeat=num):
+            for num in itertools.count(1):
+                for prod in itertools.product(ascii_lowercase, repeat=num):
                     yield ''.join(prod)
-        return islice(multiletters(), index, index + 1).next()
+        return itertools.islice(multiletters(), index, index + 1).next()
 
     def make_image_file_path(self, index):
         """Create backing file for test disk device"""


### PR DESCRIPTION
Calling backported itertools using 'from ... import ...' will cause
following error.

ERROR| Traceback (most recent call last):
ERROR|   File "virttest/standalone_test.py", line 182, in run_once
ERROR|     test_modules[t_type] = imp.load_module(t_type, f, p, d)
ERROR|   File "libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py", line 14, in <module>
ERROR|     from virttest.staging.backports.itertools import product, islice, count
ERROR| ImportError: No module named itertools

Signed-off-by: Hao Liu hliu@redhat.com
