### PR TITLE
virttest.video_maker: Fix the counter bug

### DIFF
--- a/virttest/video_maker.py
+++ b/virttest/video_maker.py
@@ -12,6 +12,7 @@ import os
 import time
 import glob
 import logging
+import re
 
 
 __all__ = ['GstPythonVideoMaker', 'video_maker']
@@ -146,7 +147,15 @@ class GstPythonVideoMaker(object):
         Process the input files and output the video file
         '''
         self.normalize_images(input_dir)
-        no_files = len(glob.glob(os.path.join(input_dir, '*.jpg')))
+        file_list = glob.glob(os.path.join(input_dir, '*.jpg'))
+        no_files = len(file_list)
+        if no_files == 0:
+            logging.debug("Number of files to encode as video is zero")
+            return
+        index_list = []
+        for ifile in file_list:
+            index_list.append(int(re.findall(r"/+.*/(\d{4})\.jpg", ifile)[0]))
+            index_list.sort()
         if self.verbose:
             logging.debug('Number of files to encode as video: %s', no_files)
 
@@ -157,7 +166,7 @@ class GstPythonVideoMaker(object):
         if self.verbose:
             logging.debug("Source location: %s", source_location)
         source.set_property('location', source_location)
-        source.set_property('index', 1)
+        source.set_property('index', index_list[0])
         source_caps = gst.Caps()
         source_caps.append('image/jpeg,framerate=(fraction)4/1')
         source.set_property('caps', source_caps)


### PR DESCRIPTION
When the test case destroy the old vm and recreate new, there will
be two different folders which has the screendump pictures,
however, when the video make try get the pictures in the new folder,
the index will be not 1

This patch is to find the smallest index in the folder.

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
