### PR TITLE
get_image_info: Use 'bytes' value from qemu-img instead of normalize_data_size value

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1257,54 +1257,7 @@ class BackgroundTest(object):
 
 
 def get_image_info(image_file):
-    """
-    Get image information and put it into a dict. Image information like this:
-
-    ::
-
-        *******************************
-        image: /path/vm1_6.3.img
-        file format: raw
-        virtual size: 10G (10737418240 bytes)
-        disk size: 888M
-        ....
-        ....
-        *******************************
-
-    And the image info dict will be like this
-
-    ::
-
-        image_info_dict = {'format':'raw',
-                           'vsize' : '10737418240'
-                           'dsize' : '931135488'}
-
-    :todo: Add more information to `image_info_dict`.
-    """
-    try:
-        cmd = "qemu-img info %s" % image_file
-        image_info = utils.run(cmd, ignore_status=False).stdout.strip()
-        image_info_dict = {}
-        if image_info:
-            for line in image_info.splitlines():
-                if line.find("format") != -1:
-                    image_info_dict['format'] = line.split(':')[-1].strip()
-                elif line.find("virtual size") != -1:
-                    vsize = line.split(":")[-1].strip().split(" ")[0]
-                    vsize = utils_misc.normalize_data_size(vsize,
-                                                           order_magnitude="B",
-                                                           factor=1024)
-                    image_info_dict['vsize'] = int(float(vsize))
-                elif line.find("disk size") != -1:
-                    dsize = line.split(':')[-1].strip()
-                    dsize = utils_misc.normalize_data_size(dsize,
-                                                           order_magnitude="B",
-                                                           factor=1024)
-                    image_info_dict['dsize'] = int(float(dsize))
-        return image_info_dict
-    except (KeyError, IndexError, ValueError, error.CmdError), detail:
-        raise error.TestError("Fail to get information of %s:\n%s" %
-                              (image_file, detail))
+    return utils_misc.get_image_info(image_file)
 
 
 def ntpdate(service_ip, session=None):


### PR DESCRIPTION
Don't use the 'normalize_data_size()' method for the returned 'vsize'.
Use the 'bytes' value within the parentheses since it's the real value
that qemu-img finds/determines from the meta data.

Signed-off-by: John Ferlan jferlan@redhat.com
