### PR TITLE
virt: Override update() method of PropCanBase.

### DIFF
--- a/virttest/propcan.py
+++ b/virttest/propcan.py
@@ -257,6 +257,25 @@ class PropCanBase(dict, PropCanInternal):
         """
         return self.__class__(dict(self))
 
+    def update(self, other=None, excpt=AttributeError, **kwargs):
+        """
+        Update properties in __all_slots__ with another dict.
+        """
+        _tmp_dict = dict()
+        _other_dict = dict()
+
+        if other:
+            _other_dict = dict(other)
+
+        try:
+            _tmp_dict.update(_other_dict)
+            _tmp_dict.update(kwargs)
+        except TypeError, detail:
+            raise excpt(detail)
+
+        for item in _tmp_dict.keys():
+            self[item] = _tmp_dict[item]
+
 
 class PropCan(PropCanBase):
 

--- a/virttest/propcan_unittest.py
+++ b/virttest/propcan_unittest.py
@@ -184,6 +184,25 @@ class TestPropCanBase(unittest.TestCase):
         self.assertTrue(testcan.foo == testdict.foo)
         self.assertTrue(testcan.bar == testdict.bar)
 
+    def test_update(self):
+        class FooBar(propcan.PropCanBase):
+            __slots__ = ('foo', 'bar')
+
+        testdict = FooBar()
+        other = {'foo': 1, 'bar': 2}
+        testdict.update(other)
+        self.assertEqual(testdict, other)
+
+        other = 'string'
+        self.assertRaises(ValueError, testdict.update, other)
+
+        other = {'foo': 1, 'bar': 2, 'v3': 3}
+        self.assertRaises(KeyError, testdict.update, other)
+
+        kwargs = {'foo': "foo", 'bar': "bar"}
+        testdict.update(**kwargs)
+        self.assertEqual(testdict, kwargs)
+
 
 class TestPropCan(unittest.TestCase):
 


### PR DESCRIPTION
Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
