### PR TITLE
libvirt_vm: set_console_getty() check for systemd

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -971,6 +971,8 @@ class VM(virt_vm.BaseVM):
             try:
                 # Only configurate RHEL5 and below
                 regex = "gettys are handled by"
+                # As of RHEL7 systemd message is displayed
+                regex += "|inittab is no longer used when using systemd"
                 output = session.cmd_output("cat /etc/inittab")
                 if re.search(regex, output):
                     logging.debug("Skip setting inittab for %s", device)


### PR DESCRIPTION
In RHEL7 (and as of at least f18), the output for /etc/inittab has
changed, thus the existing search doesn't work resulting in the unnecessary
modification of /etc/inittab on the guest.
