### PR TITLE
virttest.gluster: Typo fix.

### DIFF
--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -38,7 +38,7 @@ def glusterd_start():
     """
     cmd = "service glusterd status"
     output = utils.system_output(cmd, ignore_status=True)
-    if 'inactive' or 'stopped' in output:
+    if 'inactive' in output or 'stopped' in output:
         cmd = "service glusterd start"
         error.context("Starting gluster dameon failed")
         output = utils.system_output(cmd)


### PR DESCRIPTION
if 'inactive' or 'stopped' in output:

if 'inactive' will always true.

Signed-off-by: Feng Yang fyang@redhat.com
