### PR TITLE
PoolVolumeTest: cleanup_pool: Clean up directory tree for more types

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -620,7 +620,7 @@ class PoolVolumeTest(object):
             if pool_type in ["logical", "iscsi", "fs", "disk", "scsi"]:
                 setup_or_cleanup_iscsi(is_setup=False,
                                        emulated_image=emulated_image)
-            if pool_type == "dir":
+            if pool_type in ["dir", "fs", "netfs"]:
                 pool_target = os.path.join(self.tmpdir, pool_target)
                 if os.path.exists(pool_target):
                     shutil.rmtree(pool_target)


### PR DESCRIPTION
When cleaning up the pool, we need to be sure to remove the pool_target
tree created during pre_pool setup for more than just the "dir" pool.
The "fs" and "netfs" pools also will 'mkdir' on the 'target_pool'. If not
cleaned up - other tests which use the same name space will have failures.

I found this during a run of "all" tests where 'virsh.vol_create' failed,
but would succeed when running alone.  I narrowed this down to the running
of 'virsh.vol_download_upload' which would create and use the directory
"fs-pool", but would not clean up after itself. This was not a problem until
"vol_create" ran later using the same "fs-pool" name and thus would fail to
create the pool because a directory already existed.

If interested run the following prior to this change to see the issue:

./run -t libvirt --tests \
 virsh.vol_download_upload.download_upload.fs_pool.upload.no_options, \
 virsh.vol_create.positive_test.fs_like_pool.vol_format.v_raw.src_pool_type.fs

The first will PASS and the second will ERROR
