### PR TITLE
virttest: issue fix for wait_for_get_address.

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -997,7 +997,7 @@ def get_guest_ip_addr(session, mac_addr, os_type="linux", ip_version="ipv4",
             raise IPAddrGetError(mac_addr, "Unknown os type")
 
         if ip_version == "ipv4":
-            return nic_address["ipv4"]
+            return nic_address["ipv4"][-1]
         else:
             global_address = [x for x in nic_address["ipv6"]
                               if not x.lower().startswith("fe80")]

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -944,7 +944,8 @@ class BaseVM(object):
         client = self.params.get("shell_client")
         ip_version = self.params.get("ip_version", "ipv4").lower()
         neigh_attach_if = ""
-        address = self.wait_for_get_address(nic_index, ip_version=ip_version)
+        address = self.wait_for_get_address(nic_index, timeout=360,
+                                            ip_version=ip_version)
         if address and address.lower().startswith("fe80"):
             neigh_attach_if = utils_net.get_neigh_attch_interface(address)
         port = self.get_port(int(self.params.get("shell_port")))


### PR DESCRIPTION
wait_for_get_address will raise error, when try to get guest
ipv4 address via serial session, this patch fix this issue

Signed-off-by: Yunping Zheng yunzheng@redhat.com
