### PR TITLE
disable the combination of WinXP.i386 and e1000

### DIFF
--- a/shared/cfg/guest-os/Windows/WinXP/i386.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP/i386.cfg
@@ -1,4 +1,6 @@
 - i386:
+    # e1000 does not support WinXP guest
+    no e1000 
     vm_arch_name = i686
     image_name += -32
     whql.submission:


### PR DESCRIPTION
e1000 does not support WinXP.i386 guest

Signed-off-by: Cong Li coli@redhat.com
