### PR TITLE
virt: Support _min _max _equal suffix in configure.

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -1926,24 +1926,26 @@ class Parser(object):
 
 def print_dicts_default(options, dicts):
     """Print dictionaries in the default mode"""
-    for i, d in enumerate(dicts):
+    for count, dic in enumerate(dicts):
+        postfix_parse(dic)
         if options.fullname:
-            print "dict %4d:  %s" % (i + 1, d["name"])
+            print "dict %4d:  %s" % (count + 1, dic["name"])
         else:
-            print "dict %4d:  %s" % (i + 1, d["shortname"])
+            print "dict %4d:  %s" % (count + 1, dic["shortname"])
         if options.contents:
-            keys = d.keys()
+            keys = dic.keys()
             keys.sort()
             for key in keys:
-                print "    %s = %s" % (key, d[key])
+                print "    %s = %s" % (key, dic[key])
 
 
 # pylint: disable=W0613
 def print_dicts_repr(options, dicts):
     import pprint
     print "["
-    for d in dicts:
-        print "%s," % (pprint.pformat(d))
+    for dic in dicts:
+        postfix_parse(dic)
+        print "%s," % (pprint.pformat(dic))
     print "]"
 
 
@@ -1952,6 +1954,77 @@ def print_dicts(options, dicts):
         print_dicts_repr(options, dicts)
     else:
         print_dicts_default(options, dicts)
+
+
+def convert_data_size(size, default_sufix='B'):
+    '''
+    Convert data size from human readable units to an int of arbitrary size.
+
+    @param size: Human readable data size representation (string).
+    @param default_sufix: Default sufix used to represent data.
+    @return: Int with data size in the appropriate order of magnitude.
+    '''
+    orders = {'B': 1,
+              'K': 1024,
+              'M': 1024 * 1024,
+              'G': 1024 * 1024 * 1024,
+              'T': 1024 * 1024 * 1024 * 1024,
+              }
+
+    order = re.findall("([BbKkMmGgTt])", size[-1])
+    if not order:
+        size += default_sufix
+        order = [default_sufix]
+
+    return int(float(size[0:-1]) * orders[order[0].upper()])
+
+
+def compare_string(str1, str2):
+    """
+    Compare two int string and return -1, 0, 1.
+    It can compare two memory value even in sufix
+
+    @param str1: The first string
+    @param str2: The second string
+
+    @Return: Rteurn -1, when str1<  str2
+                     0, when str1 = str2
+                     1, when str1>  str2
+    """
+    order1 = re.findall("([BbKkMmGgTt])", str1)
+    order2 = re.findall("([BbKkMmGgTt])", str2)
+    if order1 or order2:
+        value1 = convert_data_size(str1, "M")
+        value2 = convert_data_size(str2, "M")
+    else:
+        value1 = int(str1)
+        value2 = int(str2)
+    if value1<  value2:
+        return -1
+    elif value1 == value2:
+        return 0
+    else:
+        return 1
+
+
+def postfix_parse(dic):
+    tmp_dict = {}
+    for key in dic:
+        if key.endswith("_max"):
+            tmp_key = key.split("_max")[0]
+            if not dic.has_key(tmp_key) or \
+                   compare_string(dic[tmp_key], dic[key])>  0:
+                tmp_dict[tmp_key] = dic[key]
+        elif key.endswith("_min"):
+            tmp_key = key.split("_min")[0]
+            if not dic.has_key(tmp_key) or \
+                   compare_string(dic[tmp_key], dic[key])<  0:
+                tmp_dict[tmp_key] = dic[key]
+        elif key.endswith("_equal"):
+            tmp_key = key.split("_equal")[0]
+            tmp_dict[tmp_key] = dic[key]
+    for key in tmp_dict:
+        dic[key] = tmp_dict[key]
 
 
 if __name__ == "__main__":

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -775,10 +775,10 @@ def run_tests(parser, options):
         logging.info(line)
 
     logging.info("Defined test set:")
-    for i, d in enumerate(parser.get_dicts()):
+    for count, dic in enumerate(parser.get_dicts()):
         shortname = d.get("_name_map_file")["subtests.cfg"]
 
-        logging.info("Test %4d:  %s", i + 1, shortname)
+        logging.info("Test %4d:  %s", count + 1, shortname)
         last_index += 1
 
     if last_index == -1:
@@ -808,6 +808,7 @@ def run_tests(parser, options):
     job_start_time = time.time()
 
     for dct in parser.get_dicts():
+        cartesian_config.postfix_parse(dct)
         shortname = d.get("_short_name_map_file")["subtests.cfg"]
 
         if index == 0:

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -22,7 +22,7 @@ import getpass
 from autotest.client import utils, os_dep
 from autotest.client.shared import error, logging_config
 from autotest.client.shared import git
-import data_dir
+import data_dir, cartesian_config
 try:
     from staging import utils_koji
 except ImportError:
@@ -480,8 +480,8 @@ def run_tests(parser, job):
     :return: True, if all tests ran passed, False if any of them failed.
     """
     last_index = -1
-    for i, d in enumerate(parser.get_dicts()):
-        logging.info("Test %4d:  %s" % (i + 1, d["shortname"]))
+    for count, dic in enumerate(parser.get_dicts()):
+        logging.info("Test %4d:  %s" % (count + 1, dic["shortname"]))
         last_index += 1
 
     status_dict = {}
@@ -497,6 +497,7 @@ def run_tests(parser, job):
     setup_flag = 1
     cleanup_flag = 2
     for param_dict in parser.get_dicts():
+        cartesian_config.postfix_parse(param_dict)
         if param_dict.get("host_setup_flag", None) is not None:
             flag = int(param_dict["host_setup_flag"])
             if index == 0:


### PR DESCRIPTION
After this patch, A_min set minimum for A, A_max set maximum for A,
A_equal set value for A.
This feature is useful when we set a parameter and do not want it covered by
new value late.

e.g:
mem_min = 1024
mem = 2048

Then mem = 1024 will be used.

Signed-off-by: Feng Yang fyang@redhat.com
