### PR TITLE
virt.qemu_storage: Always check the image by qemu-img info, if glusterfs...

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -347,7 +347,9 @@ class QemuImg(storage.QemuImg):
         """
         logging.debug("Run qemu-img info comamnd on %s", self.image_filename)
         cmd = self.image_cmd
-        if os.path.exists(self.image_filename):
+        if (os.path.exists(self.image_filename) or
+                "gluster:" in self.image_filename or
+                "iscsi:" in self.image_filename):
             cmd += " info %s" % self.image_filename
             output = utils.system_output(cmd)
         else:


### PR DESCRIPTION
... used.

As os.path.exists() do not support gluster://IP:0/volume/image.qcow2

ID: 1134649
Signed-off-by: Feng Yang fyang@redhat.com
