### PR TITLE
[PR updated] virsh: Add virsh itself group commands and fix dargs update problem in VirshClosure

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -3041,3 +3041,63 @@ def nwfilter_edit(name, options="", **dargs):
     """
     cmd = "nwfilter-edit %s %s" % (name, options)
     return command(cmd, **dargs)
+
+
+def cd(dir_path, options="", **dargs):
+    """
+    Run cd command in virsh interactive session.
+
+    :param dir_path: dir path string
+    :param options: extra options
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "cd --dir %s %s" % (dir_path, options)
+    return command(cmd, **dargs)
+
+
+def pwd(options="", **dargs):
+    """
+    Run pwd command in virsh session.
+
+    :param options: extra options
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "pwd %s" % options
+    return command(cmd, **dargs)
+
+
+def echo(echo_str, options="", **dargs):
+    """
+    Run echo command in virsh session.
+
+    :param echo_str: the echo string
+    :param options: extra options
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "echo %s %s" % (echo_str, options)
+    return command(cmd, **dargs)
+
+
+def exit(**dargs):
+    """
+    Run exit command in virsh session.
+
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "exit"
+    return command(cmd, **dargs)
+
+
+def quit(**dargs):
+    """
+    Run quit command in virsh session.
+
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "quit"
+    return command(cmd, **dargs)


### PR DESCRIPTION
Update the PR for repo split.
Add virsh itself group commands and fix dargs update problem in VirshClosure.

Oldlog:
Add test case for command 'cd', 'pwd', 'echo', 'exit' and 'quit' in virsh interactive mode.
