### PR TITLE
virsh: Init virsh_exec with default value if it is None.

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -140,6 +140,9 @@ class VirshSession(aexpect.ShellSession):
         self.remote_user = remote_user
         self.remote_pwd = remote_pwd
 
+        if virsh_exec is None:
+            virsh_exec = VIRSH_EXEC
+
         # Special handling if setting up a remote session
         if ssh_remote_auth:  # remote to remote
             if remote_pwd:


### PR DESCRIPTION
Without this patch, we will get a virsh cmd like "None -c uri start vm".

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
