### PR TITLE
virttest: Make nwfilter_xml.py compatible before python 2.6

### DIFF
--- a/virttest/libvirt_xml/nwfilter_xml.py
+++ b/virttest/libvirt_xml/nwfilter_xml.py
@@ -226,7 +226,7 @@ class NwfilterXMLBase(base.LibvirtXMLBase):
                 "Value must be a NwfilterXMLRules or subclass")
         try:
             source_root = self.xmltreefile.findall('rule')
-        except KeyError as detail:
+        except KeyError, detail:
             raise xcepts.LibvirtXMLError(detail)
         if source_root[rule_index] is not None:
             self.del_rule(rule_index)


### PR DESCRIPTION
except..as syntax not support before python 2.6
