### PR TITLE
virt: Fix a bug in check_iface func

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -930,7 +930,7 @@ def check_iface(iface_name, checkpoint, extra=""):
             # Check virsh list output
             result = virsh.iface_list(extra, ignore_status=True)
             check_exit_status(result, False)
-            output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]",
+            output = re.findall(r"(\S+)\ +(\S+)\ +",
                                 str(result.stdout))
             if filter(lambda x: x[0] == iface_name, output[1:]):
                 list_find = True


### PR DESCRIPTION
```
Command 'virsh iface-list --all' may output like this:
eth1                 active     00:0c:29:7d:0a:36
lo                   active     00:00:00:00:00:00
test                 inactive
virbr0               active     00:0c:29:7d:0a:2c
```

And the original source cannot get 'test' interface.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
