### PR TITLE
Iscsi small bugs fix.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -176,6 +176,7 @@ image_unbootable_pattern = "Hard Disk.*not a bootable disk"
 # For both iscsi and emulated iscsi should have this option:
 # target: target name of your iscsi device
 # device_id(optinal): The number of your device if the iscsi device already formated
+# iscsi_init_timeout(optional): Timeout for OS to init iscsi device under /dev after login to the target. Default value is 10s
 # For iscsi device only:
 # portal_ip: iscsi server ip
 # initiator: initiator name

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -493,7 +493,13 @@ class Iscsidev(storage.Iscsidev):
         else:
              self.iscsidevice.login()
 
-        device_name = self.iscsidevice.get_device_name()
+        if utils_misc.wait_for(self.iscsidevice.get_device_name,
+                               self.iscsi_init_timeout):
+            device_name = self.iscsidevice.get_device_name()
+        else:
+            raise error.TestError("Can not get iscsi device name in host"
+                                  " in %ss" % self.iscsi_init_timeout)
+
         if self.device_id:
             device_name += self.device_id
         return device_name

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -462,6 +462,7 @@ class Iscsidev(Rawdev):
         params["iscsi_thread_id"] = self.image_name
         self.iscsidevice = iscsi.Iscsi(params, root_dir=root_dir)
         self.device_id = params.get("device_id")
+        self.iscsi_init_timeout = int(params.get("iscsi_init_timeout", 10))
 
 
 class LVMdev(Rawdev):


### PR DESCRIPTION
Fix two problems find in our test:
1. Login will failed in setup() when the session is already present
2. Sometimes OS need several seconds to init iscsi device under /dev (based on host stress status).
