### PR TITLE
shared.cfg: Add config to timedrift_monotonicity for windows guest

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -67,6 +67,7 @@
         time_command = "echo TIME: %date% %time%"
         time_filter_re = "(?<=TIME: \w\w\w ).{19}(?=\.\d\d)"
         time_format = "%m/%d/%Y %H:%M:%S"
+        cmd_get_time = "echo %TIME%"
         # For this to work, the cdrom at d: should contain vlc (d:\vlc\vlc.exe) and a video (d:\ED_1024.avi)
         guest_load_command = 'cmd /c "d:\vlc\vlc -f --loop --no-qt-privacy-ask --no-qt-system-tray d:\ED_1024.avi"'
         # Alternative guest load:


### PR DESCRIPTION
"date +%s%N" cannot show the current time for windows guest.

Signed-off-by: Shuping Cui scui@redhat.com
