### PR TITLE
nic_hotplug.one_pci.nic_e1000: small fix to the escape character

### DIFF
--- a/virttest/unittest_data/testcfg.huge/guest-os.cfg
+++ b/virttest/unittest_data/testcfg.huge/guest-os.cfg
@@ -1675,7 +1675,7 @@ variants:
             find_pci_cmd = ipconfig /all | find "Description"
             wait_secs_for_hook_up = 10
             nic_e1000:
-                match_string = "Intel(R) PRO/1000 MT Network Connection"
+                match_string = "Intel\(R\) PRO/1000 MT Network Connection"
             nic_virtio:
                 match_string = "VirtIO Ethernet"
         block_hotplug:


### PR DESCRIPTION
Signed-off-by: Cong Li coli@redhat.com
