### PR TITLE
virt: Remove some filters from v2v/cfg/tests.cfg

### DIFF
--- a/backends/v2v/cfg/tests.cfg
+++ b/backends/v2v/cfg/tests.cfg
@@ -13,8 +13,6 @@ variants:
         only smallpages
         no multi_host
         # Simple testing for automatically converting/importing an existing foreign VM into libvirt.
-        only virsh_pool_create_as convert_libvirt linux_vm_check_local
-        #only convert_ovirt ovirt linux_vm_check_remote
     - @v2v_build:
         only raw
         only virtio_net


### PR DESCRIPTION
These filters will make './run -t v2v --list-tests'
cannot get all test cases in v2v, so remove them.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
