### PR TITLE
Backends: Libguestfs fix

### DIFF
--- a/backends/libguestfs/cfg/tests-shared.cfg
+++ b/backends/libguestfs/cfg/tests-shared.cfg
@@ -17,9 +17,6 @@ vm_type = libvirt
 # where default or unset means derive from installed system
 connect_uri = default
 
-# Additional directory for find virt type tests. Relative to client/tests/virt
-other_tests_dirs = "libguestfs"
-
 # Modify/comment the following lines if you wish to modify the paths of the
 # image files, ISO files or qemu binaries.
 #


### PR DESCRIPTION
No need other_tests_dir any more.
