### PR TITLE
perf.cfg: update indexes for netperf

### DIFF
--- a/tools/perf.conf
+++ b/tools/perf.conf
@@ -8,7 +8,7 @@ avg_update =
 [netperf]
 result_file_pattern = .*.RHS
 ignore_col = 2
-avg_update = 4,2,3|14,6,12|15,5,13
+avg_update = 4,2,3|12,5,10|13,6,11
 desc = The tests are *%s* seconds sessions of 'Netperf'. 'throughput' was taken from netperf's report.\nOther measurements were taken on the host.\nHow to read the results:\n - The Throughput is measured in Mbit/sec.\n - io_exit: io exits of KVM.\n - irq_inj: irq injections of KVM.\n
 
 [iozone]


### PR DESCRIPTION
We just adjusted the title order in the result, [1] so
the avg_update indexes also need to be updated.

tpkt_per_exit 13=6/11,rpkt_per_irq 12=5/10 according
to following columns.

2             3       4              5       6
throughput    CPU     thr_per_CPU    rx_pkts tx_pkts
7         8        9        10       11
rx_byts   tx_byts  re_pkts  irq_inj  io_exit
12           13
rpkt_per_irq tpkt_per_exit

Signed-off-by: Amos Kong akong@redhat.com

[1] https://github.com/autotest/tp-qemu/pull/34
