### PR TITLE
virttest.utils_test: Delete volumes for disk and logical pool cleanup

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -534,7 +534,7 @@ class PoolVolumeTest(object):
         """
         sp = libvirt_storage.StoragePool()
         pv = libvirt_storage.PoolVolume(pool_name)
-        if pool_type in ["dir", "netfs"]:
+        if pool_type in ["dir", "netfs", "logical", "disk"]:
             vols = pv.list_volumes()
             for vol in vols:
                 # Ignore failed deletion here for deleting pool


### PR DESCRIPTION
As libvirt also support delete volume for logical and disk pool, add
logical and disk pool to clean besides dir and netfs pool, this fix a
problem when destroy logical pool with error:

/usr/bin/virsh pool-destroy virt-logical-pool
stderr:
error: Failed to destroy pool virt-logical-pool
error: internal error: Child process (/usr/sbin/vgchange -aln vg_logical)
unexpected exit status 5:   Cannot deactivate "vol_create_test_vorigin"
locally..

Signed-off-by: Wayne Sun gsun@redhat.com
