### PR TITLE
utils_misc: Fix get_image_info fail to get format

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2166,7 +2166,7 @@ def get_image_info(image_file):
         image_info_dict = {}
         if image_info:
             for line in image_info.splitlines():
-                if line.find("format") != -1:
+                if line.find("file format") != -1:
                     image_info_dict['format'] = line.split(':')[-1].strip()
                 elif line.find("virtual size") != -1:
                     # Use the value in (xxxxxx bytes) since it's the more


### PR DESCRIPTION
For qemu-img-1.5.3, We get following message when running:
`# qemu-img info /var/lib/virt_test/images/jeos-19-64.qcow2`

```
image: /var/lib/virt_test/images/jeos-19-64.qcow2
file format: qcow2
virtual size: 10G (10737418240 bytes)
disk size: 761M
cluster_size: 65536
Format specific information:
    compat: 0.10
```

The `Format specific information:` line which containing a
`Format` will flush the saved file format. Now we use a more
specific line to check file format.

Signed-off-by: Hao Liu hliu@redhat.com
