### PR TITLE
virttest: add help flags for QemuImg help_text

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -32,7 +32,10 @@ class QemuImg(storage.QemuImg):
         """
         storage.QemuImg.__init__(self, params, root_dir, tag)
         self.image_cmd = utils_misc.get_qemu_img_binary(params)
-        q_result = utils.run(self.image_cmd, ignore_status=True,
+
+        qemu_img_cmd = self.image_cmd
+        qemu_img_cmd += " --help"
+        q_result = utils.run(qemu_img_cmd, ignore_status=True,
                              verbose=False)
         self.help_text = q_result.stdout
 


### PR DESCRIPTION
When calling qemu-img with no arguments in qemu 2.1 the following is printed:
qemu-img: Not enough arguments

This adds the --help flag to ensure that 'qemu-img check' works.

Signed-off-by: Chris J Arges chris.j.arges@canonical.com
