### PR TITLE
env_process: Do not fail the test if catch a TestWarn.

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -661,6 +661,8 @@ def postprocess(test, params, env):
     try:
         process(test, params, env, postprocess_image, postprocess_vm,
                 vm_first=True)
+    except error.TestWarn, details:
+        logging.warn(details)
     except Exception, details:
         err += "\nPostprocess: %s" % str(details).replace('\\n', '\n  ')
         logging.error(details)


### PR DESCRIPTION
In post_process, we call process() and catch the Exception in it.
But there is a step to check image in process() will raise an TestWarn
if our image has a leak space.

```
$qemu-img check /data/jeos-17-64.qcow2
Leaked cluster 37553 refcount=1 reference=0
Leaked cluster 37561 refcount=1 reference=0
Leaked cluster 37562 refcount=1 reference=0
Leaked cluster 48756 refcount=1 reference=0
Leaked cluster 50410 refcount=1 reference=0
Leaked cluster 52588 refcount=1 reference=0

6 leaked clusters were found on the image.
This means waste of disk space, but no harm to data.
```

Yes, there is a warn about it, but we should not make the test fail.
Otherwise, the all cases will fail if our image has a waste of
disk space, but it is no harm to data.

This patch resolve this problem, it catch the TestWarn error and just
logging.warn() it, without appending the detail to err. Then this warn
will not affact the err which is used as a flag for success or failure.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
