### PR TITLE
Couple of miscellaneous fixes

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1656,7 +1656,7 @@ def get_qemu_binary(params):
 
     if not os.path.isfile(qemu_binary_path):
         logging.debug('Could not find params qemu in %s, searching the '
-                      'host PATH for one to use')
+                      'host PATH for one to use', qemu_binary_path)
         try:
             qemu_binary = find_command('qemu-kvm')
             logging.debug('Found %s', qemu_binary)

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -303,7 +303,7 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
         sv_status = None
         if utils_misc.selinux_enforcing():
             sv_status = utils_selinux.get_status()
-            utils_selinux.set_status("Permissive")
+            utils_selinux.set_status("permissive")
         _iscsi.export_target()
         if sv_status is not None:
             utils_selinux.set_status(sv_status)

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1453,7 +1453,7 @@ def net_state_dict(only_names=False, virsh_instance=None, **dargs):
     # If command failed, exception would be raised here
     netlist = net_list_result.stdout.strip().splitlines()
     # First two lines contain table header followed by entries
-    # for each pool on the host, such as:
+    # for each network on the host, such as:
     #
     #   Name                 State      Autostart     Persistent
     #  ----------------------------------------------------------


### PR DESCRIPTION
utils_misc: Need to add parameter for a %s directive in message
            for get_qemu_binary method

utils_test/libvirt: Use 'permissive' not 'Permissive' since the set_status
                    expects the lower case

virsh: Simple typo in comment for net_state_dict() which was copied from
       a similar pool function, but the comment change was missed
