### PR TITLE
virt: Fix 2 bugs in RemoteFile class

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -909,7 +909,7 @@ class RemoteFile(object):
             self._pull_file()
         except SCPTransferFailedError:
             # Remote file doesn't exist, create empty file on local
-            self._write_local("")
+            self._write_local([])
 
         # Save a backup.
         shutil.copy(self.local_path, self.backup_path)
@@ -999,6 +999,24 @@ class RemoteFile(object):
             for index in range(len(lines)):
                 line = lines[index]
                 lines[index] = re.sub(pattern, repl, line)
+        self._write_local(lines)
+        self._push_file()
+
+    def truncate(self, length=0):
+        """
+        Truncate the detail of remote file to assigned length
+        Content before
+        line 1
+        line 2
+        line 3
+        remote_file.truncate(length=1)
+        Content after
+        line 1
+
+        :param length: how many lines you want to keep
+        """
+        lines = self._read_local()
+        lines = lines[0: length]
         self._write_local(lines)
         self._push_file()
 


### PR DESCRIPTION
1.Join the list elements before writing.
2.Catch SCPTransferFailedError, and create new empty file on local if remote file doesn't exist.
