### PR TITLE
virttest.ppm_utils: Skip invalid ppm files

### DIFF
--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -319,7 +319,12 @@ def img_similar(base_img, comp_img, threshold=10):
     """
     check whether two images are similar by hamming distance
     """
-    if img_ham_distance(base_img, comp_img) < threshold:
+    try:
+        hamming_distance = img_ham_distance(base_img, comp_img)
+    except IOError:
+        return False
+
+    if hamming_distance < threshold:
         return True
     else:
         return False


### PR DESCRIPTION
When testing the code under RHEL5, we've noticed that Windows
install tests would fail with:

Unhandled IOError: cannot identify image file [context: waiting for installation to finish]

Let's handle image comparison more carefully, returning
false if the screenshot file had any problems.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
