### PR TITLE
utils_libvirtd: Don't need to wait if start failed

### DIFF
--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -58,16 +58,18 @@ class Libvirtd(object):
 
     def start(self):
         # pylint: disable=E1103
-        self.libvirtd.start()
+        if not self.libvirtd.start():
+            return False
         return self._wait_for_start()
 
     def stop(self):
         # pylint: disable=E1103
-        self.libvirtd.stop()
+        return self.libvirtd.stop()
 
     def restart(self):
         # pylint: disable=E1103
-        self.libvirtd.restart()
+        if not self.libvirtd.restart():
+            return False
         return self._wait_for_start()
 
     def is_running(self):


### PR DESCRIPTION
If libvirtd service start or restart failed, just checking the exit code
will be enough, we don't need to wait 60 seconds to check whether a
virsh command can be executed.

Signed-off-by: Hao Liu hliu@redhat.com
