### PR TITLE
virttest.libvirt_xml: Add class for cputune entry

### DIFF
--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -148,7 +148,7 @@ class Disk(base.TypedDeviceBase):
         def marshal_to_seclabel(tag, attr_dict, index, libvirtxml):
             """Convert a tag + attributes into a Seclabel instance"""
             del index           # not used
-            if tag is not 'seclabel':
+            if tag != 'seclabel':
                 return None     # Don't convert this item
             Seclabel = librarian.get('seclabel')
             newone = Seclabel(virsh_instance=libvirtxml.virsh)
@@ -171,7 +171,7 @@ class Disk(base.TypedDeviceBase):
             """Convert a tag + attributes into a dictionary"""
             del index                    # not used
             del libvirtxml               # not used
-            if tag is not 'host':
+            if tag != 'host':
                 return None              # skip this one
             return dict(attr_dict)       # return copy of dict, not reference
 

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -81,6 +81,18 @@ class VMXMLBase(base.LibvirtXMLBase):
             get: returns VMXMLDevices instance for all devices
             set: Define all devices from VMXMLDevices instance
             del: remove all devices
+        cputune: VMCPUTune
+            get: return VMCPUTune instance for the domain.
+            set: Define cputune tag from a VMCPUTune instance.
+            del: remove cputune tag
+        current_vcpu: string, 'current' attribute of vcpu tag
+            get: return a string for 'current' attribute of vcpu
+            set: change 'current' attribute of vcpu
+            del: remove 'current' attribute of vcpu
+        placement: string, 'placement' attribute of vcpu tag
+            get: return a string for 'placement' attribute of vcpu
+            set: change 'placement' attribute of vcpu
+            del: remove 'placement' attribute of vcpu
         emulatorpin: string, cpuset value (see man virsh: cpulist)
             get: return text value of cputune/emulatorpin attributes
             set: set cputune/emulatorpin attributes from string
@@ -90,8 +102,8 @@ class VMXMLBase(base.LibvirtXMLBase):
     # Additional names of attributes and dictionary-keys instances may contain
     __slots__ = ('hypervisor_type', 'vm_name', 'uuid', 'vcpu', 'max_mem',
                  'current_mem', 'numa', 'devices', 'seclabel',
-                 'cputune', 'emulatorpin', 'cpuset', 'placement',
-                 'current_vcpu', 'os', 'os_type', 'os_arch', 'os_init')
+                 'cputune', 'placement', 'current_vcpu', 'os', 'os_type',
+                 'os_arch', 'os_init')
 
     __uncompareable__ = base.LibvirtXMLBase.__uncompareable__
 
@@ -167,17 +179,13 @@ class VMXMLBase(base.LibvirtXMLBase):
                                  forbidden=None,
                                  parent_xpath='numatune',
                                  tag_name='memory')
-        accessors.XMLElementText(property_name="cputune",
+        accessors.XMLElementNest(property_name='cputune',
                                  libvirtxml=self,
-                                 forbidden=None,
                                  parent_xpath='/',
-                                 tag_name='cputune')
-        accessors.XMLAttribute(property_name="emulatorpin",
-                               libvirtxml=self,
-                               forbidden=None,
-                               parent_xpath='/cputune',
-                               tag_name='emulatorpin',
-                               attribute='cpuset')
+                                 tag_name='cputune',
+                                 subclass=VMCPUTune,
+                                 subclass_dargs={
+                                     'virsh_instance': virsh_instance})
         super(VMXMLBase, self).__init__(virsh_instance=virsh_instance)
 
     def get_devices(self, device_type=None):
@@ -1045,3 +1053,59 @@ class VMClockXML(VMXML):
             return newone
         else:
             return None
+
+
+class VMCPUTune(base.LibvirtXMLBase):
+    """
+    CPU tuning tag XML class
+
+    Elements:
+        vcpupins:             list of dict - vcpu, cpuset
+        emulatorpin:          attribute    - cpuset
+        shares:               int
+        period:               int
+        quota:                int
+        emulator_period:      int
+        emulator_quota:       int
+    """
+
+    __slots__ = ('vcpupins', 'emulatorpin', 'shares', 'period', 'quota',
+                 'emulator_period', 'emulator_quota')
+
+    def __init__(self, virsh_instance=base.virsh):
+        accessors.XMLElementList('vcpupins', self, parent_xpath='/',
+                                 marshal_from=self.marshal_from_vcpupins,
+                                 marshal_to=self.marshal_to_vcpupins)
+        accessors.XMLAttribute('emulatorpin', self, parent_xpath='/',
+                               tag_name='emulatorpin', attribute='cpuset')
+        for slot in self.__all_slots__:
+            if slot in ('shares', 'period', 'quota', 'emulator_period',
+                        'emulator_quota'):
+                accessors.XMLElementInt(slot, self, parent_xpath='/',
+                                        tag_name=slot)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
+        self.xml = '<cputune/>'
+
+    @staticmethod
+    def marshal_from_vcpupins(item, index, libvirtxml):
+        """
+        Convert a dict to vcpupin tag and attributes.
+        """
+        del index
+        del libvirtxml
+        if not isinstance(item, dict):
+            raise xcepts.LibvirtXMLError("Expected a dictionary of host "
+                                         "attributes, not a %s"
+                                         % str(item))
+        return ('vcpupin', dict(item))
+
+    @staticmethod
+    def marshal_to_vcpupins(tag, attr_dict, index, libvirtxml):
+        """
+        Convert a vcpupin tag and attributes to a dict.
+        """
+        del index
+        del libvirtxml
+        if tag != 'vcpupin':
+            return None
+        return dict(attr_dict)


### PR DESCRIPTION
1) Use a dedicated class VMCPUTune to manipulate `<cputune>` tag
   instead of using a tag string and a lot of attributes which is
   not intuitive when using.

2) Add a simple getter setter delter unittest for this class.

3) Fixed two `<string> is not <string>` to `<string> != <string>`.
   The first one is identity test and will not alway get `False`
   even if two strings are equal.

Signed-off-by: Hao Liu hliu@redhat.com
