### PR TITLE
qemu.tests: make qemu-img covert more test scenario

### DIFF
--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -22,21 +22,23 @@
             image_name_large = create_large_image
             remove_image_large = yes
             variants:
-                 - non-preallocated:
-                     variants:
-                         - cluster_512:
-                             image_cluster_size = 512
-                         - cluster_1024:
-                             image_cluster_size = 1024
-                         - cluster_4096:
-                             image_cluster_size = 4096
-                         - cluster_1M:
-                             image_cluster_size = 1M
-                         - cluster_2M:
-                             image_cluster_size = 2M
-                 - preallocated:
-                     no raw
-                     preallocated = metadata
+                - cluster_512:
+                    image_cluster_size = 512
+                - cluster_1024:
+                    image_cluster_size = 1024
+                - cluster_4096:
+                    image_cluster_size = 4096
+                - cluster_1M:
+                    image_cluster_size = 1M
+                - cluster_2M:
+                    image_cluster_size = 2M
+            variants:
+                - non-preallocated:
+                    no raw
+                    preallocated = off
+                - preallocated:
+                    no raw
+                    preallocated = metadata
         - convert:
             subcommand = convert
             compressed = no


### PR DESCRIPTION
Test plan updated, we need to make qemu_img test option 'preallation'
and 'cluster_size' togethor to avoid bug like:
qemu-img coredump when create image with cluster_size > 65536 and
option 'preallation=metadata';

Signed-off-by: Xu Tian xutian@redhat.com
