### PR TITLE
perf: add scripts to collect guest/host sysinfo

### DIFF
--- a/shared/scripts/rh_perf_log_guestinfo_script.bat
+++ b/shared/scripts/rh_perf_log_guestinfo_script.bat
@@ -1,0 +1,3 @@
+echo %DATE%
+echo "If you want to get some more information from guest,
+echo "please edit shared/scripts/rh_perf_log_guestinfo_script.bat"

--- a/shared/scripts/rh_perf_log_guestinfo_script.sh
+++ b/shared/scripts/rh_perf_log_guestinfo_script.sh
@@ -1,0 +1,13 @@
+function call() {
+    echo "`echo \# $@; eval $@ ; echo \"==>Returned: $?\"`"
+    echo
+}
+
+echo
+echo "==================== Configuration on guest ============================"
+
+call cat /proc/cmdline
+
+call cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+
+call "grep flags /proc/cpuinfo |head -n 1"

--- a/shared/scripts/rh_perf_log_hostinfo_script.sh
+++ b/shared/scripts/rh_perf_log_hostinfo_script.sh
@@ -1,0 +1,47 @@
+function call() {
+    echo "`echo \# $@; eval $@ ; echo \"==>Returned: $?\"`"
+    echo
+}
+
+echo "==================== Configuration on host ============================="
+call hostname
+
+call cat /proc/cmdline
+
+call cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+
+call lscpu
+
+call "grep flags /proc/cpuinfo |head -n 1"
+
+call numactl --hardware
+
+call "cat /proc/meminfo  |grep HugePages_Total"
+
+call cat /sys/kernel/debug/sched_features
+
+bridges=`brctl show|grep -v "bridge.*name.*bridge.*id"|awk {'print $1'}`
+ports=`brctl show|grep -v "bridge.*name.*bridge.*id"|awk {'print $4'}`
+
+for i in $bridges;do
+    call echo "ethtool -k $i"
+    call ethtool -k $i
+done
+for i in $ports;do
+    call ethtool -k $i
+    call ethtool -i $i
+    call brctl showstp $i
+done
+
+echo "=========================== Test steps ================================="
+
+echo "------------------------- (netperf cmdline) ----------------------------"
+grep "Start netperf thread by cmd" $1/../debug.log |sed -e "s/^.*|//"
+
+echo "------------------------- (qemu cmdline) -------------------------------"
+grep "Running qemu command" $1/../debug.log -A 1 |sed -e "s/^.*|//"
+grep "Running qemu command" $1/../debug.log -A 100|grep "^ *-"
+
+echo "------------------------- (thread pinning) -----------------------------"
+grep "pin .* thread(.*) to cpu(.*)" $1/../debug.log -A 1 |sed -e "s/^.*|//"
+


### PR DESCRIPTION
This is prepared for RHEL OS, others can write their own scripts
to collect what they want to get.

These two scripts are examples.

Signed-off-by: Amos Kong akong@redhat.com

The two script be used by netperf.py, you can find detail in https://github.com/autotest/tp-qemu/pull/35
