### PR TITLE
utils_config: Add new class to manipulate config files

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -1,0 +1,448 @@
+import ast
+import logging
+import os.path
+import ConfigParser
+import StringIO
+import utils_libvirtd
+
+
+class ConfigError(Exception):
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class ConfigNoOptionError(ConfigError):
+
+    def __init__(self, option, path):
+        self.option = option
+        self.path = path
+
+    def __str__(self):
+        return "There's no option %s in config file %s." % (
+            self.option, self.path)
+
+
+class LibvirtConfigSyncError(ConfigError):
+
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "Failed to restart libvirtd when syncronizing config file."
+
+
+class LibvirtConfigUnknownKeyTypeError(ConfigError):
+
+    def __init__(self, key, key_type):
+        self.key = key
+        self.key_type = key_type
+
+    def __str__(self):
+        return "Unknown type %s for key %s." % (self.key, self.key_type)
+
+
+class LibvirtConfigUnknownKeyError(ConfigError):
+
+    def __init__(self, key):
+        self.key = key
+
+    def __str__(self):
+        return 'Unknown config key %s' % self.key
+
+
+class SectionlessConfig(object):
+
+    """
+    This is a wrapper class for python's internal library ConfigParser except
+    allows manipulating sectionless configuration file with a dict-like way.
+
+    Example config file test.conf:
+
+    ># This is a comment line.
+    >a = 1
+    >b = [hi, there]
+    >c = hello
+    >d = "hi, there"
+    >e = [hi,
+    >    there]
+
+    Example script using `try...finally...` statement:
+
+    >>> from virttest import utils_config
+    >>> config = utils_config.SectionlessConfig('test.conf')
+    >>> try:
+    ...     print len(config)
+    ...     print config
+    ...     print config['a']
+    ...     del config['a']
+    ...     config['f'] = 'test'
+    ...     print config
+    ... finally:
+    ...     config.restore()
+
+    Example script using `with` statement:
+
+    >>> from virttest import utils_config
+    >>> with utils_config.SectionlessConfig('test.conf') as config:
+    ...     print len(config)
+    ...     print config
+    ...     print config['a']
+    ...     del config['a']
+    ...     config['f'] = 'test'
+    ...     print config
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.parser = ConfigParser.ConfigParser()
+        self.backup_content = open(path, 'r').read()
+        read_fp = StringIO.StringIO('[root]\n' + self.backup_content)
+        self.parser.readfp(read_fp)
+
+    def __sync_file(self):
+        out_file = open(self.path, 'w')
+        try:
+            out_file.write(self.__str__())
+        finally:
+            out_file.close()
+
+    def __len__(self):
+        return len(self.parser.items('root'))
+
+    def __getitem__(self, option):
+        try:
+            return self.parser.get('root', option)
+        except ConfigParser.NoOptionError:
+            raise ConfigNoOptionError(option, self.path)
+
+    def __setitem__(self, option, value):
+        self.parser.set('root', option, value)
+        self.__sync_file()
+
+    def __delitem__(self, option):
+        res = self.parser.remove_option('root', option)
+        if res:
+            self.__sync_file()
+        else:
+            raise ConfigNoOptionError(option, self.path)
+
+    def __contains__(self, item):
+        return self.parser.has_option('root', item)
+
+    def __str__(self):
+        write_fp = StringIO.StringIO()
+        self.parser.write(write_fp)
+        return write_fp.getvalue().split('\n', 1)[1]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.restore()
+
+    def restore(self):
+        out_file = open(self.path, 'w')
+        try:
+            out_file.write(self.backup_content)
+        finally:
+            out_file.close()
+
+    def set_raw(self, option, value):
+        self[option] = "%s" % value
+
+    def set_string(self, option, value):
+        self[option] = '"%s"' % value
+
+    def set_int(self, option, value):
+        self[option] = '%d' % int(value)
+
+    def set_float(self, option, value):
+        self[option] = '%s' % float(value)
+
+    def set_boolean(self, option, value):
+        if type(value) == str:
+            value = int(value)
+        if bool(value):
+            self[option] = '1'
+        else:
+            self[option] = '0'
+
+    def set_list(self, option, value):
+        # TODO: line separation
+        value = ['"%s"' % i for i in list(value)]
+        self[option] = '[%s]' % ', '.join(value)
+
+    def get_raw(self, option):
+        return self[option]
+
+    def get_string(self, option):
+        raw_str = self[option].strip()
+        if raw_str.startswith('"') and raw_str.endswith('"'):
+            raw_str = raw_str[1:-1]
+        elif raw_str.startswith("'") and raw_str.endswith("'"):
+            raw_str = raw_str[1:-1]
+        else:
+            raise ValueError("Invalid value for string: %s" % raw_str)
+        return raw_str
+
+    def get_int(self, option):
+        return int(self.get_raw(option))
+
+    def get_float(self, option):
+        return float(self.get_raw(option))
+
+    def get_boolean(self, option):
+        try:
+            bool_str = self.get_string(option).lower()
+        except ValueError:
+            bool_str = str(self.get_int(option))
+
+        if bool_str in ["1", "yes", "true", "on"]:
+            return True
+        if bool_str in ["0", "no", "false", "off"]:
+            return False
+        raise ValueError("Invalid value for boolean: %s" % bool_str)
+
+    def get_list(self, option):
+        list_str = self.get_raw(option)
+        return [str(i) for i in ast.literal_eval(list_str)]
+
+
+class LibvirtConfigCommon(SectionlessConfig):
+
+    """
+    A abstract class to manipulate options of a libvirt related configure files
+    in a property's way.
+
+    Variables "__option_types__" and "conf_path" must be setup in the
+    inherented classes before use.
+
+    "__option_types__" is a dict contains every possible option as keys and
+    their type ("boolean", "int", "string", "float" or "list") as values.
+
+    Basic usage:
+    1) Create a config file object:
+    >>> # LibvirtdConfig is a subclass of LibvirtConfigCommon.
+    >>> config = LibvirtdConfig()
+
+    2) Set or update an option:
+    >>> config.listen_tcp = True
+    >>> config.listen_tcp = 1
+    >>> config.listen_tcp = "1" # All three have the same effect.
+
+    >>> # If the setting value don't meet the specified type.
+    >>> config.listen_tcp = "invalid"
+    >>> # It'll thown an warning message and set a raw string instead.
+
+    >>> # Use set_* methods when need to customize the result.
+    >>> config.set_raw("'1'")
+
+    3) Get an option:
+    >>> is_listening = config.listen_tcp
+    >>> print is_listening
+    True
+
+    4) Delete an option from the config file:
+    >>> del config.listen_tcp
+
+    5) Make the changes take effect in libvirt by restart libvirt daemon.
+    >>> config.sync()
+
+    6) Restore the content of the config file.
+    >>> config.restore()
+    """
+    __option_types__ = {}
+    conf_path = ''
+
+    def __init__(self, path=''):
+        if path:
+            self.conf_path = path
+        if not self.conf_path:
+            raise ConfigError("Path for config file is not set up.")
+        if not self.__option_types__:
+            raise ConfigError("__option_types__ is not set up.")
+        self.libvirtd = utils_libvirtd.Libvirtd()
+        if not os.path.isfile(self.conf_path):
+            raise ConfigError("Path for config file %s don't exists."
+                              % self.conf_path)
+        super(LibvirtConfigCommon, self).__init__(self.conf_path)
+
+    def __getattr__(self, key):
+        if key in self.__option_types__:
+            key_type = self.__option_types__[key]
+            if key_type not in ['boolean', 'int', 'float', 'string', 'list']:
+                raise LibvirtConfigUnknownKeyTypeError(key, key_type)
+            else:
+                get_func = eval('self.get_' + key_type)
+                try:
+                    return get_func(key)
+                except ConfigNoOptionError:
+                    return None
+        else:
+            raise LibvirtConfigUnknownKeyError(key)
+
+    def __setattr__(self, key, value):
+        if key in self.__option_types__:
+            key_type = self.__option_types__[key]
+            if key_type not in ['boolean', 'int', 'float', 'string', 'list']:
+                raise LibvirtConfigUnknownKeyTypeError(key, key_type)
+            else:
+                set_func = eval('self.set_' + key_type)
+                try:
+                    set_func(key, value)
+                except ValueError:
+                    logging.warning("Key %s might not have type %s. Set raw "
+                                    "string instead.", key, key_type)
+                    self.set_raw(key, value)
+        super(LibvirtConfigCommon, self).__setattr__(key, value)
+
+    def __delattr__(self, key):
+        if key in self.__option_types__:
+            key_type = self.__option_types__[key]
+            if key_type not in ['boolean', 'int', 'float', 'string', 'list']:
+                raise LibvirtConfigUnknownKeyTypeError(key, key_type)
+            else:
+                try:
+                    del self[key]
+                except ConfigNoOptionError:
+                    pass
+                super(LibvirtConfigCommon, self).__setattr__(key, None)
+        else:
+            raise LibvirtConfigUnknownKeyError(key)
+
+    def sync(self):
+        if not self.libvirtd.restart():
+            raise LibvirtConfigSyncError()
+
+    def restore(self):
+        super(LibvirtConfigCommon, self).restore()
+        self.sync()
+
+
+class LibvirtdConfig(LibvirtConfigCommon):
+
+    """
+    Class for libvirt daemon config file.
+    """
+    conf_path = '/etc/libvirt/libvirtd.conf'
+    __option_types__ = {
+        'listen_tls': 'boolean',
+        'listen_tcp': 'boolean',
+        'tls_port': 'string',
+        'tcp_port': 'string',
+        'listen_addr': 'string',
+        'mdns_adv': 'boolean',
+        'mdns_name': 'string',
+        'unix_sock_group': 'string',
+        'unix_sock_ro_perms': 'string',
+        'unix_sock_rw_perms': 'string',
+        'unix_sock_dir': 'string',
+        'auth_unix_ro': 'string',
+        'auth_unix_rw': 'string',
+        'auth_tcp': 'string',
+        'auth_tls': 'string',
+        'access_drivers': 'list',
+        'key_file': 'string',
+        'cert_file': 'string',
+        'ca_file': 'string',
+        'crl_file': 'string',
+        'tls_no_sanity_certificate': 'boolean',
+        'tls_no_verify_certificate': 'boolean',
+        'tls_allowed_dn_list': 'list',
+        'sasl_allowed_username_list': 'list',
+        'max_clients': 'int',
+        'max_queued_clients': 'int',
+        'min_workers': 'int',
+        'max_workers': 'int',
+        'prio_workers': 'int',
+        'max_requests': 'int',
+        'max_client_requests': 'int',
+        'log_level': 'int',
+        'log_filters': 'string',
+        'log_outputs': 'string',
+        'log_buffer_size': 'int',
+        'audit_level': 'int',
+        'audit_logging': 'int',
+        'host_uuid': 'string',
+        'keepalive_interval': 'int',
+        'keepalive_count': 'int',
+        'keepalive_required': 'boolean',
+    }
+
+
+class LibvirtQemuConfig(LibvirtConfigCommon):
+
+    """
+    Class for libvirt qemu config file.
+    """
+    conf_path = '/etc/libvirt/qemu.conf'
+    __option_types__ = {
+        'vnc_listen': 'string',
+        'vnc_auto_unix_socket': 'boolean',
+        'vnc_tls': 'boolean',
+        'vnc_tls_x509_cert_dir': 'string',
+        'vnc_tls_x509_verify': 'boolean',
+        'vnc_password': 'string',
+        'vnc_sasl': 'boolean',
+        'vnc_sasl_dir': 'string',
+        'vnc_allow_host_audio': 'boolean',
+        'spice_listen': 'string',
+        'spice_tls': 'boolean',
+        'spice_tls_x509_cert_dir': 'string',
+        'spice_password': 'string',
+        'remote_display_port_min': 'int',
+        'remote_display_port_max': 'int',
+        'remote_websocket_port_min': 'int',
+        'remote_websocket_port_max': 'int',
+        'security_driver': 'list',
+        'security_default_confined': 'boolean',
+        'security_require_confined': 'boolean',
+        'user': 'string',
+        'group': 'string',
+        'dynamic_ownership': 'boolean',
+        'cgroup_controllers': 'list',
+        'cgroup_device_acl': 'list',
+        'save_image_format': 'string',
+        'dump_image_format': 'string',
+        'snapshot_image_format': 'string',
+        'auto_dump_path': 'string',
+        'auto_dump_bypass_cache': 'boolean',
+        'auto_start_bypass_cache': 'boolean',
+        'hugetlbfs_mount': 'string',
+        'bridge_helper': 'string',
+        'clear_emulator_capabilities': 'boolean',
+        'set_process_name': 'boolean',
+        'max_processes': 'int',
+        'max_files': 'int',
+        'mac_filter': 'boolean',
+        'relaxed_acs_check': 'boolean',
+        'allow_disk_format_probing': 'boolean',
+        'lock_manager': 'string',
+        'max_queued': 'int',
+        'keepalive_interval': 'int',
+        'keepalive_count': 'int',
+        'seccomp_sandbox': 'int',
+        'migration_address': 'string',
+        'migration_port_min': 'int',
+        'migration_port_max': 'int',
+    }
+
+
+class LibvirtdSysConfig(LibvirtConfigCommon):
+
+    """
+    Class for sysconfig libvirtd config file.
+    """
+    conf_path = '/etc/sysconfig/libvirtd'
+    __option_types__ = {
+        'LIBVIRTD_CONFIG': 'string',
+        'LIBVIRTD_ARGS': 'string',
+        'KRB5_KTNAME': 'string',
+        'QEMU_AUDIO_DRV': 'string',
+        'SDL_AUDIODRIVER': 'string',
+        'LIBVIRTD_NOFILES_LIMIT': 'int',
+    }

--- a/virttest/utils_config_unittest.py
+++ b/virttest/utils_config_unittest.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python
+
+import os
+import unittest
+import common
+import tempfile
+import utils_libvirtd
+from staging import service
+from nfs_unittest import FakeService
+from autotest.client.shared.test_utils import mock
+import utils_config
+
+# Test conf file content
+content = """# This is a comment line.
+a = 1
+b = [hi, there]
+c = hello
+d = "hi, there"
+e = [hi,
+    there]
+
+"""
+
+# Expected changed conf file content
+changed_content = """a = 1
+b = [hi, there]
+c = hello
+d = "hi, there"
+f = test
+
+"""
+
+
+class SectionlessConfigTest(unittest.TestCase):
+
+    def test_accessers(self):
+        config_file = tempfile.NamedTemporaryFile()
+        config_path = config_file.name
+        config_file.close()
+
+        try:
+            config_file = open(config_path, 'w')
+            config_file.write(content)
+            config_file.close()
+
+            # Test 'try...finally...' usage.
+            config = utils_config.SectionlessConfig(config_path)
+            try:
+                # Test loader.
+                self.assertEqual(len(config), 5)
+                self.assertEqual(config['a'], '1')
+                self.assertEqual(config['b'], '[hi, there]')
+                self.assertEqual(config['c'], 'hello')
+                self.assertEqual(config['d'], '"hi, there"')
+                self.assertEqual(config['e'], '[hi,\nthere]')
+
+                # Test getter.
+                try:
+                    config['f']
+                except Exception, e:
+                    self.assertEqual(utils_config.ConfigNoOptionError, e.__class__)
+                    self.assertTrue('no option' in str(e))
+
+                # Test setter.
+                config['f'] = 'test'
+                self.assertEqual(config['f'], 'test')
+
+                # Test deleter.
+                # delete exist option.
+                del config['f']
+                # delete non-exist option.
+                try:
+                    del config['f']
+                except Exception, e:
+                    self.assertEqual(utils_config.ConfigNoOptionError, e.__class__)
+                    self.assertTrue('no option' in str(e))
+
+                # Test contain.
+                self.assertTrue('a' in config)
+                self.assertFalse('f' in config)
+
+            finally:
+                config.restore()
+
+            # Test 'with' usage.
+            with utils_config.SectionlessConfig(config_path) as config:
+                # Test loader.
+                self.assertEqual(len(config), 5)
+                self.assertEqual(config['a'], '1')
+                self.assertEqual(config['b'], '[hi, there]')
+                self.assertEqual(config['c'], 'hello')
+                self.assertEqual(config['d'], '"hi, there"')
+                self.assertEqual(config['e'], '[hi,\nthere]')
+
+                # Test getter.
+                try:
+                    config['f']
+                except Exception, e:
+                    self.assertEqual(utils_config.ConfigNoOptionError, e.__class__)
+                    self.assertTrue('no option' in str(e))
+
+                # Test setter.
+                config['f'] = 'test'
+                self.assertEqual(config['f'], 'test')
+
+                # Test deleter.
+                del config['f']
+                try:
+                    config['f']
+                except Exception, e:
+                    self.assertEqual(utils_config.ConfigNoOptionError, e.__class__)
+                    self.assertTrue('no option' in str(e))
+
+                # Test contain.
+                self.assertTrue('a' in config)
+                self.assertFalse('f' in config)
+        finally:
+            os.remove(config_path)
+
+    def test_specific_accessers(self):
+        config_file = tempfile.NamedTemporaryFile()
+        config_path = config_file.name
+        config_file.close()
+
+        try:
+            config_file = open(config_path, 'w')
+            config_file.write(content)
+            config_file.close()
+
+            config = utils_config.SectionlessConfig(config_path)
+            try:
+                config.set_string('a', 'Hi')
+                self.assertEqual(config['a'], '"Hi"')
+                self.assertEqual(config.get_string('a'), 'Hi')
+                config['a'] = "'Hi'"
+                self.assertEqual(config.get_string('a'), 'Hi')
+                config['a'] = 'Hi'
+                self.assertRaises(ValueError, config.get_string, 'a')
+                config['a'] = '"Hi'
+                self.assertRaises(ValueError, config.get_string, 'a')
+
+                config.set_int('a', 15)
+                self.assertEqual(config['a'], '15')
+                self.assertEqual(config.get_int('a'), 15)
+                config.set_int('a', -15)
+                self.assertEqual(config.get_int('a'), -15)
+                config.set_string('a', 'invalid')
+                self.assertRaises(ValueError, config.get_float, 'a')
+
+                config.set_float('a', 15.123)
+                self.assertEqual(config['a'], '15.123')
+                self.assertEqual(config.get_float('a'), 15.123)
+                config.set_string('a', 'invalid')
+                self.assertRaises(ValueError, config.get_float, 'a')
+
+                config.set_boolean('a', True)
+                self.assertEqual(config['a'], '1')
+                self.assertTrue(config.get_boolean('a'))
+                config.set_string('a', 'Yes')
+                self.assertTrue(config.get_boolean('a'))
+                config.set_string('a', 'ON')
+                self.assertTrue(config.get_boolean('a'))
+                config.set_boolean('a', False)
+                self.assertEqual(config['a'], '0')
+                self.assertFalse(config.get_boolean('a'))
+                config.set_string('a', 'fAlSe')
+                self.assertFalse(config.get_boolean('a'))
+                config.set_string('a', 'off')
+                self.assertFalse(config.get_boolean('a'))
+                config.set_string('a', 'invalid')
+                self.assertRaises(ValueError, config.get_boolean, 'a')
+
+                config.set_list('a', [15, 'Hello'])
+                self.assertEqual(config['a'], '["15", "Hello"]')
+                config.set_list('a', [15, 'Hello'])
+                self.assertEqual(config.get_list('a'), ["15", "Hello"])
+                config['a'] = '[15, \n     "Hello"]'
+                self.assertEqual(config.get_list('a'), ["15", "Hello"])
+                config['a'] = '[15, "Hi, there"]'
+                self.assertEqual(config.get_list('a'), ["15", "Hi, there"])
+            finally:
+                config.restore()
+        finally:
+            os.remove(config_path)
+
+    def test_restore(self):
+        config_file = tempfile.NamedTemporaryFile()
+        config_path = config_file.name
+        config_file.close()
+
+        # Restore after use.
+        try:
+            config_file = open(config_path, 'w')
+            config_file.write(content)
+            config_file.close()
+
+            config = utils_config.SectionlessConfig(config_path)
+            try:
+                # Change the config.
+                config['f'] = 'test'
+                self.assertEqual(config['f'], 'test')
+                del config['e']
+            finally:
+                config.restore()
+        finally:
+            final_file = open(config_path)
+            try:
+                self.assertEqual(final_file.read(),
+                                 content)
+            finally:
+                final_file.close()
+            os.remove(config_path)
+
+        # Don't restore after use.
+        try:
+            config_file = open(config_path, 'w')
+            config_file.write(content)
+            config_file.close()
+
+            config = utils_config.SectionlessConfig(config_path)
+
+            # Change the config.
+            config['f'] = 'test'
+            self.assertEqual(config['f'], 'test')
+            del config['e']
+        finally:
+            final_file = open(config_path)
+            try:
+                self.assertEqual(final_file.read(),
+                                 changed_content)
+            finally:
+                final_file.close()
+            os.remove(config_path)
+
+    def test_sync_file(self):
+        config_file = tempfile.NamedTemporaryFile()
+        config_path = config_file.name
+        config_file.close()
+
+        try:
+            config_file = open(config_path, 'w')
+            config_file.write(content)
+            config_file.close()
+
+            config = utils_config.SectionlessConfig(config_path)
+            try:
+                # Change the config.
+                config['f'] = 'test'
+                self.assertEqual(config['f'], 'test')
+                del config['e']
+
+                # Test the change is applied to target file.
+                cur_file = open(config_path)
+                try:
+                    self.assertEqual(cur_file.read(),
+                                     changed_content)
+                finally:
+                    cur_file.close()
+            finally:
+                config.restore()
+        finally:
+            os.remove(config_path)
+
+
+class LibvirtConfigCommonTest(unittest.TestCase):
+
+    class UnimplementedConfig(utils_config.LibvirtConfigCommon):
+        pass
+
+    class NoTypesConfig(utils_config.LibvirtConfigCommon):
+        conf_path = '/tmp/config_unittest.conf'
+
+    class UndefinedTypeConfig(utils_config.LibvirtConfigCommon):
+        __option_types__ = {
+            'test': 'invalid_type',
+            'test2': 'boolean',
+        }
+        conf_path = '/tmp/config_unittest.conf'
+
+    def test_unimplemented(self):
+        try:
+            self.UnimplementedConfig()
+        except Exception, e:
+            self.assertEqual(utils_config.ConfigError, e.__class__)
+            self.assertTrue("not set up" in str(e))
+
+    def test_no_path(self):
+        try:
+            self.NoTypesConfig()
+        except Exception, e:
+            self.assertEqual(utils_config.ConfigError, e.__class__)
+            self.assertTrue("not set up" in str(e))
+
+    def test_undefined_type(self):
+        try:
+            self.god = mock.mock_god()
+            self.god.stub_function(service.Factory, "create_service")
+            service.Factory.create_service.expect_any_call().and_return(
+                FakeService("libvirtd"))
+            config = self.UndefinedTypeConfig()
+        except Exception, e:
+            self.assertEqual(utils_config.ConfigError, e.__class__)
+            self.assertTrue("don't exists" in str(e))
+
+        try:
+            config_file = open('/tmp/config_unittest.conf', 'w')
+            config_file.write('')
+            config_file.close()
+
+            self.god = mock.mock_god()
+            self.god.stub_function(service.Factory, "create_service")
+            service.Factory.create_service.expect_any_call().and_return(
+                FakeService("libvirtd"))
+            config = self.UndefinedTypeConfig()
+
+            # Test setter getter
+            # Normal option
+            config.test2 = True
+            self.assertEqual(config.test2, True)
+            # Repeat set option
+            config.test2 = False
+            self.assertEqual(config.test2, False)
+            # Set unknown type
+            try:
+                config.test = '1'
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigUnknownKeyTypeError, e.__class__)
+                self.assertTrue('Unknown type' in str(e))
+            # Get unknown type
+            try:
+                print config.test
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigUnknownKeyTypeError, e.__class__)
+                self.assertTrue('Unknown type' in str(e))
+            # Set Get not defined type
+            config.test3 = "abc"
+            self.assertEqual(config.test3, "abc")
+            config.test3 = True
+            self.assertTrue(config.test3)
+
+            # Test deleter
+            # Normal option
+            del config.test2
+            # Non set option
+            del config.test2
+            # Unknown type option
+            try:
+                del config.test
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigUnknownKeyTypeError, e.__class__)
+                self.assertTrue('Unknown type' in str(e))
+            # Not defined option
+            try:
+                del config.test3
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigUnknownKeyError, e.__class__)
+                self.assertTrue('Unknown config key' in str(e))
+
+            try:
+                config.restore()
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigSyncError, e.__class__)
+                self.assertTrue('Failed' in str(e))
+        finally:
+            os.remove('/tmp/config_unittest.conf')
+
+
+class LibvirtConfigTest(unittest.TestCase):
+
+    def test_accessers(self):
+        config_file = tempfile.NamedTemporaryFile()
+        config_path = config_file.name
+        config_file.close()
+        try:
+            config_file = open(config_path, 'w')
+            config_file.write('')
+            config_file.close()
+            self.god = mock.mock_god()
+            self.god.stub_function(service.Factory, "create_service")
+            service.Factory.create_service.expect_any_call().and_return(
+                FakeService("libvirtd"))
+            config = utils_config.LibvirtdConfig(path=config_path)
+
+            # Test internal property.
+            self.assertEqual(config.conf_path, config_path)
+
+            # Test undefined property.
+            try:
+                config.undefined_property
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigUnknownKeyError, e.__class__)
+                self.assertTrue('Unknown config key' in str(e))
+
+            # Test defined boolean property.
+            self.assertEqual(config.listen_tls, None)
+            config.listen_tls = 1
+            self.assertEqual(config.get_raw('listen_tls'), '1')
+            self.assertEqual(config.listen_tls, 1)
+            config.listen_tls = False
+            self.assertEqual(config.get_raw('listen_tls'), '0')
+            self.assertEqual(config.listen_tls, 0)
+            config.listen_tls = "1"
+            self.assertEqual(config.get_raw('listen_tls'), '1')
+            config.listen_tls = "undefined"
+            self.assertEqual(config.get_raw('listen_tls'), 'undefined')
+            del config.listen_tls
+            self.assertEqual(config.listen_tls, None)
+
+            # Test defined string property.
+            self.assertEqual(config.host_uuid, None)
+            config.host_uuid = 1
+            self.assertEqual(config.get_raw('host_uuid'), '"1"')
+            config.host_uuid = 'a'
+            self.assertEqual(config.get_raw('host_uuid'), '"a"')
+
+            # Test defined integer property.
+            self.assertEqual(config.max_clients, None)
+            config.max_clients = 1
+            self.assertEqual(config.get_raw('max_clients'), '1')
+
+            # Test defined list property.
+            self.assertEqual(config.access_drivers, None)
+            config.access_drivers = [1, "a"]
+            self.assertEqual(
+                config.get_raw('access_drivers'), '["1", "a"]')
+
+            try:
+                config.sync()
+            except Exception, e:
+                self.assertEqual(utils_config.LibvirtConfigSyncError, e.__class__)
+                self.assertTrue('Failed' in str(e))
+
+        finally:
+            os.remove(config_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A set of classes to manipulate options of a libvirt related configure
files such as `/etc/libvirt/libvirtd.conf` in a property's way.

Variables `"__option_types__"` and `"conf_path"` must be setup in the
inherented classes before use.

`"__option_types__"` is a dict contains every possible option as keys and
their type ("boolean", "int", "string", "float" or "list") as values.

Basic usage:
1) Create a config file object:

```
>>> config = LibvirtdConfig()
```

2) Set or update an option:

```
>>> config.listen_tcp = True
>>> config.listen_tcp = 1
>>> config.listen_tcp = "1" # All three have the same effect.

>>> # If the setting value don't meet the specified type.
>>> config.listen_tcp = "invalid"
>>> # It'll thown an warning message in log and set a raw string instead.

>>> # Use set_* methods when need to customize the result.
>>> config.set_raw("'1'")
```

3) Get an option:

```
>>> is_listening = config.listen_tcp
>>> print is_listening
True
```

4) Delete an option from the config file:

```
>>> del config.listen_tcp
```

5) Make the changes take effect in libvirt by restart libvirt daemon.

```
>>> config.sync()
```

6) Restore the content of the config file.

```
>>> config.restore()
```

Signed-off-by: Hao Liu hliu@redhat.com
