### PR TITLE
SLES11.xml: make serial port can be login

### DIFF
--- a/shared/unattended/SLES-11.xml
+++ b/shared/unattended/SLES-11.xml
@@ -536,15 +536,6 @@
     <default>3</default>
   </runlevel>
   <scripts>
-  <chroot-scripts config:type="list">
-    <script>
-      <chrooted config:type="boolean">true</chrooted>
-      <source>
-        <![CDATA[sed -i 's/^#S0\(.*\)9600\(.*\)/S0\1115200\2/g' /etc/inittab
-echo ttyS0 >> /etc/securetty]]>
-      </source>
-    </script>
-  </chroot-scripts>
    <init-scripts config:type="list">
       <script>
         <debug config:type="boolean">true</debug>
@@ -557,6 +548,16 @@ service sshd restart
       </script>
     </init-scripts>
   <chroot-scripts config:type="list">
+    <script>
+      <chrooted config:type="boolean">false</chrooted>
+      <filename>serial_port_setting.sh</filename>
+      <debug config:type="boolean">true</debug>
+      <interpreter>shell</interpreter>
+      <source>
+        <![CDATA[sed -i 's/^#S0\(.*\)9600\(.*\)/S0\1115200\2/g' /mnt/etc/inittab
+echo ttyS0 >> /mnt/etc/securetty]]>
+      </source>
+    </script>
     <script>
       <chrooted config:type="boolean">true</chrooted>
       <source>


### PR DESCRIPTION
Move chroot-scripts into one section and make serial port work
with chrooted as false.

Signed-off-by: Xiangmin Han xhan@redhat.com
