### PR TITLE
libvirt_xml.vm_xml: Separate os tag to VMOSXML and unified class names

### DIFF
--- a/virttest/libvirt_xml_unittest.py
+++ b/virttest/libvirt_xml_unittest.py
@@ -808,7 +808,7 @@ class testSerialXML(LibvirtXMLTestBase):
         self.assertEqual(source_connect['service'], '5442')
 
 
-class testVMCPUTune(LibvirtXMLTestBase):
+class testVMCPUTuneXML(LibvirtXMLTestBase):
 
     def test_get_set_del(self):
         vmxml = vm_xml.VMXML.new_from_dumpxml('foobar',


### PR DESCRIPTION
1) Use a dedicated class to access the os tag in VM's XML.
2) Unify class names in vm_xml.

Signed-off-by: Hao Liu hliu@redhat.com
