### PR TITLE
virsh: Add ShellProcessTerminatedError in close_session.

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -339,7 +339,8 @@ class VirshPersistent(Virsh):
                     existing = VirshSession(a_id=session_id)
                     if existing.is_alive():
                         self.counter_decrease()
-                except aexpect.ShellStatusError:
+                except (aexpect.ShellStatusError,
+                        aexpect.ShellProcessTerminatedError):
                     # session was already closed
                     pass  # don't check is_alive or update counter
                 self.__dict_del__("session_id")


### PR DESCRIPTION
When a VirshSession is already terminated when we call close_session(),
it will raise a ShellProcessTerminatedError. We should catch it and
notice that this session is already closed.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
