### PR TITLE
Update the md5sum for fedora 20 ppc64

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/20.ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/20.ppc64.cfg
@@ -1,20 +1,22 @@
 - 20.ppc64:
     image_name = images/f20-ppc64
     only pseries
+    os_variant = fedora20
     no unattended_install..floppy_ks
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
-    unattended_install:
-        kernel_params = "root=live:CDLABEL=Fedora-20-ppc64 ks=cdrom:/ks.cfg console=hvc0 serial rd_NO_PLYMOUTH"
+    unattended_install, svirt_install:
+        kernel_params = 'repo=cdrom:/dev/disk/by-label/Fedora\x2020\x20x86_64'
+        kernel_params += ' ks=cdrom:/dev/disk/by-label/CDROM nicdelay=60 console=hvc0 serial rd_NO_PLYMOUTH'
         unattended_file = unattended/Fedora-20.ks
         cdrom_unattended = images/f20-ppc64/ks.iso
         kernel = images/f20-ppc64/vmlinuz
         initrd = images/f20-ppc64/initrd.img
         syslog_server_proto = tcp
-    unattended_install.cdrom:
+    unattended_install.cdrom, svirt_install:
         boot_path = ppc/ppc64
         cdrom_cd1 = isos/linux/Fedora-20-ppc64-DVD.iso
-        md5sum_cd1 = 26b6e0068a2c76742c0f097a0c9e1eb9
-        md5sum_1m_cd1 = 10043a86d6e8929f80cad16c5ff5eccb
+        md5sum_cd1 = c808116a953c3769bfc3b5e20130063f
+        md5sum_1m_cd1 = cad135432df93005bced7698b5e21453
     unattended_install.url:
         url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/20/Everything/ppc64/os


### PR DESCRIPTION
The current md5sum for fedora 20 ppc64 ISO is wrong.
This patch is to correct it.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
