### PR TITLE
x-rdma migration is not supported by Qemu anymore

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -82,7 +82,7 @@ class VM(virt_vm.BaseVM):
     This class handles all basic VM operations.
     """
 
-    MIGRATION_PROTOS = ['rdma', 'x-rdma', 'tcp', 'unix', 'exec', 'fd']
+    MIGRATION_PROTOS = ['rdma', 'tcp', 'unix', 'exec', 'fd']
 
     # By default we inherit all timeouts from the base VM class except...
     CLOSE_SESSION_TIMEOUT = 30
@@ -1967,7 +1967,7 @@ class VM(virt_vm.BaseVM):
         :param params: A dict containing VM params
         :param root_dir: Base directory for relative filenames
         :param migration_mode: If supplied, start VM for incoming migration
-                using this protocol (either 'rdma', 'x-rdma', 'rdma', 'tcp', 'unix' or 'exec')
+                using this protocol (either 'rdma', 'tcp', 'unix' or 'exec')
         :param migration_exec_cmd: Command to embed in '-incoming "exec: ..."'
                 (e.g. 'gzip -c -d filename') if migration_mode is 'exec'
                 default to listening on a random TCP port
@@ -2203,7 +2203,7 @@ class VM(virt_vm.BaseVM):
                                            'Check the log for traceback.')
 
             # Add migration parameters if required
-            if migration_mode in ["tcp", "rdma", "x-rdma"]:
+            if migration_mode in ["tcp", "rdma"]:
                 self.migration_port = utils_misc.find_free_port(5200, 6000)
                 qemu_command += (" -incoming " + migration_mode +
                                  ":0:%d" % self.migration_port)
@@ -3285,7 +3285,7 @@ class VM(virt_vm.BaseVM):
                 if cmdline:
                     self.monitor.send_args_cmd(cmdline)
 
-            if protocol in ["tcp", "rdma", "x-rdma"]:
+            if protocol in ["tcp", "rdma"]:
                 if local:
                     uri = protocol + ":localhost:%d" % clone.migration_port
                 else:

--- a/virttest/unittest_data/testcfg.huge/subtests.cfg
+++ b/virttest/unittest_data/testcfg.huge/subtests.cfg
@@ -135,18 +135,6 @@ variants:
                used_mem = 1024
                mig_timeout = 3600
                migration_protocol = "tcp"
-           - balloon-migrate-x-rdma:
-               sub_balloon_test_enlarge = "migration"
-               sub_balloon_test_evict = "migration"
-               migration_test_command = help
-               migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
-               migration_bg_check_command = pgrep tcpdump
-               migration_bg_kill_command = pkill tcpdump
-               kill_vm_on_error = yes
-               iterations = 2
-               used_mem = 1024
-               mig_timeout = 3600
-               migration_protocol = "x-rdma"
            - balloon-migrate-rdma:
                sub_balloon_test_enlarge = "migration"
                sub_balloon_test_evict = "migration"
@@ -504,8 +492,6 @@ variants:
         variants:
             - tcp:
                 migration_protocol = "tcp"
-            - x-rdma:
-                migration_protocol = "x-rdma"
             - rdma:
                 migration_protocol = "rdma"
             - unix:
@@ -516,10 +502,6 @@ variants:
                 migration_protocol = "fd"
             - mig_cancel:
                 migration_protocol = "tcp"
-                mig_cancel = yes
-                only migrate..default
-            - mig_cancel_x_rdma:
-                migration_protocol = "x-rdma"
                 mig_cancel = yes
                 only migrate..default
             - mig_cancel_rdma:
@@ -679,10 +661,6 @@ variants:
                 regain_ip_cmd = killall dhclient; sleep 10; dhclient;
                 variants:
                     #Migration protocol.
-                    - x-rdma:
-                        mig_protocol = "x-rdma"
-                    - rdma:
-                        mig_protocol = "rdma"
                     - tcp:
                         mig_protocol = "tcp"
                     - fd:


### PR DESCRIPTION
As seen at the commit 41310c68781d742fa9bbfd5fcb1df9b7f23f5759 from
Qemu github mirror, x-rdma was renamed to rdma.

Signed-off-by: Eduardo Otubo eduardo.otubo@profitbricks.com
