### PR TITLE
Add test for virsh send-key

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -1,0 +1,51 @@
+- virsh.sendkey:
+    type = virsh_sendkey
+    start_vm = "yes"
+    take_regular_screendumps = "no"
+    variants:
+        - params_test:
+            sendkey_params = "yes"
+            create_file_name = "/root/abc"
+            variants:
+                # All code implement "touch create_file_name" command in guest
+                - with_holdtime:
+                    sendkey_options = "--holdtime 1000 20 24 22 46 35 57 30 48 46 28"
+                - linux_keycode:
+                    sendkey_options = "--codeset linux 20 24 22 46 35 57 30 48 46 28"
+                - os-x_name:
+                    sendkey_options = "--codeset os_x ANSI_T ANSI_O ANSI_U ANSI_C ANSI_H Space ANSI_A ANSI_B ANSI_C Return"
+                - os-x_keycode:
+                    sendkey_options = "--codeset os_x 0x11 0x1f 0x20 0x8 0x4 0x31 0x0 0xb 0x8 0x24"
+                - at_set1_keycode:
+                    sendkey_options = "--codeset atset1 20 24 22 46 35 57 30 48 46 28"
+                - at_set2_keycode:
+                    sendkey_options = "--codeset atset2 44 68 60 33 51 41 28 50 33 90"
+                - at_set3_keycode:
+                    sendkey_options = "--codeset atset3 44 68 60 33 51 41 28 50 33 90"
+                - xt_keycode:
+                    sendkey_options = "--codeset xt 20 24 22 46 35 57 30 48 46 28"
+                - xt_kbd_keycode:
+                    sendkey_options = "--codeset xt_kbd 20 24 22 46 35 57 30 48 46 28"
+                - usb_keycode:
+                    sendkey_options = "--codeset usb 23 18 24 6 11 44 4 5 6 40"
+                - win32_name:
+                    sendkey_options = "--codeset win32 VK_T VK_O VK_U VK_C VK_H VK_SPACE VK_A VK_B VK_C VK_RETURN"
+                - win32_keycode:
+                    sendkey_options = "--codeset win32 0x54 0x4f 0x55 0x43 0x48 0x20 0x41 0x42 0x43 0x0d"
+                - rfb_keycode:
+                    sendkey_options = "--codeset rfb 20 24 22 46 35 57 30 48 46 28"
+                - default_name:
+                    sendkey_options = "KEY_T KEY_O KEY_U KEY_C KEY_H KEY_SPACE KEY_A KEY_B KEY_C KEY_ENTER"
+        - sysrq:
+            sendkey_sysrq = "yes"
+            variants:
+                - help:
+                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_H"
+                - show_memory_usage:
+                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_M"
+                - show_task_status:
+                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_T"
+        - readonly:
+            readonly = True
+            status_error = "yes"
+            sendkey_options = "KEY_T"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -1,0 +1,110 @@
+import logging
+import time
+from autotest.client.shared import error
+from virttest import virsh
+
+
+def run(test, params, env):
+    """
+    Test send-key command, include all types of codeset and sysrq
+
+    For normal sendkey test, we create a file to check the command
+    execute by send-key. For sysrq test, check the /var/log/messages
+    and guest status
+    """
+
+    if not virsh.has_help_command('send-key'):
+        raise error.TestNAError("This version of libvirt does not support "
+                                "the send-key test")
+
+    vm_name = params.get("main_vm", "virt-tests-vm1")
+    status_error = ("yes" == params.get("status_error", "no"))
+    options = params.get("sendkey_options", "")
+    params_test = ("yes" == params.get("sendkey_params", "no"))
+    sysrq_test = ("yes" == params.get("sendkey_sysrq", "no"))
+    readonly = params.get("readonly", False)
+    username = params.get("username")
+    password = params.get("password")
+    create_file = params.get("create_file_name")
+
+    def send_line(send_str):
+        """
+        send string to guest with send-key and end with Enter
+        """
+        for send_ch in list(send_str):
+            virsh.sendkey(vm_name, "KEY_%s" % send_ch.upper(),
+                          ignore_status=False)
+
+        virsh.sendkey(vm_name, "KEY_ENTER", ignore_status=False)
+
+    vm = env.get_vm(vm_name)
+    session = vm.wait_for_login()
+
+    if sysrq_test:
+        # clear messages before test
+        session.cmd("echo '' > /var/log/message")
+        # enable sysrq
+        session.cmd("echo 1 > /proc/sys/kernel/sysrq")
+
+    # make sure the environment is clear
+    session.cmd("rm -rf %s" % create_file)
+
+    try:
+        # wait for tty1 started
+        tty1_stat = "ps aux|grep [/]sbin/.*tty.*tty1"
+        timeout = 60
+        while timeout >= 0 and \
+                session.get_command_status(tty1_stat) != 0:
+            time.sleep(1)
+            timeout = timeout - 1
+        if timeout < 0:
+            raise error.TestFail("Can not wait for tty1 started in 60s")
+
+        # send user and passwd to guest to login
+        send_line(username)
+        time.sleep(2)
+        send_line(password)
+        time.sleep(2)
+
+        output = virsh.sendkey(vm_name, options, readonly=readonly)
+        time.sleep(2)
+        if output.exit_status != 0:
+            if status_error:
+                logging.info("Failed to sendkey to guest as expected, Error:"
+                             "%s.", output.stderr)
+                return
+            else:
+                raise error.TestFail("Failed to send key to guest, Error:%s." %
+                                     output.stderr)
+        elif status_error:
+            raise error.TestFail("Expect fail, but succeed indeed.")
+
+        if params_test:
+            # check if created file exist
+            cmd_ls = "ls %s" % create_file
+            sec_status, sec_output = session.get_command_status_output(cmd_ls)
+            if sec_status == 0:
+                logging.info("Succeed to create file with send key")
+            else:
+                raise error.TestFail("Fail to create file with send key, "
+                                     "Error:%s" % sec_output)
+        elif sysrq_test:
+            # check /var/log/message info according to different key
+            if "KEY_H" in options:
+                get_status = session.cmd_status("cat /var/log/messages|"
+                                                "grep SysRq.*HELP")
+            elif "KEY_M" in options:
+                get_status = session.cmd_status("cat /var/log/messages|"
+                                                "grep 'SysRq.*Show Memory'")
+            elif "KEY_T" in options:
+                get_status = session.cmd_status("cat /var/log/messages|"
+                                                "grep 'SysRq.*Show State'")
+            if get_status != 0:
+                raise error.TestFail("SysRq does not take effect in guest, "
+                                     "options is %s" % options)
+            else:
+                logging.info("Succeed to send SysRq command")
+
+    finally:
+        session.cmd("rm -rf %s" % create_file)
+        session.close()

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2835,3 +2835,15 @@ def domfstrim(name, minimum=None, mountpoint=None, options="", **dargs):
 
     cmd += " %s" % options
     return command(cmd, **dargs)
+
+
+def sendkey(name, options="", **dargs):
+    """
+    Send keycodes to the guest
+    :param name: name of domain
+    :param codeset: the codeset of keycodes
+    :param keycode: the key code
+    :return: CmdResult object
+    """
+    cmd = "send-key %s %s" % (name, options)
+    return command(cmd, **dargs)


### PR DESCRIPTION
```
  NAME
    send-key - Send keycodes to the guest

  SYNOPSIS
    send-key <domain> [--codeset <string>] [--holdtime <number>] {[--keycode] <string>}...

  DESCRIPTION
    Send keycodes (integers or symbolic names) to the guest

  OPTIONS
    [--domain] <string>  domain name, id or uuid
    --codeset <string>  the codeset of keycodes, default:linux
    --holdtime <number>  the time (in milliseconds) how long the keys will be held
    [--keycode] <string>  the key code

```

Signed-off-by: Kyla Zhang weizhan@redhat.com
