### PR TITLE
test providers: Update test provider URIs

### DIFF
--- a/test-providers.d/io-github-autotest-libvirt.ini
+++ b/test-providers.d/io-github-autotest-libvirt.ini
@@ -1,5 +1,5 @@
 [provider]
-uri: https://github.com/autotest/tp-libvirt.git
+uri: git://github.com/autotest/tp-libvirt.git
 [libvirt]
 subdir: libvirt/
 [libguestfs]

--- a/test-providers.d/io-github-autotest-qemu.ini
+++ b/test-providers.d/io-github-autotest-qemu.ini
@@ -1,5 +1,5 @@
 [provider]
-uri: https://github.com/autotest/tp-qemu.git
+uri: git://github.com/autotest/tp-qemu.git
 [generic]
 subdir: generic/
 [qemu]


### PR DESCRIPTION
It is more likely that people will have trouble with
pulling git repos out of https than git. Also, git
performance is better, so let's update.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
