### PR TITLE
qemu.cfg.qemu_img: Change the way used to limit image_backend variant

### DIFF
--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -41,8 +41,6 @@
             subcommand = convert
             compressed = no
             encrypted = no
-            (image_backend=gluster):
-                only to_raw to_qcow2
             variants:
                 - to_qcow2:
                     dest_image_format = qcow2
@@ -62,6 +60,7 @@
                     dest_image_format = raw
                 - to_qed:
                     no Host_RHEL
+                    no (image_backend=gluster)
                     dest_image_format = qed
 
         - snapshot:


### PR DESCRIPTION
"(image_backend=gluster):" is not supported. It is parsed as (image_backend = gluster):

So add "no (image_backend=gluster)" under to_qed variant

Signed-off-by: Feng Yang fyang@redhat.com
