### PR TITLE
test.cfg.fillup_disk: adjust the fillup timeout to 320s

### DIFF
--- a/tests/cfg/fillup_disk.cfg
+++ b/tests/cfg/fillup_disk.cfg
@@ -3,7 +3,7 @@
     only Linux
     only qcow2
     type = fillup_disk
-    fillup_timeout = 120
+    fillup_timeout = 320
     fillup_size = 200
     fillup_cmd = "dd if=/dev/zero of=/%s/fillup.%d bs=%dM count=1 oflag=direct"
     kill_vm = yes


### PR DESCRIPTION
Write file with oflag=direct would take more time to finish.
