### PR TITLE
documentation: Add requirements.txt pip file

### DIFF
--- a/documentation/source/requirements.txt
+++ b/documentation/source/requirements.txt
@@ -1,0 +1,1 @@
+autotest


### PR DESCRIPTION
So that read the docs can fetch autotest from PyPI
when building the docs.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
