### PR TITLE
qemu_cpu.cfg: qemu64 also had broken alias bits on RHEL-6

### DIFF
--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -297,7 +297,7 @@
                     #KNOWN BUG: RHEL-6 has broken feature aliases on
                     # 0x80000001.EDX and they were not fixed, so ignore them:
                     machine.rhel.rhel600, machine.rhel.rhel610, machine.rhel.rhel620, machine.rhel.rhel630, machine.rhel.rhel640, machine.rhel.rhel650:
-                        cpu.amd.athlon, cpu.amd.cpu64_rhel6, cpu.intel.kvm64:
+                        cpu.amd.athlon, cpu.amd.cpu64_rhel6, cpu.intel.kvm64, cpu.amd.qemu64:
                             # vme, mtrr, mca, pse36
                             ignore_cpuid_leaves += " 0x80000001,0x0,edx,1"
                             ignore_cpuid_leaves += " 0x80000001,0x0,edx,12"


### PR DESCRIPTION
Update the config file so we ignore the broken alias bits on qemu64 too.

Signed-off-by: Eduardo Habkost ehabkost@redhat.com
