### PR TITLE
virt.shared.cfg: force cd_format in machines.cfg

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -4,14 +4,14 @@ variants:
     - @i440fx:
         only i386, x86_64
         machine_type = pc
-        unattended_install..extra_cdrom_ks:
+        unattended_install..cdrom, unattended_install..extra_cdrom_ks:
             cd_format = ide
     - q35:
         only i386, x86_64
         no ide
         machine_type = q35
-        unattended_install..extra_cdrom_ks:
-            cd_format = ahci 
+        unattended_install..cdrom, unattended_install..extra_cdrom_ks:
+            cd_format = ahci
     - @pseries:
         only ppc64
         machine_type = pseries


### PR DESCRIPTION
force cd_format for unattended_install.cdrom test, because windows guest
not support boot from a virtio_blk or virtio_scsi cdrom.

Signed-off-by: Xu Tian xutian@redhat.com
