### PR TITLE
virttest: Move sessions from virt_vm to specific vm class

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -120,6 +120,7 @@ class VM(virt_vm.BaseVM):
             self.device_id = []
             self.pci_devices = []
             self.uuid = None
+            self.remote_sessions = []
 
         self.spice_port = 8000
         self.name = name

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -121,6 +121,8 @@ class VM(virt_vm.BaseVM):
             self.vhost_threads = []
             self.devices = None
             self.logs = {}
+            self.remote_sessions = []
+            self.logsessions = {}
 
         self.name = name
         self.params = params
@@ -138,7 +140,6 @@ class VM(virt_vm.BaseVM):
         # }
         # This structure can used in usb hotplug/unplug test.
         self.usb_dev_dict = {}
-        self.logsessions = {}
         self.driver_type = 'qemu'
         self.params['driver_type_' + self.name] = self.driver_type
         # virtnet init depends on vm_type/driver_type being set w/in params

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -501,14 +501,6 @@ class BaseVM(object):
     def __init__(self, name, params):
         self.name = name
         self.params = params
-        #
-        # Assuming all low-level hypervisors will have a serial (like) console
-        # connection to the guest. libvirt also supports serial (like) consoles
-        # (virDomainOpenConsole). subclasses should set this to an object that
-        # is or behaves like aexpect.ShellSession.
-        #
-        self.serial_console = None
-        self.remote_sessions = []
         # Create instance if not already set
         if not hasattr(self, 'instance'):
             self._generate_unique_id()


### PR DESCRIPTION
Move sessions from virt_vm to specific vm class. And dont clean it
when clone status is True. So when we clone a vm, these objects can
be saved in new vm object. Otherwise when we try to destroy a cloned
vm object. Many sessions will be left in system.

This pullreq try to fix the problem mention in https://github.com/autotest/virt-test/issues/1360
