### PR TITLE
virttest.iscsi: Only search luns under created target id

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -368,7 +368,13 @@ class Iscsi(object):
             logging.debug("Exported image already exists.")
             self.export_flag = True
         else:
-            luns = len(re.findall("\s+LUN:\s(\d+)", output, re.M))
+            tgt_str = re.search(r'.*(Target\s+\d+:\s+%s\s*.*)$' % self.target,
+                                output, re.DOTALL)
+            if tgt_str:
+                luns = len(re.findall("\s+LUN:\s(\d+)",
+                                      tgt_str.group(1), re.M))
+            else:
+                luns = len(re.findall("\s+LUN:\s(\d+)", output, re.M))
             cmd = "tgtadm --mode logicalunit --op new "
             cmd += "--tid %s --lld iscsi " % self.emulated_id
             cmd += "--lun %s " % luns


### PR DESCRIPTION
While decide lun id under new created target, other luns under
other targets need not be counted in, so only find the luns
under new created target string.

This update will help maintain the lun id as 1 under new created
target, which will avoid mismatch lun id when multiple luns
alreay exist on server.

Signed-off-by: Wayne Sun gsun@redhat.com
