### PR TITLE
destroy_pool: Fix return value

### DIFF
--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -297,12 +297,7 @@ class StoragePool(object):
         if not self.is_pool_active(name):
             logging.info("pool '%s' is already inactive.", name)
             return True
-        try:
-            cmd_result = self.virsh_instance.pool_destroy(name)
-            return (not cmd_result.exit_status)
-        except error.CmdError:
-            logging.error("Destroy pool '%s' failed.", name)
-            return False
+        return self.virsh_instance.pool_destroy(name)
 
     def define_dir_pool(self, name, target_path):
         """


### PR DESCRIPTION
The virsh_instance.pool_destroy method returns a boolean, so
adjust destroy_pool to just return that rather than checking
cmd_result.exit_status
