### PR TITLE
qemu.test.watchdog: Remove RHEL.5 from the ib700 cfg

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -9,6 +9,7 @@
             watchdog_device_type = i6300esb
             dmesg_info = "i6300ESB.*init"
         -ib700:
+            no RHEL.5
             watchdog_device_type = ib700
             dmesg_info = "ib700wdt.*init"
     variants:


### PR DESCRIPTION
Remove RHEL.5 from the cfg, sinece RHEL.5 not support ib700wdt.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
