### PR TITLE
utils_test.libvirt: Fix pre_pool for iscsi_get_sessions.

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -25,7 +25,9 @@ def iscsi_get_sessions():
     sessions = []
     if "No active sessions" not in output:
         for session in output.splitlines():
-            sessions.append(session.split()[3])
+            ip_addr = session.split()[2].split(',')[0]
+            target = session.split()[3]
+            sessions.append((ip_addr, target))
     return sessions
 
 
@@ -143,7 +145,7 @@ class Iscsi(object):
         """
         sessions = iscsi_get_sessions()
         login = False
-        if self.target in sessions:
+        if self.target in map(lambda x: x[1], sessions):
             login = True
         return login
 


### PR DESCRIPTION
I adopt @will-Do 's idea to recover tuple of get_iscsi_sessions.
Because, the destroy failed of iscsi-pool caused by not suitable ip_addr, 
so we should use what we get from sessions. 
@jferlan, you can try this one now.

I have left the port in returns of sessions for extension in future when we need that port.
- Let iscsi.get_iscsi_sessions return tuple of target and address
- Before cleanup of pool in PoolVolumeTest, we should check
  whether pool exists.
- As iscsi.iscsi_get_sessions returns ip_addr and port,
  we should remove port for pool-operations.
