### PR TITLE
Qemu.test: make nic_hotplug support RHEL4, RHEL5 guest

### DIFF
--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -5,6 +5,8 @@
     type = nic_hotplug
     run_dhclient = yes
     nic_hotplug_count = 4
+    RHEL.4, RHEL.5:
+        additional_operation = yes
     variants:
         - nic_8139:
             pci_model = rtl8139

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -29,7 +29,10 @@
             repeat_times = 1
         - additional:
             no Host_RHEL.5
+            run_dhclient = yes
             type = nic_hotplug
+            RHEL.4, RHEL.5:
+                additional_operation = yes
         - migration:
             # For now, migration + networking only works
             # with bridge (no usermode)

--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -1,7 +1,7 @@
 - RHEL:
     no setup
     shell_prompt = "^\[.*\][\#\$]\s*$"
-    nic_hotplug:
+    nic_hotplug, multi_nics_hotplug:
         modprobe_module = acpiphp
     block_hotplug:
         modprobe_module = acpiphp


### PR DESCRIPTION
This patch make nic_hotplug support RHEL4, RHEL5 guest, also modify
the code style to follow pep8 rules.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
