### PR TITLE
libvirt: Adapt the remote config in base.cfg to existing tests.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -402,9 +402,9 @@ virt_install_wait_time = 300
 
 # libvirt (host information for remote testcases)
 # TODO: Create auto-login between remote and local host.
-local_ip = LOCAL.EXAMPLE.COM
+local_ip = ENTER.YOUR.LOCAL.EXAMPLE.COM
 local_pwd = ""
-remote_ip = REMOTE.EXAMPLE.COM
+remote_ip = ENTER.YOUR.REMOTE.EXAMPLE.COM
 remote_user = root
 # Default password is same as local_pwd
 remote_pwd = "${local_pwd}"


### PR DESCRIPTION
Since there are several tests in libvirt are using ENTER.YOUR as
the default configuration of remote, we should add this substring
into base.cfg.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
