### PR TITLE
qemu.cfg: Add the lost host-kernel.cfg in tests-shared.cfg

### DIFF
--- a/qemu/cfg/tests-shared.cfg
+++ b/qemu/cfg/tests-shared.cfg
@@ -15,6 +15,7 @@ include subtests.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg
+include host-kernel.cfg
 include cdkeys.cfg
 include virtio-win.cfg
 


### PR DESCRIPTION
This patch add the lost host-kernel.cfg in tests-shared.cfg.

Signed-off-by: Shuping Cui scui@redhat.com
