### PR TITLE
virt.shared.cfg: Set mac_changeable to no in unattended_install.

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -126,6 +126,8 @@ variants:
         RHEL.6, RHEL.5:
             mac_ip_filter = "HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+)\s+?inet addr:(.\d+\.\d+\.\d+\.\d+)"
         mac_changeable = "yes"
+        unattended_install:
+            mac_changeable = no
     - vf_assignable:
         pci_assignable = vf
         nettype = bridge
@@ -147,6 +149,8 @@ variants:
         RHEL.6, RHEL.5:
             mac_ip_filter = "HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+)\s+?inet addr:(.\d+\.\d+\.\d+\.\d+)"
         mac_changeable = "yes"
+        unattended_install:
+            mac_changeable = no
         sr-iov.sr_iov_negative.negative_max_vfs:
             driver_option = "max_vfs=-1"
         sr-iov.sr_iov_negative.more_than_max_vfs:


### PR DESCRIPTION
Signed-off-by: Feng Yang fyang@redhat.com
