### PR TITLE
shared.unattended: Disable the color display from console

### DIFF
--- a/shared/unattended/Ubuntu-11-04.preseed
+++ b/shared/unattended/Ubuntu-11-04.preseed
@@ -48,4 +48,5 @@ d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf
+echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc

--- a/shared/unattended/Ubuntu-11-10.preseed
+++ b/shared/unattended/Ubuntu-11-10.preseed
@@ -48,4 +48,5 @@ d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf
+echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc

--- a/shared/unattended/Ubuntu-12-04.preseed
+++ b/shared/unattended/Ubuntu-12-04.preseed
@@ -52,4 +52,5 @@ echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
 echo "#!/bin/sh -e" > /target/etc/rc.local; \
 echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
-echo "exit 0" >> /target/etc/rc.local
+echo "exit 0" >> /target/etc/rc.local; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc

--- a/shared/unattended/Ubuntu-12-10.preseed
+++ b/shared/unattended/Ubuntu-12-10.preseed
@@ -52,4 +52,5 @@ echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
 echo "#!/bin/sh -e" > /target/etc/rc.local; \
 echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
-echo "exit 0" >> /target/etc/rc.local
+echo "exit 0" >> /target/etc/rc.local; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc

--- a/shared/unattended/Ubuntu-13-04.preseed
+++ b/shared/unattended/Ubuntu-13-04.preseed
@@ -52,4 +52,5 @@ echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
 echo "#!/bin/sh -e" > /target/etc/rc.local; \
 echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
-echo "exit 0" >> /target/etc/rc.local
+echo "exit 0" >> /target/etc/rc.local; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc

--- a/shared/unattended/Ubuntu-13-10.preseed
+++ b/shared/unattended/Ubuntu-13-10.preseed
@@ -52,4 +52,5 @@ echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
 echo "#!/bin/sh -e" > /target/etc/rc.local; \
 echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
-echo "exit 0" >> /target/etc/rc.local
+echo "exit 0" >> /target/etc/rc.local; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc


### PR DESCRIPTION
The default bashrc for root in Ubuntu will enable color display
in the console. This caused unreadable characters for some
cmd output, like 'ls'. It will fail our cases as script can not
get the output we want. So disable it in preseed files for install.
