### PR TITLE
Disable balloon_fix_value case in ppc64 platform

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -68,6 +68,7 @@
             balloon_type_evict = evict
             balloon_type_enlarge = enlarge
         - balloon_fix_value:
+            no ppc64
             only balloon_base
             test_tags = "evict_to_0.5 enlarge_to_0.75 enlarge_to_0.8"
             balloon_type_evict_to_0.5 = evict


### PR DESCRIPTION
ppc64 platform does not support X86 ACPI s3 and s4 cases,
disable it in ppc64 platform

Signed-off-by: Man Li limansh@cn.ibm.com
Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
