### PR TITLE
standalone_test: Enable only filter when listing tests

### DIFF
--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -554,6 +554,9 @@ def print_test_list(options, cartesian_parser):
     index = 0
 
     pipe.write(get_cartesian_parser_details(cartesian_parser))
+    if options.tests:
+        tests = options.tests.split(" ")
+        cartesian_parser.only_filter(", ".join(tests))
     for params in cartesian_parser.get_dicts():
         virt_test_type = params.get('virt_test_type', "")
         supported_virt_backends = virt_test_type.split(" ")


### PR DESCRIPTION
Currently when running with option `--list-tests`, we can use `--no`
to remove some tests, but we can't apply an `only` filter.

With this modification, we can apply an `only` filter, for example by running

```
./run -t libvirt --list-tests --tests virsh.domuuid --no error_test
```

, to list the tests you needed exactly.

Signed-off-by: Hao Liu hliu@redhat.com
