### PR TITLE
virttest.utils_misc: Fix bug of zero disk size for get_image_info.

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1983,7 +1983,9 @@ def normalize_data_size(value_str, order_magnitude="M", factor="1024"):
     order_magnitude_index = _get_magnitude_index(magnitude_list,
                                                  " %s" % order_magnitude)
 
-    if magnitude_index < 0 or order_magnitude_index < 0:
+    if data == 0:
+        return 0
+    elif magnitude_index < 0 or order_magnitude_index < 0:
         logging.error("Unknown input order of magnitude. Please check your"
                       "value '%s' and desired order of magnitude"
                       " '%s'." % (value_str, order_magnitude))


### PR DESCRIPTION
When disk size is zero, get_image_info will raise ValueError because
normalize_data_size return a null string. But zero of disk size
should be allowed.

@Guannan-Ren , This is work for https://github.com/autotest/tp-libvirt/pull/37
Please help me to check it.

Before:

```
09:52:05 DEBUG| Running 'qemu-img info /MYDISK/BIG/autotest/client/tests/gren_virt/tmp/blockresize_test'
09:52:05 DEBUG| image: /MYDISK/BIG/autotest/client/tests/gren_virt/tmp/blockresize_test
file format: raw
virtual size: 1.0M (1048576 bytes)
disk size: 0
...
09:52:24 ERROR|     image_info_dict['dsize'] = int(float(normalize_data_size(dsize, "B")))
ValueError: could not convert string to float:
```

Now:
{'dsize': 0, 'vsize': 1048576, 'format': 'raw'}

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
