### PR TITLE
tools/run_unittests_nose: Remove hardcoded blacklist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
     - pip install -r requirements.txt
 
 script:
-    VIRT_TEST_DIR=. ./tools/run_unittests_nose.py -c .nose.cfg -s virttest
+    VIRT_TEST_DIR=. ./tools/run_unittests_nose.py -c .nose.cfg -s virttest --virttest-skip-tests "virsh_unittest versionable_class_unittest"

--- a/tools/run_unittests_nose.py
+++ b/tools/run_unittests_nose.py
@@ -30,17 +30,14 @@ class VirtTestSelector(Selector):
         return True
 
     def wantFile(self, filename):
-        blacklist = ['versionable_class_unittest.py', 'virsh_unittest.py']
         if not filename.endswith('_unittest.py'):
-            return False
-        if os.path.basename(filename) in blacklist:
             return False
 
         skip_tests = []
         if self.config.options.skip_tests:
             skip_tests = self.config.options.skip_tests.split()
 
-        if filename[:-3] in skip_tests:
+        if os.path.basename(filename)[:-3] in skip_tests:
             logger.debug('Skipping test: %s' % filename)
             return False
 


### PR DESCRIPTION
And use the script options to remove tests from the
execution.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
