### PR TITLE
cfg.base: Add migration relative parameters.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -419,6 +419,35 @@ remote_user = root
 # Default password is same as local_pwd
 remote_pwd = "${local_pwd}"
 
+##### migration use only parameters
+##### host information for destination and source
+migrate_source_host = ENTER.YOUR.SOURCE.EXAMPLE.COM
+migrate_source_pwd = PASSWORD.SOURCE.EXAMPLE
+# Remove comment if local and remote host can be used for migration
+# migrate_source_host = "${local_ip}"
+# migrate_source_pwd = "${local_pwd}"
+migrate_dest_host = ENTER.YOUR.DEST.EXAMPLE.COM
+migrate_dest_pwd = PASSWORD.DEST.EXAMPLE
+# migrate_dest_host = "${remote_ip}"
+# migrate_dest_pwd = "${remote_pwd}"
+
+# Please provide a shared VM image for migration
+# It could be put into NFS or SAN, it is used to create
+# a vm with shared_storage on source and destination
+migrate_shared_storage = SHARED_IMAGE.EXAMPLE.COM
+# Defined VMs that can be used for migration
+# For example: "migrate_vm1 migrate_vm2 migrate_vm3"
+# So please put images of vms into NFS or SAN
+migrate_vms = ""
+# Used for loading stress for host during stress migration
+migrate_load_vms = ""
+
+# Protocol of migrate uri(tcp, udp)
+migrate_proto = "tcp"
+# Port of migration: 49152-49216
+# Remember to open ports on both source and destination
+migrate_port = 49152
+
 # NFS directory of guest images
 #images_good = fileserver.foo.com:/autotest/images_good
 


### PR DESCRIPTION
Use remote_ip and local_ip as destination and source host
for migration may disturb libvirt tests. So separate them
only for migration relative tests.

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
