### PR TITLE
virttest.qemu_vm: update regrex pattern for maxcpus option of smp device

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -517,7 +517,7 @@ class VM(virt_vm.BaseVM):
 
         def add_smp(devices):
             smp_str = " -smp %d" % self.cpuinfo.smp
-            smp_pattern = "smp n\[,maxcpus=cpus\].*"
+            smp_pattern = "smp .*n\[,maxcpus=cpus\].*"
             if devices.has_option(smp_pattern):
                 smp_str += ",maxcpus=%d" % self.cpuinfo.maxcpus
             smp_str += ",cores=%d" % self.cpuinfo.cores


### PR DESCRIPTION
In latest upstream qemu-kvm, help info for smp device changed like
   ' -smp [cpus=]n[,maxcpus=cpus][,'
updated regrex pattern to make 'vcpu_maxcpus' param works for latest
qemu-kvm build.

Signed-off-by: Xu Tian xutian@redhat.com
