### PR TITLE
Set autoyast iso as 1st cdrom for url/nfs unattended_installation

### DIFF
--- a/shared/cfg/guest-os/Linux/OpenSUSE.cfg
+++ b/shared/cfg/guest-os/Linux/OpenSUSE.cfg
@@ -4,3 +4,5 @@
     unattended_install, svirt_install:
         kernel_params = "autoyast=device://sr1/autoinst.xml console=ttyS0,115200 console=tty0"
         wait_no_ack = yes
+    unattended_install.url, unattended_install.nfs:
+        kernel_params = "autoyast=device://sr0/autoinst.xml console=ttyS0,115200 console=tty0"

--- a/shared/cfg/guest-os/Linux/SLES.cfg
+++ b/shared/cfg/guest-os/Linux/SLES.cfg
@@ -5,6 +5,8 @@
         kernel = linux
         initrd = initrd
         wait_no_ack = yes
+    unattended_install.url, unattended_install.nfs:
+        kernel_params = "autoyast=device://scd0/autoinst.xml console=ttyS0,115200 console=tty0"
     boot:
         # As SLES need to perform firstboot to finish the installation, Extending the boot login_timeout
         login_timeout = 720

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -850,6 +850,9 @@ class UnattendedInstallConfig(object):
                 self.kernel_params = re.sub('repo\=[\:\w\d\/]*',
                                             'repo=%s' % self.url,
                                             self.kernel_params)
+            elif 'autoyast=' in self.kernel_params:
+                # SUSE
+                self.kernel_params = (self.kernel_params + " ip=dhcp install=" + self.url)
 
         elif self.vm_type == 'libvirt':
             logging.info("Not downloading vmlinuz/initrd.img from %s, "
@@ -880,6 +883,11 @@ class UnattendedInstallConfig(object):
             utils.run(initrd_fetch_cmd, verbose=DEBUG)
         finally:
             utils_disk.cleanup(self.nfs_mount)
+
+        if 'autoyast=' in self.kernel_params:
+            # SUSE
+            self.kernel_params = (self.kernel_params + " ip=dhcp "
+                                  "install=nfs://" + self.nfs_server + ":" + self.nfs_dir)
 
     def setup_import(self):
         self.unattended_file = None


### PR DESCRIPTION
For unattended_install.url and unattended_install.nfs,
autoyast.iso will be mounted as 1st cdrom.

Follow Paolo's suggestion, Add code to handle kernel_params
in unattended_install.py

Signed-off-by: Lin Ma lma@suse.com
