### PR TITLE
Disable strict host key checking for ssh session

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -216,6 +216,7 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
         host = "%s%%%s" % (host, interface)
     if client == "ssh":
         cmd = ("ssh -o UserKnownHostsFile=/dev/null "
+               "-o StrictHostKeyChecking=no "
                "-o PreferredAuthentications=password -p %s %s@%s" %
                (port, username, host))
     elif client == "telnet":
@@ -408,6 +409,7 @@ def scp_to_remote(host, port, username, password, local_path, remote_path,
         host = "%s%%%s" % (host, interface)
 
     command = ("scp -v -o UserKnownHostsFile=/dev/null "
+               "-o StrictHostKeyChecking=no "
                "-o PreferredAuthentications=password -r %s "
                "-P %s %s %s@\[%s\]:%s" %
                (limit, port, local_path, username, host, remote_path))
@@ -443,6 +445,7 @@ def scp_from_remote(host, port, username, password, remote_path, local_path,
         host = "%s%%%s" % (host, interface)
 
     command = ("scp -v -o UserKnownHostsFile=/dev/null "
+               "-o StrictHostKeyChecking=no "
                "-o PreferredAuthentications=password -r %s "
                "-P %s %s@\[%s\]:%s %s" %
                (limit, port, username, host, remote_path, local_path))
@@ -485,6 +488,7 @@ def scp_between_remotes(src, dst, port, s_passwd, d_passwd, s_name, d_name,
         dst = "%s%%%s" % (dst, dst_inter)
 
     command = ("scp -v -o UserKnownHostsFile=/dev/null -o "
+               "-o StrictHostKeyChecking=no "
                "PreferredAuthentications=password -r %s -P %s"
                " %s@\[%s\]:%s %s@\[%s\]:%s" %
                (limit, port, s_name, src, s_path, d_name, dst, d_path))

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -327,6 +327,7 @@ class Env(UserDict.IterableUserDict):
         cmd = cmd_template % utils_misc.find_command("tcpdump")
         if self._params.get("remote_preprocess") == "yes":
             login_cmd = ("ssh -o UserKnownHostsFile=/dev/null -o "
+                         "-o StrictHostKeyChecking=no "
                          "PreferredAuthentications=password -p %s %s@%s" %
                          (port, username, address))
 


### PR DESCRIPTION
Because of StrictHostKeyChecking=ask is the default setting in ssh config,
If there is no host key for the server, it will show the fingerprint and
ask to confirm, And because of we already set /dev/null as the user host
key database, the ssh connection always waits for the test scripts answers
"yes" for confirmation. So the test scripts will be blocked at this stage.
(unless the option StrictHostKeyChecking has been disabled in command-line
or /etc/ssh/ssh_config or ~/.ssh/config)

Signed-off-by: Lin Ma lma@suse.com
