### PR TITLE
virt-test: Replace the line break of info numa with "\n"

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -374,6 +374,7 @@ class Monitor:
                  MB and cpus is a set of CPU numbers
         """
         r = self.human_monitor_cmd("info numa")
+        r = "\n".join(r.splitlines())
         return self.parse_info_numa(r)
 
     def info(self, what, debug=True):


### PR DESCRIPTION
In different version of qemu, the output of info numa is different.
So we need replace the line break with "\n" so the pattern can
actually work.
