### PR TITLE
Fix libvirtd status check function

### DIFF
--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -97,17 +97,13 @@ def service_libvirtd_control(action, remote_ip=None,
     elif action == "status":
         if session:
             try:
-                status, output = session.cmd_status_output(service_cmd)
+                output = session.cmd_output(service_cmd)
             except aexpect.ShellError, detail:
                 raise LibvirtdActionError(action, detail)
-            if status:
-                raise LibvirtdActionError(action, output)
         else:
             cmd_result = utils.run(service_cmd, ignore_status=True)
-            if cmd_result.exit_status:
-                raise LibvirtdActionError(action, cmd_result.stderr)
             output = cmd_result.stdout
-
+        logging.debug("Checking libvirtd status:\n%s", output)
         if re.search("running", output):
             return True
         else:
@@ -159,11 +155,7 @@ def libvirtd_is_running():
     """
     Check if libvirt service is running.
     """
-    try:
-        return service_libvirtd_control('status')
-    except LibvirtdActionError, detail:
-        logging.debug("Failed to get status of libvirtd:\n%s", detail)
-        return False
+    return service_libvirtd_control('status')
 
 
 def libvirtd_wait_for_start(timeout=60, session=None):

--- a/virttest/utils_libvirtd_unittest.py
+++ b/virttest/utils_libvirtd_unittest.py
@@ -16,7 +16,7 @@ class UtilsLibvirtdTest(unittest.TestCase):
         self.assertTrue(service_libvirtd_control('status') in (True, False))
 
     def test_libvirtd_error(self):
-        action_list = ["restart", "start", "stop", "status"]
+        action_list = ["restart", "start", "stop"]
 
         for action in action_list:
             self.assertRaises(utils_libvirtd.LibvirtdActionError,


### PR DESCRIPTION
If libvirtd not running(stop, corrdump, etc.), service check command
always exit with code 3:
$ service libvirtd status
Redirecting to /bin/systemctl status  libvirtd.service
libvirtd.service - Virtualization daemon
   Loaded: loaded (/usr/lib/systemd/system/libvirtd.service; disabled)
   Active: inactive (dead) since Tue 2014-03-18 17:43:26 CST; 3h 9min ago
  Process: 6034 ExecStart=/usr/sbin/libvirtd $LIBVIRTD_ARGS (code=exited, status=0/SUCCESS)
 Main PID: 6034 (code=exited, status=0/SUCCESS)

$ echo $?
3

And it's wrong to raise LibvirtdActionError, on system which using
systemd, it may looks like:
LibvirtdActionError: Failed to status libvirtd.
Detail: Redirecting to /bin/systemctl status  libvirtd.service

So remove this exception and just output the debug log.

Signed-off-by: Yanbing Du ydu@redhat.com
