### PR TITLE
env_process: Check if VM exists when preprocessing

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -93,6 +93,15 @@ def preprocess_vm(test, params, env, name):
         vm = env.create_vm(vm_type, target, name, params, test.bindir)
     old_vm = copy.copy(vm)
 
+    if vm_type == 'libvirt':
+        if not vm.exists() and params.get("type") != "unattended_install":
+            error_msg = "Test VM %s does not exist." % name
+            if name == params.get("main_vm"):
+                error_msg += " You may need --install option to create the guest."
+                raise error.TestError(error_msg)
+            else:
+                raise error.TestNAError(error_msg)
+
     remove_vm = False
     if params.get("force_remove_vm") == "yes":
         remove_vm = True


### PR DESCRIPTION
Before this patch when running test cases without a main VM exists,
say `virt-tests-vm1`, the test still goes on, it will raise a `TestFail`
if it tries to start the non-exist VM or if test was configured not to be
started at the preprocess progress, there will be strange outputs.

This patch check the existence of target VM, and raise a `TestError` if
`main_vm` don't exist or a `TestNAError` if a non-`main_vm` don't exist.

Signed-off-by: Hao Liu hliu@redhat.com
