### PR TITLE
virttest.qemu_vm: Catch all exceptions when sending quit to monitor in d...

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2362,8 +2362,12 @@ class VM(virt_vm.BaseVM):
                 logging.debug("Ending VM %s process (monitor)", self.name)
                 try:
                     self.monitor.quit()
-                except qemu_monitor.MonitorError, e:
+                except Exception, e:
                     logging.warn(e)
+                    if self.is_dead():
+                        logging.warn("VM %s down during try to kill it "
+                                      "by monitor", self.name)
+                        return
                 else:
                     # Wait for the VM to be really dead
                     if self.wait_until_dead(5, 0.5, 0.5):


### PR DESCRIPTION
When host or guest under heavy load or in a shutdown status from pre case.
VM process may quit during destory() in any steps and will raise very strange
error message like if it is try to kill vm by monitor:
 error: (9, 'Bad file descriptor')

So catch all kinds of exceptions and judge if the process is alive or not.
Log warning message in the log file instead of through errors.
