### PR TITLE
virttest: Change working dir before showing git log

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -123,6 +123,7 @@ def download_test_provider(provider, update=False):
             except error.CmdError:
                 pass
             utils.run('git pull origin %s' % branch)
+        os.chdir(download_dst)
         utils.system('git log -1')
 
 


### PR DESCRIPTION
When run download_test_provider if the test_provider is already
downloaded, current working dir won't change before running "git log -1".

This will output false log info or won't work at all if cwd is not a git
repo.

Signed-off-by: Hao Liu hliu@redhat.com
