### PR TITLE
libvirt_xml: Add a function to delete memoryBacking tag.

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1239,6 +1239,18 @@ class VMXML(VMXMLBase):
         vmxml.mb = mb_xml
         vmxml.sync()
 
+    @staticmethod
+    def del_memoryBacking_tag(vm_name, virsh_instance=base.virsh):
+        """
+        Remove the memoryBacking tag from a domain
+        """
+        vmxml = VMXML.new_from_dumpxml(vm_name, virsh_instance=virsh_instance)
+        try:
+            vmxml.xmltreefile.remove_by_xpath("/memoryBacking")
+            vmxml.sync()
+        except (AttributeError, TypeError):
+            pass  # Element already doesn't exist
+
 
 class VMCPUXML(base.LibvirtXMLBase):
 


### PR DESCRIPTION
del_memoryBacking_tag() can delete memoryBacking tag for specific vm,
and it's paired with add_memoryBacking_tag().
