### PR TITLE
Add methods to get host/VM cpu topolopy

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1758,6 +1758,32 @@ class VM(virt_vm.BaseVM):
         # statm stores informations in pages, translate it to MB
         return shm * 4.0 / 1024
 
+    def get_cpu_topolopy_in_cmdline(self):
+        """
+        Return the VM's cpu topolopy in VM cmdline.
+
+        :return: A dirt of cpu topolopy
+        """
+        cpu_topolopy = {}
+        vm_pid = self.get_pid()
+        if vm_pid is None:
+            logging.error("Fail to get VM pid")
+        else:
+            cmdline = open("/proc/%d/cmdline" % vm_pid).read()
+            values = re.findall("sockets=(\d+),cores=(\d+),threads=(\d+)",
+                                cmdline)[0]
+            cpu_topolopy = dict(zip(["sockets", "cores", "threads"], values))
+        return cpu_topolopy
+
+    def get_cpu_topolopy_in_vm(self):
+        cpu_topolopy = {}
+        cpu_info = utils_misc.get_cpu_info(self.wait_for_login())
+        if cpu_info:
+            cpu_topolopy['sockets'] = cpu_info['Socket(s)']
+            cpu_topolopy['cores'] = cpu_info['Core(s) per socket']
+            cpu_topolopy['threads'] = cpu_info['Thread(s) per core']
+        return cpu_topolopy
+
     def activate_nic(self, nic_index_or_name):
         # TODO: Implement nic hotplugging
         pass  # Just a stub for now

--- a/virttest/libvirt_xml/capability_xml.py
+++ b/virttest/libvirt_xml/capability_xml.py
@@ -25,7 +25,8 @@ class CapabilityXML(base.LibvirtXMLBase):
     # e.g. guest_count etc.
 
     __slots__ = ('uuid', 'os_arch_machine_map', 'cpu_count', 'arch', 'model',
-                 'vendor', 'feature_list', 'power_management_list')
+                 'vendor', 'feature_list', 'power_management_list',
+                 'cpu_topolopy')
     __schema_name__ = "capability"
 
     def __init__(self, virsh_instance=base.virsh):
@@ -56,6 +57,11 @@ class CapabilityXML(base.LibvirtXMLBase):
                                  forbidden=['del'],
                                  parent_xpath='/host/cpu',
                                  tag_name='vendor')
+        accessors.XMLElementDict(property_name="cpu_topolopy",
+                                 libvirtxml=self,
+                                 forbidden=['del'],
+                                 parent_xpath='/host/cpu',
+                                 tag_name='topology')
         # This will skip self.get_feature_list() defined below
         accessors.AllForbidden(property_name="feature_list",
                                libvirtxml=self)

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1216,6 +1216,26 @@ def cpu_str_to_list(origin_str):
         return cpu_list
 
 
+def get_cpu_info(session=None):
+    """
+    Return information about the CPU architecture
+
+    :param session: session Object
+    :return: A dirt of cpu information
+    """
+    cpu_info = {}
+    cmd = "lscpu"
+    if session is None:
+        output = utils.system_output(cmd, ignore_status=True)
+    else:
+        try:
+            output = session.cmd_output(cmd).strip().splitlines()
+        finally:
+            session.close()
+    cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":")], output))
+    return cpu_info
+
+
 class NumaInfo(object):
 
     """


### PR DESCRIPTION
1. Add accessors for cpu_topolopy in capability xml.
2. Add three func for libvirt VM to get domian cpu topolopy from
   different ways.

Signed-off-by: Yanbing Du ydu@redhat.com
