### PR TITLE
qemu.tests: Update get_property useage in vhost_with_cgroup

### DIFF
--- a/qemu/tests/vhost_with_cgroup.py
+++ b/qemu/tests/vhost_with_cgroup.py
@@ -65,6 +65,6 @@ def run(test, params, env):
     error.context("Check whether vhost attached to cgroup successfully",
                   logging.info)
 
-    if vhost_pid not in cgroup.get_property("/tasks"):
+    if vhost_pid not in cgroup.get_property("tasks"):
         raise error.TestError("Oops, vhost process attach to cgroup FAILED!")
     logging.info("Vhost process attach to cgroup successfully")


### PR DESCRIPTION
The parameter in get_property should be filename without .
