### PR TITLE
virttest.virsh: Add blockresize() API

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2516,6 +2516,19 @@ def blockpull(name, path, options="", **dargs):
     return command(cmd, **dargs)
 
 
+def blockresize(name, path, size, **dargs):
+    """
+    Resize block device of domain.
+
+    :param name: name of domain
+    :param path: path of block device
+    :size: new size of the block device
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult instance
+    """
+    return command("blockresize %s %s %s" % (name, path, size), **dargs)
+
+
 def domblkinfo(name, device, **dargs):
     """
     Get block device size info for a domain.


### PR DESCRIPTION
Add new API to support the libvirt test
virsh_blockresize

Signed-off-by: Guannan Ren gren@redhat.com

The pull request of testcase virsh_blockresize.py|cfg
https://github.com/autotest/tp-libvirt/pull/37
