### PR TITLE
Extend SLES guest boot timeout

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES.cfg
+++ b/shared/cfg/guest-os/Linux/SLES.cfg
@@ -5,3 +5,6 @@
         kernel = linux
         initrd = initrd
         wait_no_ack = yes
+    boot:
+        # As SLES need to perform firstboot to finish the installation, Extending the boot login_timeout
+        login_timeout = 720


### PR DESCRIPTION
As SLES need to perform firstboot to finish the installation
otherwise, the boot testcase after OS install might fail.

Signed-off-by: Xiaoqing Wei xwei@redhat.com
