### PR TITLE
virttest.standalone_test: Use name instead shortname in print_guest_list

### DIFF
--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -627,13 +627,13 @@ def print_guest_list(options):
         index += 1
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)
-        shortname = params['shortname']
+        name = params['name']
         if os.path.isfile(image_name):
             out = (bcolors.blue + str(index) + bcolors.end + " " +
-                   shortname + "\n")
+                   name + "\n")
         else:
             out = (bcolors.blue + str(index) + bcolors.end + " " +
-                   shortname + " " + bcolors.yellow +
+                   name + " " + bcolors.yellow +
                    "(missing %s)" % os.path.basename(image_name) +
                    bcolors.end + "\n")
         pipe.write(out)


### PR DESCRIPTION
When we list the guest names with run we need the whole guest name but not
the shortname. Otherwise we will filter more cases than expect when we use
the output from --list-guests to run a test.

Signed-off-by: Yiqiao Pu ypu@redhat.com
