### PR TITLE
Always keep screendumps

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -234,6 +234,7 @@ vga = std
 # Capture contents of display during each test
 take_regular_screendumps = yes
 keep_screendumps_on_error = yes
+keep_screendumps = yes
 screendump_delay = 5
 # Encode video from vm screenshots
 encode_video_files = yes


### PR DESCRIPTION
screendumps are important, the current
policy of saving it when case error only is
not enough, if a VM network works fine and
case pass, but VM vga malfunction, deleted
them would potential miss bugs

Signed-off-by: Xiaoqing Wei xwei@redhat.com
