### PR TITLE
virt.tests.file_transfer: Modify vhostforce variant to disable msi

### DIFF
--- a/tests/cfg/file_transfer.cfg
+++ b/tests/cfg/file_transfer.cfg
@@ -17,7 +17,14 @@
                     #vhost=on only has effect for virtio guests which use MSIX
                     #for non-MSIX guests vhost_net will disabled automatically
                 - vhostforce_on:
-                    #only for non-MSIX guests, for these guests using
-                    #vhostforce=on, force enable vhost.
-                    only RHEL.5, Windows
+                    #For non-MSIX guests or guest disable pci msi,
+                    #using vhostforce=on, force enable vhost.
                     netdev_extra_params_nic1 += ',vhostforce=on'
+                    variants:
+                        - @default_msi_setting:
+                            only Windows
+                        - force_disable_msi:
+                            #Force disable guest msi
+                            only Linux
+                            pci_msi_sensitive= yes
+                            disable_pci_msi = yes


### PR DESCRIPTION
This patch changes the file_transfer configuration to disable msi
inside guest when using Linux.
