### PR TITLE
utils_misc: Use re.split to do regexp split

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1510,7 +1510,7 @@ def get_cpu_flags(cpu_info=""):
     if not cpu_flag_lists:
         return []
     cpu_flags = cpu_flag_lists[0]
-    return cpu_flags.strip().split('\s+')
+    return re.split("\s+", cpu_flags.strip())
 
 
 def get_cpu_vendor(cpu_info="", verbose=True):


### PR DESCRIPTION
The .split() method of python's standard string type does not take a
regexp as an argument, only another string. Switch to re.split().

Signed-off-by: Jonas Eriksson jonas.eriksson@enea.com
