### PR TITLE
qemu.test: Update the check method in smbios_table

### DIFF
--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -87,7 +87,7 @@ def run(test, params, env):
                 if smbios_get_para == notset_output:
                     smbios_get_para = default_key_para
 
-                if (smbios_get_para != smbios_set_para):
+                if (smbios_set_para not in smbios_get_para):
                     e_msg = ("%s.%s mismatch, Set '%s' but guest is : '%s'"
                              % (sm_type, key, smbios_set_para,
                                 smbios_get_para))


### PR DESCRIPTION
In the machine_type check for smbios_table, we only care the main version
information but not the details. And the command line output from guest
will include more than the version info:
System.Version mismatch, Set 'RHEL 7.0.0 PC'
but guest is : 'RHEL 7.0.0 PC (i440FX + PIIX, 1996)'

So update the check method for it.
