### PR TITLE
virttest.standalone_test: Close file handler at the end of test

### DIFF
--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -88,6 +88,7 @@ class Test(object):
     def stop_file_logging(self):
         logger = logging.getLogger()
         logger.removeHandler(self.file_handler)
+        self.file_handler.close()
 
     def verify_background_errors(self):
         """


### PR DESCRIPTION
Free up resources at the end of each test, as we should
have done anyway.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
