### PR TITLE
qemu_disk_img: Update md5sum_bin to D:\coreutils\md5sum.exe for windows ...

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -314,7 +314,7 @@
         stop_cmd = "taskkill /T /F /IM heavyload.exe"
     qemu_disk_img:
         # md5sum binary path, eg, c:\program\md5sum.exe
-        md5sum_bin = "md5sum"
+        md5sum_bin = "D:\coreutils\md5sum.exe"
         guest_file_name  = "c:\test.img"
         guest_file_name_image1  = "c:\test.img"
         guest_file_name_snA = "c:\sna.img"


### PR DESCRIPTION
...guest.

We put md5sum.exe in win_utils.

Signed-off-by: Feng Yang fyang@redhat.com
