### PR TITLE
Add RHEL.7 guest installation config

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.0.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0.cfg
@@ -1,0 +1,35 @@
+- 7.0:
+    no setup
+    image_name = images/rhel70
+    os_variant = rhel7
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        unattended_file = unattended/RHEL-7-series.ks
+        syslog_server_proto = udp
+    nic_hotplug:
+        modprobe_module =
+    block_hotplug:
+        modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/7.0/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/x86_64.cfg
@@ -1,0 +1,15 @@
+- x86_64:
+    grub_file = /boot/grub/grub.conf
+    vm_arch_name = x86_64
+    image_name += -64
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/rhel70-64/ks.iso
+        kernel = images/rhel70-64/vmlinuz
+        initrd = images/rhel70-64/initrd.img
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_cd1 = isos/linux/RHEL7.0-Server-x86_64.iso
+        md5sum_cd1 = 08961a5cb32d2cdf72026bec43876b7f
+        md5sum_1m_cd1 = e1ffd40aa14c8048e423160e5d4cf49b
+    unattended_install..floppy_ks:
+        floppies = "fl"
+        floppy_name = images/rhel70-64/ks.vfd

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -1,0 +1,76 @@
+install
+KVM_TEST_MEDIUM
+graphical
+poweroff
+lang en_US.UTF-8
+keyboard us
+network --onboot yes --device eth0 --bootproto dhcp
+rootpw redhat
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+clearpart --all --initlabel
+autopart
+xconfig --startxonboot
+
+%packages --ignoremissing
+@base
+@core
+@development
+@additional-devel
+@debugging-tools
+@network-tools
+@fonts
+@x11
+@gnome-desktop
+lftp
+gcc
+gcc-c++
+patch
+make
+git
+nc
+NetworkManager
+ntpdate
+redhat-lsb
+numactl-libs
+numactl
+sg3_utils
+hdparm
+lsscsi
+libaio-devel
+perl-Time-HiRes
+flex
+prelink
+%end
+
+%post
+echo "OS install is completed" > /dev/ttyS0
+echo "remove rhgb quiet by grubby" > /dev/ttyS0
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+echo "dhclient" > /dev/ttyS0
+dhclient
+echo "get repo" > /dev/ttyS0
+wget http://fileshare.englab.nay.redhat.com/pub/section2/repo/epel/rhel-autotest.repo -O /etc/yum.repos.d/rhel-autotest.repo
+echo "yum makecache" > /dev/ttyS0
+yum makecache
+echo "yum install -y stress" > /dev/ttyS0
+yum install -y stress
+echo "chkconfig sshd on" > /dev/ttyS0
+chkconfig sshd on
+echo "iptables -F" > /dev/ttyS0
+iptables -F
+echo "echo 0 > selinux/enforce" > /dev/ttyS0
+echo 0 > /selinux/enforce
+echo "chkconfig NetworkManager on" > /dev/ttyS0
+chkconfig NetworkManager on
+echo "update ifcfg-eth0" > /dev/ttyS0
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+echo "Disable lock cdrom udev rules" > /dev/ttyS0
+sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
+echo 'Post set up finished' > /dev/ttyS0
+echo Post set up finished > /dev/hvc0
+%end

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1044,7 +1044,7 @@ def run(test, params, env):
 
     post_finish_str = params.get("post_finish_str",
                                  "Post set up finished")
-    install_timeout = int(params.get("install_timeout", 3000))
+    install_timeout = int(params.get("install_timeout", 4800))
 
     migrate_background = params.get("migrate_background") == "yes"
     if migrate_background:


### PR DESCRIPTION
1. Add RHEL.7 guest installation config,
   include RHEL.7.0.cfg and RHEL.7.ks.
2. Enlarge the installation timeout from 3000 to 4800,
   as RHEL.7 graphical installtion and boot needs more packages.

Signed-off-by: Cong Li coli@redhat.com
