### PR TITLE
libvirt_xml: Introduce a method get_section_string() in base

### DIFF
--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -166,6 +166,16 @@ class LibvirtXMLBase(propcan.PropCanBase):
             pass  # no XML was loaded yet
         return the_copy
 
+    def get_section_string(self, xpath):
+        """
+        Returns the content of section in xml.
+        """
+        section = self.xmltreefile.find(xpath)
+        if section is None:
+            raise xcepts.LibvirtXMLNotFoundError("Path %s is not found.")
+
+        return self.xmltreefile.get_element_string(xpath)
+
     def get_validates(self):
         """
         Accessor method for 'validates' property returns virt-xml-validate T/F

--- a/virttest/xml_utils.py
+++ b/virttest/xml_utils.py
@@ -321,6 +321,12 @@ class XMLTreeFile(ElementTree.ElementTree, XMLBackup):
                 next_element = ElementTree.SubElement(cur_element, tag)
             cur_element = next_element
 
+    def get_element_string(self, xpath):
+        """
+        Returns the string for the element on xpath.
+        """
+        return ElementTree.tostring(self.find(xpath))
+
     # This overrides the file.write() method
     def write(self, filename=None, encoding=ENCODING):
         """


### PR DESCRIPTION
Sometimes we need to get the all element in xml, this
method will return a string of a element.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
