### PR TITLE
utils_test/libvirt/get_all_cells(): Fix call to virsh.freecell

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -191,7 +191,7 @@ def get_all_cells():
                         "1":"1059868 KiB",
                         "Total":"1184068 KiB"}
     """
-    fc_result = virsh.freecell("--all", ignore_status=True)
+    fc_result = virsh.freecell(options="--all", ignore_status=True)
     if fc_result.exit_status:
         if fc_result.stderr.count("NUMA not supported"):
             raise error.TestNAError(fc_result.stderr.strip())


### PR DESCRIPTION
Commit id '30073c37' added a 'cellno' parameter to virsh.freecell as
the first optional/named parameter; however, the call here didn't indicate
or name whether its first parameter was for 'options', thus the assumption
was it was for cellno.  This led to test failure in 'virsh.nodememstats'
when the 'all' option was selected for 'cell_test.max_plus_one'.

The call would look like: "virsh freecell --cellno --all" instead
of "virsh freecell --all", resulting in error:

```
"stderr: error: cell number has to be a number"
```
