### PR TITLE
libvirt_vm: Destroy crashed VM

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1327,7 +1327,9 @@ class VM(virt_vm.BaseVM):
                                 return
                         finally:
                             session.close()
-                virsh.destroy(self.name, uri=self.connect_uri)
+            # Destroy VM directly, as 'ignore_status=True' by default, so destroy
+            # a shutoff domain is also acceptable here.
+            virsh.destroy(self.name, uri=self.connect_uri)
 
         finally:
             self.cleanup_serial_console()


### PR DESCRIPTION
If VM state is 'crashed', the qemu process still exists, and start
VM will fail. So vm destroy should cover this situation.

Signed-off-by: Yanbing Du ydu@redhat.com
