### PR TITLE
Virsh.vcpupin: Let 'vcpu' and 'cpu_list' optional

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -732,7 +732,7 @@ def setvcpus(name, count, extra="", **dargs):
     return command(cmd, **dargs)
 
 
-def vcpupin(name, vcpu, cpu_list, options="", **dargs):
+def vcpupin(name, vcpu="", cpu_list="", options="", **dargs):
     """
     Changes the cpu affinity for respective vcpu.
 


### PR DESCRIPTION
Omit 'vcpu_list' to query given vcpu affinity, and omit both 'vcpu'
and 'cpu_list' to query all domain vcpu affinity.

Signed-off-by: Yanbing Du ydu@redhat.com
