### PR TITLE
virttest.utils_libguestfs: Add sets of commands for is-*

### DIFF
--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -1289,6 +1289,22 @@ class GuestfishPersistent(Guestfish):
         """
         return self.inner_cmd("disk-virtual-size %s" % filename)
 
+    def max_disks(self):
+        """
+        max-disks - maximum number of disks that may be added
+
+        Return the maximum number of disks that may be added to a handle
+        """
+        return self.inner_cmd("max-disks")
+
+    def nr_devices(self):
+        """
+        nr-devices - return number of whole block devices (disks) added
+
+        This returns the number of whole block devices that were added
+        """
+        return self.inner_cmd("nr-devices")
+
     def pvcreate(self, physvols):
         """
         pvcreate - create an LVM physical volume


### PR DESCRIPTION
Add following commands:
is-blockdev
is-blockdev-opts
is-chardev
is-chardev-opts
is-file-opts
is-dir
is-dir-opts
is-socket
is-socket-opts
is-fifo
is-fifo-opts
is-zero
is-whole-device
is-lv
is-symlink
is-zero-device

Modify one:
is-file
