### PR TITLE
iscsi: Fix localhost iscsi target login bug

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -46,13 +46,15 @@ def iscsi_get_nodes():
     return nodes
 
 
-def iscsi_login(target_name):
+def iscsi_login(target_name, portal):
     """
     Login to a target with the target name
 
     :param target_name: Name of the target
+    :params portal: Hostname/Ip for iscsi server
     """
     cmd = "iscsiadm --mode node --login --targetname %s" % target_name
+    cmd += " --portal %s" % portal
     output = utils.system_output(cmd)
 
     target_login = ""
@@ -113,7 +115,7 @@ class Iscsi(object):
         if params.get("portal_ip"):
             self.portal_ip = params.get("portal_ip")
         else:
-            self.portal_ip = utils.system_output("hostname")
+            self.portal_ip = "localhost"
         if params.get("iscsi_thread_id"):
             self.id = params.get("iscsi_thread_id")
         else:
@@ -192,7 +194,7 @@ class Iscsi(object):
                 login_flag = True
 
         if login_flag:
-            iscsi_login(self.target)
+            iscsi_login(self.target, self.portal_ip)
 
     def get_device_name(self):
         """

--- a/virttest/iscsi_unittest.py
+++ b/virttest/iscsi_unittest.py
@@ -18,13 +18,13 @@ class iscsi_test(unittest.TestCase):
 
     def setup_stubs_init(self):
         os_dep.command.expect_call("iscsiadm")
-        utils.system_output.expect_call("hostname").and_return("localhost")
         os_dep.command.expect_call("tgtadm")
 
     def setup_stubs_login(self, iscsi_obj):
         c_cmd = "dd if=/dev/zero of=/tmp/iscsitest count=1024 bs=1K"
         lg_cmd = "iscsiadm --mode node --login --targetname "
         lg_cmd += "%s" % iscsi_obj.target
+        lg_cmd += " --portal %s" % iscsi_obj.portal_ip
         self.setup_stubs_portal_visible(iscsi_obj)
         os.path.isfile.expect_call(iscsi_obj.emulated_image).and_return(False)
         utils.system.expect_call(c_cmd)


### PR DESCRIPTION
By default, 'hostname' will be used as portal, and it will get timeout
when login this target while host ipv6 enabled:
Logging in to [iface: default, target: XXXX, portal: fe80::baac:6fff:fe3b:9aa,3260](multiple)
iscsiadm: Could not login to [iface: default, target: XX, portal: fe80::baac:6fff:fe3b:9aa,3260].
iscsiadm: initiator reported error (8 - connection timed out)

So use 'localhost' to discover and login the target will get rid of
this problem.

Signed-off-by: Yanbing Du ydu@redhat.com
