### PR TITLE
Fix parameters for LibvirtXMLError calls

### DIFF
--- a/virttest/libvirt_xml/pool_xml.py
+++ b/virttest/libvirt_xml/pool_xml.py
@@ -254,8 +254,8 @@ class PoolXML(PoolXMLBase):
         backup = poolxml.copy()
         if not pool_ins.delete_pool(name):
             del poolxml
-            raise xcepts.LibvirtXMLError("Error occur while deleting pool: %s",
-                                         name)
+            raise xcepts.LibvirtXMLError("Error occur while deleting pool: %s"
+                                         % name)
         # Alter the XML
         poolxml.name = new_name
         if uuid is None:

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -373,7 +373,8 @@ class VMXML(VMXMLBase):
             backup = None
 
         if not self.undefine(options):
-            raise xcepts.LibvirtXMLError("Failed to undefine %s.", self.vm_name)
+            raise xcepts.LibvirtXMLError("Failed to undefine %s."
+                                         % self.vm_name)
         if not self.define():
             if backup:
                 backup.define()


### PR DESCRIPTION
Initially seen in vm_xml/sync() - the raising of the exception passed
3 parameters instead of the **init** required 2:

   File "/home/virt-test/virttest/libvirt_xml/vm_xml.py", line 376, in sync
     raise xcepts.LibvirtXMLError("Failed to undefine %s.", self.vm_name)
 TypeError: **init**() takes at most 2 arguments (3 given)

Since I was fixing this one - I looked for others. Found the pool_xml/
pool_rename() condition as well, so I modified it too.
