### PR TITLE
libvirt-virsh: Add remote_pwd into VirshConnectBack.__slots__.

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -270,7 +270,7 @@ class VirshPersistent(Virsh):
     Execute libvirt operations using persistent virsh session.
     """
 
-    __slots__ = ('session_id', )
+    __slots__ = ('session_id', 'remote_pwd', 'remote_user')
 
     # B/c the auto_close of VirshSession is False, we
     # need to manager the ref-count of it manully.


### PR DESCRIPTION
If 'remote_pwd' is not in **slots**, we can not pass a remote_pwd
into VirshConnectBack, so that we can not connect to a remote host
with password. Same reason to 'remote_user'.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
