### PR TITLE
env_process: Free mac address when destroying VM

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -114,8 +114,7 @@ def preprocess_vm(test, params, env, name):
                                     params=params,
                                     basedir=test.bindir):
                     start_vm = True
-                    old_vm.destroy(gracefully=gracefully_kill,
-                                   free_mac_addresses=False)
+                    old_vm.destroy(gracefully=gracefully_kill)
                     update_virtnet = True
 
     if start_vm:
@@ -145,8 +144,7 @@ def preprocess_vm(test, params, env, name):
     else:       # VM is alive and we don't care
         if params.get("kill_vm_before_test") == "yes":
             # Destroy the VM if kill_vm_before_test = "yes".
-            old_vm.destroy(gracefully=gracefully_kill,
-                           free_mac_addresses=False)
+            old_vm.destroy(gracefully=gracefully_kill)
         else:
             # VM is alive and we just need to open the serial console
             vm.create_serial_console()
@@ -641,7 +639,7 @@ def preprocess(test, params, env):
         for vm_name in params.get("vms").split():
             vm = env.get_vm(vm_name)
             if vm:
-                vm.destroy(free_mac_addresses=False)
+                vm.destroy()
                 env.unregister_vm(vm_name)
 
             vm_params = params.object_params(vm_name)


### PR DESCRIPTION
Sometimes we meet error "NetError: qemu/default MAC generation
failed with prefix 9a after 1024 attempts for NIC nic1 on VM virt-tests-vm1

We should free the mac address when destroying VM. Then we can
reuse the mac in other case.

Now  free_mac_address() only set mac to none in db, but items still in db.

'20140221-144646-CsfdrJfy': "[{'tapfds': '19', 'vhostfds': '20', 'ip': None, 'netdst': 'switch', 'netdev_id': 'idwIrJwd', 'ifname': 't0-xeHUBE', 'romfile': None, 'vlan': '0', 'mac': None, 'g_nic_name': None, 'device_id': 'id15NMz2', 'nic_model': 'virtio', 'queues': '1', 'vectors': None, 'nic_name': 'nic1', 'nic_extra_params': None, 'netdev_extra_params': None, 'nettype': 'bridge', 'tftp': None, 'tapfd_ids': ['idvjjAiw']}]"

Is any reason we must key destroyed VM's information in db?

```
def save_to_db(self, db_key=None):
    """
    Writes string representation out to database
    """
    if db_key is None:
        db_key = self.db_key
    logging.info("*** self = %s ***", self)
    data = str(self)
    logging.info("*** data = %s ***", data)
    logging.info("*** db_key = %s ***", db_key)
    logging.info("*** self.db = %s ***", self.db)
    # Avoid saving empty entries
    if len(data) > 3:
```

Why we check len(data) > 3?  When this happen

I never meet the situation that len(data) <=3.  data is a string here.

So  del self.db[db_key]  never run for me.  db file become bigger and bigger in my host.

@lmr could you help look into it.  Thanks

```
        try:
            self.db[self.db_key] = data
        except AttributeError:
            raise DbNoLockError
    else:
        try:
            logging.info("***  self.db[db_key] = %s",  self.db[db_key])
            # make sure old db entry is removed
            del self.db[db_key]
        except KeyError:
            pass
```

Signed-off-by: Feng Yang fyang@redhat.com
