### PR TITLE
virttest: Remove the special strings from sysfs of numa possible node

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1176,6 +1176,7 @@ def cpu_str_to_list(origin_str):
     :rtype: list
     """
     if isinstance(origin_str, str):
+        origin_str = "".join([_ for _ in origin_str if _ in string.printable])
         cpu_list = []
         for cpu in origin_str.strip().split(","):
             if "-" in cpu:


### PR DESCRIPTION
In some system the possible node information read from sysfs include some
special string as \x00 for end of the string. Need remove it as it will
failed the translate of string to int.
