### PR TITLE
virttest: Add debug option to ssh and dhclient command

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -217,7 +217,7 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
     if client == "ssh":
         cmd = ("ssh -o UserKnownHostsFile=/dev/null "
                "-o StrictHostKeyChecking=no "
-               "-o PreferredAuthentications=password -p %s %s@%s" %
+               "-o PreferredAuthentications=password -vvv -p %s %s@%s" %
                (port, username, host))
     elif client == "telnet":
         cmd = "telnet -l %s %s %s" % (username, host, port)

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1022,9 +1022,9 @@ def renew_guest_ip(session, mac_addr, os_type="linux", ip_version="ipv4"):
         renew_cmd = "ifconfig %s up; " % nic_ifname
         renew_cmd += "pidof dhclient && killall dhclient; "
         if ip_version == "ipv6":
-            renew_cmd += "dhclient -6 %s &" % nic_ifname
+            renew_cmd += "dhclient -v -6 %s" % nic_ifname
         else:
-            renew_cmd += "dhclient %s &" % nic_ifname
+            renew_cmd += "dhclient -v %s" % nic_ifname
     elif os_type == "windows":
         nic_connectionid = get_windows_nic_attribute(session,
                                                      "macaddress", mac_addr,
@@ -2293,7 +2293,7 @@ def restart_guest_network(session, nic_name=None):
 
     if if_list:
         session.sendline("killall dhclient && "
-                         "dhclient %s &" % ' '.join(if_list))
+                         "dhclient -v %s" % ' '.join(if_list))
 
 
 def update_mac_ip_address(vm, params, timeout=None):


### PR DESCRIPTION
Add debug option to ssh and dhclient command to get more information
to figure out if a test failed is caused by netowrk env problem.
Also let dhclient do not run in background to show the infomrmation.
