### PR TITLE
virttest: Make Numa related functions can work on host have disabled node

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1095,9 +1095,8 @@ class VM(virt_vm.BaseVM):
             if int(utils_misc.get_node_count()) <= int(params.get("smp", 1)):
                 logging.info("Skip pinning, no enough nodes")
             elif numa_node < 0:
-                p = utils_misc.NumaNode(numa_node)
-                n = int(utils_misc.get_node_count()) + numa_node
-                cmd += "numactl -m %s " % n
+                n = utils_misc.NumaNode(numa_node)
+                cmd += "numactl -m %s " % n.node_id
             else:
                 n = numa_node - 1
                 cmd += "numactl -m %s " % n


### PR DESCRIPTION
Now the functions and classes caculate node id by nodes number. And
in a host have disabled node, it may give scripts the disabled node
id. This patch will fix this problem by use available nodes to decide
the node scripts should use.
