### PR TITLE
[PR Updated] virttest.libvirt_xml.vm_xml: Add option to get_disk_resource

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -455,13 +455,15 @@ class VMXML(VMXMLBase):
         return disks
 
     @staticmethod
-    def get_disk_source(vm_name, virsh_instance=base.virsh):
+    def get_disk_source(vm_name, option="", virsh_instance=base.virsh):
         """
         Get block device  of a defined VM's disks.
 
         :param vm_name: Name of defined vm.
+        :param option: extra option.
         """
-        vmxml = VMXML.new_from_dumpxml(vm_name, virsh_instance=virsh_instance)
+        vmxml = VMXML.new_from_dumpxml(vm_name, option,
+                                       virsh_instance=virsh_instance)
         disks = vmxml.get_disk_all()
         return disks.values()
 


### PR DESCRIPTION
New: Update the PR to suit the change of repo split.  (2014-01-28)
Only include one commit in this:

```
virttest.libvirt_xml.vm_xml: Add option to get_disk_resource

Add option to get_disk_resource to support extra option when
dumpxml.
```

Old log:
Add virsh domblklist test

What's New:
2014-01-09:
As bug 1049529 fixed the --config flag with running domain for attach/detach-disk problem, update the domblklist to use --config rather than --live --config flag when domain is running and --inactive is specified for domblklist.
