### PR TITLE
virttest.virt_vm: Increase REBOOT_TIMEOUT value

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -498,7 +498,7 @@ class BaseVM(object):
     LOGIN_WAIT_TIMEOUT = 240
     COPY_FILES_TIMEOUT = 600
     MIGRATE_TIMEOUT = 3600
-    REBOOT_TIMEOUT = 240
+    REBOOT_TIMEOUT = 900
     CREATE_TIMEOUT = 5
 
     def __init__(self, name, params):


### PR DESCRIPTION
Default REBOOT_TIMEOUT value not enough for special guests(like: Win2012r2)
with huge memory and multiple cpu, so need to increase it.
