### PR TITLE
virttest.utils_test: Could not use error as parameter name.

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -109,12 +109,12 @@ def update_boot_option(vm, args_removed=None, args_added=None,
     cmdline = session.cmd("cat /proc/cmdline", timeout=60)
     if args_removed and args_removed in cmdline:
         logging.error(output)
-        error = "Fail to remove guest kernel option %s" % args_removed
-        raise error.TestError(error)
+        err = "Fail to remove guest kernel option %s" % args_removed
+        raise error.TestError(err)
     if args_added and args_added not in cmdline:
         logging.error(output)
-        error = "Fail to add guest kernel option %s" % args_added
-        raise error.TestError(error)
+        err = "Fail to add guest kernel option %s" % args_added
+        raise error.TestError(err)
 
 
 def stop_windows_service(session, service, timeout=120):


### PR DESCRIPTION
We have already use error as module name. So could not use it as
parameter name. Or we will get following error:
  Traceback (most recent call last):
    File "/usr/code/autotest/client/shared/test.py", line 823, in _call_test_function
      return func(_args, *_dargs)
    File "/usr/code/autotest/client/shared/test.py", line 291, in execute
      postprocess_profiled_run, args, dargs)
    File "/usr/code/autotest/client/shared/test.py", line 209, in _call_run_once
      _args, *_dargs)
    File "/usr/code/autotest/client/shared/test.py", line 313, in run_once_profiling
      self.run_once(_args, *_dargs)
    File "/usr/code/autotest/client/tests/virt/virt.py", line 154, in run_once
      run_func(self, params, env)
    File "/usr/code/autotest/client/shared/error.py", line 141, in new_fn
      return fn(_args, *_kwargs)
    File "/usr/code/autotest/client/tests/virt/test-providers.d/downloads/io-github-autotest-qemu/qemu/tests/mq_change_qnum.py", line 93, in run
      utils_test.update_boot_option(vm, args_added="pci=nomsi")
    File "/usr/code/autotest/client/shared/error.py", line 141, in new_fn
      return fn(_args, *_kwargs)
    File "/usr/code/autotest/client/tests/virt/virttest/utils_test/__init__.py", line 100, in update_boot_option
      error.context(msg, logging.info)
  UnboundLocalError: local variable 'error' referenced before assignment

Signed-off-by: Feng Yang fyang@redhat.com
