### PR TITLE
libvirt_vm: Resume vm in destroy() when vm is paused.

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1297,6 +1297,8 @@ class VM(virt_vm.BaseVM):
             # Is it already dead?
             if self.is_alive():
                 logging.debug("Destroying VM")
+                if self.is_paused():
+                    self.resume()
                 if (not self.is_lxc() and gracefully and
                         self.params.get("shutdown_command")):
                     # Try to destroy with shell command


### PR DESCRIPTION
There are some cases need to suspend vm, and in postprocess,
we need to kill vm by vm.destroy(). But when vm is paused,
vm.destroy() will wait 240s to login it. Then find it is not
loginable and kill it with virsh.destroy().

We waste 240s at this case, we should check the state of vm
before we login it.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
