### PR TITLE
remote_build: Avoid remote primitives for "localhost"

### DIFF
--- a/documentation/source/advanced/BuildingTestApplications.rst
+++ b/documentation/source/advanced/BuildingTestApplications.rst
@@ -73,3 +73,9 @@ above is:
 
 This pattern can be useful if you e.g. would like to add an additonal command
 to run before `builder.make()`, perhaps to install some extra dependencies.
+
+Despite its name, remote_build supports local builds as well. This support
+intended for small test applications that need to run both on host and on the
+guest, and is triggered by setting the `address` parameter to `"localhost"`.
+For any needs to build more complex applications host-side only, use
+`build_helper` instead.


### PR DESCRIPTION
This is a bit of an RFQ commit (although, I would like it if it was merged :-) ). On one hand, it goes against the 'remote_build' name, but on the other hand it's just an optimization for TCs that want to build the same binary on both host and target. Some TCs use SSH to connect to localhost, which would be equally good, but given the different prompts, usernames and passwords, I felt that this behavior just add unnecessary complexity to the build: More .cfg:s needs to be updated, the prompts might be different, etc. I have tested this functionality using a rewritten tsc_drift TC in tp-qemu, that I have not yet pushed as I would like to see what people think of this approach first.
To make sure that this feature is viewed as an optimization and not a primary goal, I added a short note in the documentation as well.

Thanks,
/Jonas
