### PR TITLE
Windows.cfg: Add background command return code to ignore on cleanup

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -56,6 +56,10 @@
         migration_bg_command = start ping -t localhost
         migration_bg_check_command = tasklist | find /I "ping.exe"
         migration_bg_kill_command = taskkill /IM ping.exe /F
+        # After searching MS documentation and failing, I found in:
+        # http://www.symantec.com/connect/forums/error-128-during-script-execution
+        # an indication that the error for no process found (taskkill) is 128.
+        migration_bg_kill_ignore_status = 128
     migrate.with_file_transfer:
         guest_path = C:\tmpfile
     stress_boot:


### PR DESCRIPTION
This is part of tp-qemu#149. The return code for process
not found for Windows is 128 instead of 1 (Linux). So
let's set this parameter in the Windows snippet config
file.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
