### PR TITLE
virttest: fix syntax in run_autotest()

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -850,7 +850,7 @@ def run_autotest(vm, session, control_path, timeout,
                                              "results",
                                              os.path.basename(server_control_path))
                 if os.path.isdir(server_result):
-                    utils.safe_rmdir()
+                    utils.safe_rmdir(server_result)
                 # Remove the control file for server.
                 if os.path.exists(server_control_path):
                     os.remove(server_control_path)


### PR DESCRIPTION
Signed-off-by: Xu Tian xutian@redhat.com
