### PR TITLE
virttest.defaults: Use autotest new distro API

### DIFF
--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -1,3 +1,5 @@
+from autotest.client.shared import distro
+
 DEFAULT_MACHINE_TYPE = "i440fx"
 DEFAULT_GUEST_OS = "JeOS.19"
 
@@ -8,10 +10,8 @@ def get_default_guest_os_info():
     """
     os_info = {'asset': 'jeos-19-64', 'variant': DEFAULT_GUEST_OS}
 
-    from autotest.client import utils
-
-    issue_contents = utils.read_file('/etc/issue')
-    if 'Fedora' in issue_contents and '20' in issue_contents:
+    detected = distro.detect()
+    if detected.name == 'fedora' and int(detected.version) >= 20:
         os_info = {'asset': 'jeos-20-64', 'variant': 'JeOS.20'}
 
     return os_info


### PR DESCRIPTION
Now that we have autotest 0.16 in EPEL, we can safely
use autotest.client.shared.distro. This means no more
horrible hacks have to be used to determine the appropriate
guest OS to use.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
