### PR TITLE
wait_for_get_address: Handle dead vm

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -736,6 +736,8 @@ class BaseVM(object):
             except (VMIPAddressMissingError, VMAddressVerificationError):
                 return False
         if not utils_misc.wait_for(_get_address, timeout, internal_timeout):
+            if self.is_dead():
+                raise VMIPAddressMissingError(self.virtnet[nic_index_or_name].mac)
             try:
                 s_session = None
                 s_session = self.wait_for_serial_login()


### PR DESCRIPTION
Pull request #1424 added logic to wait_for_get_address() in order to
try and renew the guest IP by using the serial console. However, it did
not take into account that the guest may not be running in this instance
and that failing and/or raising an exception may be an expected output.

As it turns out the virsh.attach_device test has such a need as part of
its processing - it expects/tests certain exceptions.

Without this change, the wait_for_get_address() eventually calls the
serial_login() function which fails (exception) when trying to determine
if the path to 'self.serial_console.inpipe_filename' exists. Trying
to change that code to call create_serial_console() will fail because
the VM is dead.  So rather than go through that processing, just fail.

This issue was exacerbated by verify_ip_address_ownership() not returning
True from the mac in macs checking on the return from parse_arp(). Since
the IP address wasn't matched a failure would result, which led to going
into the new code. Exactly what caused that I'm not quite sure as it
was only reproducible for a short period of time and now it does find
the address. When the code does return True, the remote.remote_login()
call in the login() code will eventually fail since the guest is not
up with a LoginError exception, which is caught/handled by attach_device.

Hopefully @humanux can review and comment on this.  I am open to other
suggestions, but this just seemed to be the easiest way.
