### PR TITLE
run: Don't overwrite monitors when using --monitor

### DIFF
--- a/run
+++ b/run
@@ -492,8 +492,9 @@ class VirtTestApp(object):
 
     def _process_monitor(self):
         if self.options.monitor == 'qmp':
-            self.cartesian_parser.assign("monitors", "qmp1")
-            self.cartesian_parser.assign("monitor_type_qmp1", "qmp")
+            self.cartesian_parser.only_filter("qmp")
+        else:
+            self.cartesian_parser.only_filter("human")
 
     def _process_smp(self):
         if not self.options.config:

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -201,15 +201,6 @@ image_unbootable_pattern = "Hard Disk.*not a bootable disk"
 # export_ip: optional.
 # export_options: optional.
 
-#
-# List of hypervisor-monitor object names (one per guest),
-#    used to communicate with hypervisor to control guests.
-#    Order cooresponds to 'vms' list above.
-monitors = hmp1
-# hmp1 monitor type (protocol), if only hmp1 type is going to be set
-#monitor_type_hmp1 = human
-# Default monitor type (protocol), if multiple types to be used
-monitor_type = human
 # Pattern to get vcpu threads from monitor.both support
 vcpu_thread_pattern = "thread_id.?[:|=]\s*(\d+)"
 

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -231,3 +231,13 @@ variants:
          remove_emulated_image = no
          #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
          #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"
+
+variants:
+    - @human:
+        monitors = hmp1
+        monitor_type_hmp1 = human
+        monitor_type = human
+    - qmp:
+        monitors = qmp1
+        monitor_type_qmp1 = qmp
+        monitor_type = qmp


### PR DESCRIPTION
This patch changes the way default monitor is handled and uses
the usual way (cpu, images...). This makes it possible for ./run
to filter type instead of rewrite the list of monitors.

Previous solution didn't work for tests with multiple monitors.

**I have no strong opinion, whether this should be applied. Take it only as RFC.** (I'm fine with modifying `cfg/tests` to change the monitor for multi-monitors cases)
