### PR TITLE
redirect ssh debug message to /dev/null

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -216,6 +216,7 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
         host = "%s%%%s" % (host, interface)
     if client == "ssh":
         cmd = ("ssh -o UserKnownHostsFile=/dev/null "
+               "-E /dev/null "
                "-o StrictHostKeyChecking=no "
                "-o PreferredAuthentications=password -vvv -p %s %s@%s" %
                (port, username, host))


### PR DESCRIPTION
The following commit added a '-vvv' option to ssh, then ssh will output
some debug message. If the debug message (like "debug2: channel 0:
window 999411 sent adjust 49165") mixes with the command output, it will
confuse Autotest aexpect, exceptions are raised in executing command.

This patch redirect the debug message to /dev/null, if the debug message
is needed, please save it to a file by another patch.

| commit b596354972eecafdcc493577eeaf9d3d4e51c744
| Author: Yiqiao Pu ypu@redhat.com
| Date:   Fri Mar 14 15:33:27 2014 +0800
|
|     virttest: Add debug option to ssh and dhclient command
|
|     Add debug option to ssh and dhclient command to get more information
|     to figure out if a test failed is caused by netowrk env problem.
|     Also let dhclient do not run in background to show the infomrmation.
|
|     Signed-off-by: Yiqiao Pu ypu@redhat.com

Signed-off-by: Amos Kong akong@redhat.com
