### PR TITLE
virttest.utils_test: Init subtest_dir in run_virt_sub_test

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1031,6 +1031,7 @@ def run_virt_sub_test(test, params, env, sub_type=None, tag=None):
 
     provider = params.get("provider", None)
     subtest_dirs = []
+    subtest_dir = None
 
     if provider is None:
         # Verify if we have the correspondent source file for it


### PR DESCRIPTION
Init subtest_dir to None otherwise, it will report the variable
referenced before assignment.
