### PR TITLE
Install cygwin before running case netperf.cygwin

### DIFF
--- a/qemu/tests/cfg/cyg_install.cfg
+++ b/qemu/tests/cfg/cyg_install.cfg
@@ -3,5 +3,5 @@
     type = cyginstall
     cdrom_check = wmic cdrom get id,Medialoaded
     cdrom_filter = "(\w+):\s+TRUE"
-    cygwin_install_cmd = cmd /c WINUTILS:\netperf\cygwin.exe
+    cygwin_install_cmd = cmd /c WIN_UTILS:\netperf\cygwin.exe
     cygwin_start = C:\rhcygwin\Cygwin.bat -i /Cygwin-Terminal.ico -

--- a/qemu/tests/cyginstall.py
+++ b/qemu/tests/cyginstall.py
@@ -34,7 +34,7 @@ def run(test, params, env):
     output = session.cmd_output(cdrom_check_cmd, timeout)
     cdrom = re.findall(cdrom_filter, output)
     if cdrom:
-        cygwin_install_cmd = re.sub("WINUTILS", cdrom[0],
+        cygwin_install_cmd = re.sub("WIN_UTILS", cdrom[0],
                                     cygwin_install_cmd)
     else:
         raise error.TestError("Can not find tools iso in guest")

--- a/tests/cfg/netperf.cfg
+++ b/tests/cfg/netperf.cfg
@@ -94,9 +94,13 @@
                 - cygwin:
                     only Windows
                     use_cygwin = yes
+                    type = cyginstall
                     netperf_src = %s:\netperf\netperf-2.6.0
                     cygwin_root = C:\rhcygwin\home\Administrator
                     netserver_path = C:\rhcygwin\usr\local\bin
+                    cdrom_check = wmic cdrom get id,Medialoaded
+                    cdrom_filter = "(\w+):\s+TRUE"
+                    cygwin_install_cmd = cmd /c WIN_UTILS:\netperf\cygwin.exe
                     cygwin_start = C:\rhcygwin\Cygwin.bat -i /Cygwin-Terminal.ico -
                     netserv_start_cmd = netserver
                     netperf_install_cmd = cd netperf-2.6.0; ./configure --enable-burst --enable-demo=yes; make; make install

--- a/tests/netperf.py
+++ b/tests/netperf.py
@@ -131,9 +131,11 @@ def run(test, params, env):
     if (params.get("os_type") == "windows"
             and params.get("use_cygwin") == "yes"):
         cygwin_prompt = params.get("cygwin_prompt", r"\$\s+$")
+        cygwin_install_cmd = params.get("cygwin_install_cmd")
         cygwin_start = params.get("cygwin_start")
         server_cyg = vm.wait_for_login(timeout=login_timeout)
         server_cyg.set_prompt(cygwin_prompt)
+        server_cyg.cmd_output(cygwin_install_cmd)
         server_cyg.cmd_output(cygwin_start)
     else:
         server_cyg = None


### PR DESCRIPTION
1. fix the typo from 'WINUTILS' to 'WIN_UTILS'.
2. modify the cfg in netperf so that can run the case netperf.cygwin

Signed-off-by: Cong Li coli@redhat.com
