### PR TITLE
Init serial_ports to [] instead of None

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -110,7 +110,7 @@ class VM(virt_vm.BaseVM):
             self.__dict__ = state
         else:
             self.process = None
-            self.serial_ports = None
+            self.serial_ports = []
             self.serial_console = None
             self.redirs = {}
             self.vnc_port = None
@@ -885,8 +885,7 @@ class VM(virt_vm.BaseVM):
         self.serial_console.set_log_file(output_filename)
 
     def setup_serial_ports(self):
-        if self.serial_ports is None:
-            self.serial_ports = []
+        if not self.serial_ports:
             for serial in self.params.objects("isa_serials"):
                 self.serial_ports.append(serial)
         if self.serial_console is None:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -108,6 +108,7 @@ class VM(virt_vm.BaseVM):
             self.__dict__ = state
         else:
             self.process = None
+            self.serial_ports = []
             self.serial_console = None
             self.redirs = {}
             self.spice_options = {}
@@ -2094,7 +2095,6 @@ class VM(virt_vm.BaseVM):
                 self.monitors += [monitor]
 
             # Create isa serial ports.
-            self.serial_ports = []
             for serial in params.objects("isa_serials"):
                 self.serial_ports.append(serial)
 


### PR DESCRIPTION
In very few case, parameter `serial_ports` may equal to None, then test will fail as:

```
14:23:44 DEBUG| Destroying VM
14:23:44 DEBUG| Releasing MAC addresses for vm virt-tests-vm1.
14:23:45 ERROR| 
14:23:45 ERROR| Traceback (most recent call last):
14:23:45 ERROR|   File "/home/ydu/Work/run/virt-test/virttest/standalone_test.py", line 187, in run_once
14:23:45 ERROR|     params = env_process.preprocess(self, params, env)
14:23:45 ERROR|   File "/home/ydu/Work/autotest/client/shared/error.py", line 141, in new_fn
14:23:45 ERROR|     return fn(*args, **kwargs)
14:23:45 ERROR|   File "/home/ydu/Work/run/virt-test/virttest/env_process.py", line 652, in preprocess
14:23:45 ERROR|     process(test, params, env, preprocess_image, preprocess_vm)
14:23:45 ERROR|   File "/home/ydu/Work/run/virt-test/virttest/env_process.py", line 414, in process
14:23:45 ERROR|     _call_vm_func()
14:23:45 ERROR|   File "/home/ydu/Work/run/virt-test/virttest/env_process.py", line 389, in _call_vm_func
14:23:45 ERROR|     vm_func(test, vm_params, env, vm_name)
14:23:45 ERROR|   File "/home/ydu/Work/run/virt-test/virttest/env_process.py", line 156, in preprocess_vm
14:23:45 ERROR|     vm.create_serial_console()
14:23:45 ERROR|   File "/home/ydu/Work/run/virt-test/virttest/libvirt_vm.py", line 873, in create_serial_console
14:23:45 ERROR|     cmd += (" console %s %s" % (self.name, self.serial_ports[0]))
14:23:45 ERROR| TypeError: 'NoneType' object has no attribute '__getitem__'
14:23:45 ERROR| 
14:23:45 ERROR| FAIL type_specific.virsh.blockcopy.positive_test.no_option -> TypeError: 'NoneType' object has no attribute '__getitem__'
```

As serial_ports used as a list, so init it to [] instead of None.
