### PR TITLE
shared/cfg/guest-hw.cfg: Consolidate image_backend variant

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -197,38 +197,35 @@ variants image_backend:
         # please go through https://github.com/autotest/virt-test/wiki/Virt-test-support-for-GlusterFs for more details.
         gluster_brick = "images/gl_test"
         gluster_volume_name = "vol_test"
-
-variants:
-     - @no_lvm_support:
-     - lvm_partition:
-         # use real logical volume partition as qemu block device drive
-         only raw
-         force_create_image = no
-         image_raw_device = yes
-         storage_type = lvm
-         emulational_device = no
-         # vg_name specify a exists real logical volume group name,
-         # although we support setup a real lvm envrioment automatically,
-         # but it's not ot recommended and it maybe destroy data on your
-         # hard disk; If in demand, please configure your pv_name and
-         # give a vg_name and lv_name;
-         vg_name = autotest_vg
-         #pv_name = /dev/sdb
-         #lv_name = test_lv
-         # command to reload lvm monitor serivce
-         #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
-         #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"
-         force_remove_image = no
-     - emulated_lvm:
-         only raw
-         force_create_image = no
-         image_raw_device = yes
-         storage_type = lvm
-         emulational_device = yes
-         # specify a file as emulated volume, if not will create file in
-         # autotest data dir;
-         #emulated_image =
-         force_remove_image = no
-         remove_emulated_image = no
-         #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
-         #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"
+    - lvm_partition:
+        # use real logical volume partition as qemu block device drive
+        only raw
+        force_create_image = no
+        image_raw_device = yes
+        storage_type = lvm
+        emulational_device = no
+        # vg_name specify a exists real logical volume group name,
+        # although we support setup a real lvm envrioment automatically,
+        # but it's not ot recommended and it maybe destroy data on your
+        # hard disk; If in demand, please configure your pv_name and
+        # give a vg_name and lv_name;
+        vg_name = autotest_vg
+        #pv_name = /dev/sdb
+        #lv_name = test_lv
+        # command to reload lvm monitor serivce
+        #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
+        #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"
+        force_remove_image = no
+    - emulated_lvm:
+        only raw
+        force_create_image = no
+        image_raw_device = yes
+        storage_type = lvm
+        emulational_device = yes
+        # specify a file as emulated volume, if not will create file in
+        # autotest data dir;
+        #emulated_image =
+        force_remove_image = no
+        remove_emulated_image = no
+        #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
+        #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"


### PR DESCRIPTION
It was brought to my attention that, when one passes
--image-type=raw to the test runner, we end up
not filtering out lvm related variants. Of course, that
is not what we want (when we use image_type = raw, we
are mainly assuming a raw discrete image inside a filesystem,
image.raw, if you will). This will cause boot lvm variants
to be executed, and as people do not have proper setup
to do it they will be confused as to why that is happening.

I also noticed that below the images_backend variant,
we do have a lvm related variant, and its indentation
level was wrong. I assume it is reasonable we merge
both variants and fix the indentation level of
the lvm related blocks.

This should fix people seeing lvm related variants
using --image-type=raw, while keeping the default
suite behavior not altered.

CC: Xu Tian xutian@redhat.com
Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
