### PR TITLE
libvirt_storage: Return False only when pool still exist after delete_pool()

### DIFF
--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -246,8 +246,9 @@ class StoragePool(object):
         try:
             self.virsh_instance.pool_undefine(name, ignore_status=False)
         except error.CmdError, detail:
-            logging.error("Undefine pool '%s' failed:%s", name, detail)
-            return False
+            if self.pool_exists(name):
+                logging.error("Undefine pool '%s' failed:%s", name, detail)
+                return False
         logging.info("Deleted pool '%s'", name)
         return True
 


### PR DESCRIPTION
Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
