### PR TITLE
shared.cfg: Disable guest_s3/guest_s4 if virtio devices present

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/5.10.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.10.cfg
@@ -15,3 +15,10 @@
         # thread_siblings_list file to get the thread count in a core.
         # More info, please read cpulist_scnprintf() in include/linux/cpumask.h
         cpu_threads_chk_cmd = "expr $(grep -c ',' /sys/devices/system/cpu/cpu0/topology/thread_siblings_list) + 1"
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.3.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.3.cfg
@@ -7,3 +7,10 @@
         syslog_server_proto = udp
     usb_storage.check_options:
         check_io_size_option = no
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.4.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.4.cfg
@@ -7,3 +7,10 @@
         syslog_server_proto = udp
     usb_storage.check_options:
         check_io_size_option = no
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.5.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.5.cfg
@@ -7,3 +7,10 @@
         syslog_server_proto = udp
     usb_storage.check_options:
         check_io_size_option = no
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.6.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.6.cfg
@@ -7,3 +7,10 @@
         syslog_server_proto = udp
     usb_storage.check_options:
         check_io_size_option = no
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.7.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.7.cfg
@@ -15,4 +15,10 @@
         # thread_siblings_list file to get the thread count in a core.
         # More info, please read cpulist_scnprintf() in include/linux/cpumask.h
         cpu_threads_chk_cmd = "expr $(grep -c ',' /sys/devices/system/cpu/cpu0/topology/thread_siblings_list) + 1"
-
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.8.cfg
@@ -15,4 +15,10 @@
         # thread_siblings_list file to get the thread count in a core.
         # More info, please read cpulist_scnprintf() in include/linux/cpumask.h
         cpu_threads_chk_cmd = "expr $(grep -c ',' /sys/devices/system/cpu/cpu0/topology/thread_siblings_list) + 1"
-
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/5.9.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.9.cfg
@@ -15,3 +15,10 @@
         # thread_siblings_list file to get the thread count in a core.
         # More info, please read cpulist_scnprintf() in include/linux/cpumask.h
         cpu_threads_chk_cmd = "expr $(grep -c ',' /sys/devices/system/cpu/cpu0/topology/thread_siblings_list) + 1"
+    guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
+    guest_s4:
+        no virtio_net
+        no virtio_blk

--- a/shared/cfg/guest-os/Linux/RHEL/6.0.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.0.cfg
@@ -10,6 +10,9 @@
     block_hotplug:
         modprobe_module =
     guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
         global_enable_s3:
             s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
             s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
@@ -22,6 +25,8 @@
             s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
             s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
     guest_s4:
+        no virtio_net
+        no virtio_blk
         global_enable_s4:
             s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
             s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"

--- a/shared/cfg/guest-os/Linux/RHEL/6.1.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.1.cfg
@@ -10,6 +10,9 @@
     block_hotplug:
         modprobe_module =
     guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
         global_enable_s3:
             s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
             s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
@@ -22,6 +25,8 @@
             s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
             s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
     guest_s4:
+        no virtio_net
+        no virtio_blk
         global_enable_s4:
             s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
             s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"

--- a/shared/cfg/guest-os/Linux/RHEL/6.2.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.2.cfg
@@ -10,6 +10,9 @@
     block_hotplug:
         modprobe_module =
     guest_s3:
+        # Disallow system to enter S3 or S4 states if virtio devices present for old guests
+        no virtio_net
+        no virtio_blk
         global_enable_s3:
             s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
             s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
@@ -22,6 +25,8 @@
             s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
             s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
     guest_s4:
+        no virtio_net
+        no virtio_blk
         global_enable_s4:
             s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
             s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"


### PR DESCRIPTION
Disallow system to enter S3 or S4 states
if virtio devices present for old guests.
