### PR TITLE
virt: Add catch_monitor for ScreenDump and VmRegister threads.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -211,6 +211,10 @@ monitors = hmp1
 #monitor_type_hmp1 = human
 # Default monitor type (protocol), if multiple types to be used
 monitor_type = human
+# If set catch_monitor, will start another monitor in qemu for
+# VmRegister and ScreenDump threads.
+catch_monitor = catch_monitor
+#monitor_type_catch_monitor = qmp
 # Pattern to get vcpu threads from monitor.both support
 vcpu_thread_pattern = "thread_id.?[:|=]\s*(\d+)"
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1191,7 +1191,7 @@ def store_vm_register(vm, log_filename, append=False):
     :rtype: bool
     """
     try:
-        output = vm.monitor.info('registers', debug=False)
+        output = vm.catch_monitor.info('registers', debug=False)
         timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
     except qemu_monitor.MonitorError, err:
         logging.warn(err)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2635,14 +2635,14 @@ class VM(virt_vm.BaseVM):
     def monitor(self):
         """
         Return the main monitor object, selected by the parameter main_monitor.
-        If main_monitor isn't defined, return the first monitor.
-        If no monitors exist, or if main_monitor refers to a nonexistent
-        monitor, return None.
+        If main_monitor isn't defined or it refers to a nonexistent monitor,
+        return the first monitor.
+        If no monitors exist, return None.
         """
         for m in self.monitors:
             if m.name == self.params.get("main_monitor"):
                 return m
-        if self.monitors and not self.params.get("main_monitor"):
+        if self.monitors:
             return self.monitors[0]
         return None
 
@@ -2651,14 +2651,14 @@ class VM(virt_vm.BaseVM):
         """
         Return the catch monitor object, selected by the parameter
         catch_monitor.
-        If catch_monitor isn't defined or it refers to a nonexistent,
+        If catch_monitor isn't defined or it refers to a nonexistent monitor,
         return the last monitor.
         If no monitors exist, return None.
         """
         for m in self.monitors:
             if m.name == self.params.get("catch_monitor"):
                 return m
-        if self.monitors and not self.params.get("catch_monitor"):
+        if self.monitors:
             return self.monitors[-1]
         return None
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -179,8 +179,8 @@ class VM(virt_vm.BaseVM):
         """
         Return True if the VM is alive and its monitor is responsive.
         """
-        return not self.is_dead() and (not self.monitor or
-                                       self.monitor.is_responsive())
+        return not self.is_dead() and (not self.catch_monitor or
+                                       self.catch_monitor.is_responsive())
 
     def is_dead(self):
         """
@@ -1211,6 +1211,10 @@ class VM(virt_vm.BaseVM):
                                                parent_bus=pci_bus))
 
         # Add monitors
+        catch_monitor = params.get("catch_monitor")
+        if catch_monitor:
+            if catch_monitor not in params.get("monitors"):
+                params["monitors"] += " %s" % catch_monitor
         for monitor_name in params.objects("monitors"):
             monitor_params = params.object_params(monitor_name)
             monitor_filename = qemu_monitor.get_monitor_filename(vm,
@@ -2642,6 +2646,22 @@ class VM(virt_vm.BaseVM):
             return self.monitors[0]
         return None
 
+    @property
+    def catch_monitor(self):
+        """
+        Return the catch monitor object, selected by the parameter
+        catch_monitor.
+        If catch_monitor isn't defined or it refers to a nonexistent,
+        return the last monitor.
+        If no monitors exist, return None.
+        """
+        for m in self.monitors:
+            if m.name == self.params.get("catch_monitor"):
+                return m
+        if self.monitors and not self.params.get("catch_monitor"):
+            return self.monitors[-1]
+        return None
+
     def get_monitors_by_type(self, mon_type):
         """
         Return list of monitors of mon_type type.
@@ -3466,8 +3486,8 @@ class VM(virt_vm.BaseVM):
     # should this really be expected from VMs of all hypervisor types?
     def screendump(self, filename, debug=True):
         try:
-            if self.monitor:
-                self.monitor.screendump(filename=filename, debug=debug)
+            if self.catch_monitor:
+                self.catch_monitor.screendump(filename=filename, debug=debug)
         except qemu_monitor.MonitorError, e:
             logging.warn(e)
 


### PR DESCRIPTION
We have many thread need send monitor command. So Add a
catch_monitor for ScreenDump and VmRegister threads to reduce
acquire exclusive lock fail.

Signed-off-by: Feng Yang <fyang@redhat.com>