### PR TITLE
virttest.bootstrap: Add get_jeos_info() API

### DIFF
--- a/run
+++ b/run
@@ -173,6 +173,9 @@ class VirtTestRunParser(optparse.OptionParser):
     def __init__(self):
         optparse.OptionParser.__init__(self, usage='Usage: %prog [options]')
         from virttest import data_dir
+        from virttest import bootstrap
+        jeos_info = bootstrap.get_jeos_info()
+        self.default_guest_os = jeos_info['variant']
 
         try:
             qemu_bin_path = _find_default_qemu_paths()[0]
@@ -252,7 +255,7 @@ class VirtTestRunParser(optparse.OptionParser):
                            default=None,
                            help=("Select the guest OS to be used. "
                                  "If -c is provided, this will be ignored. "
-                                 "Default: %s" % DEFAULT_GUEST_OS))
+                                 "Default: %s" % self.default_guest_os))
         general.add_option("--arch", action="store", dest="arch",
                            default=None,
                            help=("Architecture under test. "
@@ -413,7 +416,6 @@ def variant_only_file(filename):
 
 
 DEFAULT_MACHINE_TYPE = "i440fx"
-DEFAULT_GUEST_OS = "JeOS.20"
 QEMU_DEFAULT_SET = "migrate..tcp, migrate..unix, migrate..exec, migrate..fd"
 LIBVIRT_DEFAULT_SET = variant_only_file('backends/libvirt/cfg/default_tests')
 LVSB_DEFAULT_SET = ("lvsb_date")
@@ -649,7 +651,7 @@ class VirtTestApp(object):
                       self.options.guest_os)
                 sys.exit(1)
             self.cartesian_parser.only_filter(
-                self.options.guest_os or DEFAULT_GUEST_OS)
+                self.options.guest_os or self.option_parser.default_guest_os)
         else:
             logging.info("Config provided, ignoring --guest-os option")
 
@@ -917,7 +919,8 @@ class VirtTestApp(object):
                       "names correctly, and double "
                       "check that tests show "
                       "in --list-tests for guest '%s'" %
-                      (self.options.guest_os or DEFAULT_GUEST_OS))
+                      (self.options.guest_os or
+                       self.option_parser.default_guest_os))
                 sys.exit(1)
 
             if self.options.config:

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -2,7 +2,7 @@ import logging
 import os
 import glob
 import shutil
-from autotest.client.shared import logging_manager, error
+from autotest.client.shared import logging_manager, error, distro
 from autotest.client import utils
 import utils_misc
 import data_dir
@@ -51,6 +51,17 @@ last_subtest = {'qemu': ['shutdown'],
                 'lvsb': []}
 
 test_filter = ['__init__', 'cfg', 'dropin.py']
+
+
+def get_jeos_info():
+    """
+    Gets the correct asset and variant information depending on host OS.
+    """
+    detected = distro.detect()
+    if detected.name == 'fedora' and int(detected.version) >= 20:
+        return {'asset': 'jeos-20-64', 'variant': 'JeOS.20'}
+    else:
+        return {'asset': 'jeos-19-64', 'variant': 'JeOS.19'}
 
 
 def _get_config_filter():
@@ -784,7 +795,9 @@ def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
         step += 2
         logging.info("%s - Verifying (and possibly downloading) guest image",
                      step)
-        asset.download_asset('jeos-20-64', interactive=interactive,
+        jeos_info = get_jeos_info()
+        jeos_asset = jeos_info['asset']
+        asset.download_asset(jeos_asset, interactive=interactive,
                              restore_image=restore_image)
 
     if check_modules:


### PR DESCRIPTION
With the newest JeOS 20, people running earlier
versions of Fedora as a host will have trouble
with the fact that libvirt of those hosts will
not know anything about 'fedora.20' guests.

So let's use the latest JeOS only for people
running on Fedora 20, and leave the older JeOS 19
for people running on other hosts.

In order to accomplish this goal, add get_jeos_info(),
a function that will return JeOS information according
to the host OS info, and change references to the
JeOS variants and asset names to use that API.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
