### PR TITLE
MAINTAINER: Fix the description of LVSB sub testset.

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -31,7 +31,7 @@ M: Li Yang <liyang.fnst@cn.fujitsu.com>
 
 
 
-Pull request maintenance - Libvirt subtests
+Pull request maintenance - LVSB subtests
 -------------------------------------------
 
 M: Christopher Evich <cevich@redhat.com>


### PR DESCRIPTION
It seems a error from copy-paste, the description of LVSB sub tests
is "Libvirt subtests".

This patch change it to "LVSB subtests".

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
