### PR TITLE
shared.cfg: Update live_snapshot_chain commands for Windows guests

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -282,11 +282,11 @@
     balloon_check:
         free_mem_cmd = wmic os get FreePhysicalMemory
     live_snapshot_chain:
-        md5_cmd = "cd C:\test && D:\coreutils\md5sum.exe %s"
-        file_create_cmd = "D:\coreutils\DummyCMD.exe C:\test\%s 1048576 1"
+        md5_cmd = "cd C:\test && D:\coreutils\md5sum.exe %s.blockfiles"
+        file_create_cmd = "D:\coreutils\DummyCMD.exe C:\test\%s.blockfiles 1048576 1" 
+        file_check_cmd = "dir %s | find 'blockfiles' 
         file_dir = "C:\test"
         dir_create_cmd = "mkdir %s& dir"
-        file_check_cmd = "dir %s"
         check_alive_cmd = "dir"
     live_snapshot_chain.update:
         post_snapshot_cmd = {shell:D:\whql\WUInstall.exe /install}


### PR DESCRIPTION
dir command from Windows guests will include summary of current
directory informations. Which will change as we use the system disk
in test. So update the command to ignore the summary lines.
