### PR TITLE
fix 3 issues reported by xigao in regression.py

### DIFF
--- a/tools/regression.py
+++ b/tools/regression.py
@@ -120,6 +120,11 @@ class Sample(object):
             partitions = commands.getoutput("cat %s/partitions" % sysinfodir)
             fdisk = commands.getoutput("cat %s/fdisk_-l" % sysinfodir)
 
+            status_path = os.path.join(os.path.dirname(files[0]), "../status")
+            status_file = open(status_path, 'r')
+            content = status_file.readlines()
+            self.testdata = re.findall("localtime=(.*)\t", content[-1])[-1]
+
             cpunum = len(re.findall("processor\s+: \d", cpuinfo))
             cpumodel = re.findall("Model name:\s+(.*)", lscpu)
             socketnum = int(re.findall("Socket\(s\):\s+(\d+)", lscpu)[0])
@@ -491,10 +496,10 @@ def analyze(test, sample_type, arg1, arg2, configfile):
 
     desc = desc % s1.len
 
-    tee("<pre>####1. Description of setup#1\n" + s1.version + "</pre>",
-        test + ".html")
-    tee("<pre>####2. Description of setup#2\n" + s2.version + "</pre>",
-        test + ".html")
+    tee("<pre>####1. Description of setup#1\n" + s1.version + "\n test data:  "
+         + s1.testdata + "</pre>", test + ".html")
+    tee("<pre>####2. Description of setup#2\n" + s2.version + "\n test data:  "
+         + s2.testdata + "</pre>", test + ".html")
     tee("<pre>" + '\n'.join(desc.split('\\n')) + "</pre>", test + ".html")
     tee("<pre>" + s1.desc + "</pre>", test + ".html")
 


### PR DESCRIPTION
some problem was introduced in pull:  https://github.com/autotest/virt-test/pull/1516
### @xigao 's comments

```
According to the patch, here is the regression results without highlight.
http://kvm-perf.englab.nay.redhat.com/results/request/highlight-T-test/version7/fio.html
Based on above the link, here is some small faults:
1. Block_size/Iodepth/Threads is valued by float.
2. "%Diff between Avg" value keep origin data and leave many decimal points.
3. Positive "Significance" value is removed "+" signal.
```

The last patch added test data to report (requested by @ronenhod)
