### PR TITLE
remote_build: Simpler interface

### DIFF
--- a/documentation/source/advanced/BuildingTestApplications.rst
+++ b/documentation/source/advanced/BuildingTestApplications.rst
@@ -45,7 +45,9 @@ A simple example:
 
 ::
 
-    builder = utils_build.Builder(address, source_dir)
+    address = vm.get_address(0)
+    source_dir = data_dir.get_deps_dir("<testapp>")
+    builder = utils_build.Builder(params, address, source_dir)
     full_build_path = builder.build()
 
 In this case, we utilize the `.build()` method, which execute the neccessary
@@ -64,7 +66,7 @@ above is:
 
 ::
 
-    builder = utils_build.Builder(address, source_dir)
+    builder = utils_build.Builder(params, address, source_dir)
     if builder.sync_directories():
         builder.make()
     full_build_path = builder.full_build_path


### PR DESCRIPTION
As per the discussions in https://github.com/autotest/virt-test/pull/1594 and https://github.com/autotest/tp-qemu/pull/73 , I'm adding this as a pull request to simplify commenting before going home for the weekend.

Update the remote_build interface to make it figure out the default
values of lots of input parameters without being explicitly told. This
change would mean that this:

```
username = params.get("username", "")
password = params.get("password", "")
address = vm.get_address(0)
source_dir = data_dir.get_deps_dir("clock_getres")
build_dir = params.get("build_dir", "/tmp")
shell_client = params.get("shell_client", "ssh")
file_transfer_client = params.get("file_transfer_client", "scp")
shell_prompt = params.get("shell_prompt")
shell_linesep = params.get("shell_linesep")
builder = remote_build.Builder(address, source_dir, client=shell_client,
                               file_transfer_client=file_transfer_client,
                               username=username,
                               password=password,
                               build_dir=build_dir,
                               prompt=shell_prompt,
                               linesep=shell_linesep)
```

..can now be done like this, given that params is set:

```
address = vm.get_address(0)
source_dir = data_dir.get_deps_dir("clock_getres")
builder = remote_build.Builder(params, address, source_dir)
```

The idea is to reduce the boiler plate needed by test case designer to
fetch all the parameters from the cartesian configuration. It also fixes
the lack of a separate file_transfer_port, which is needed by the rss
file transfer client.

Signed-off-by: Jonas Eriksson jonas.eriksson@enea.com
