### PR TITLE
virt: Make VM create timeout configurable.

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -163,11 +163,13 @@ def preprocess_vm(test, params, env, name):
             # Start the VM (or restart it if it's already up)
             if params.get("reuse_previous_config", "no") == "no":
                 vm.create(name, params, test.bindir,
+                          timeout=int(params.get("vm_create_timeout", 20)),
                           migration_mode=params.get("migration_mode"),
                           migration_fd=params.get("migration_fd"),
                           migration_exec_cmd=params.get("migration_exec_cmd_dst"))
             else:
-                vm.create(migration_mode=params.get("migration_mode"),
+                vm.create(timeout=int(params.get("vm_create_timeout", 20)),
+                          migration_mode=params.get("migration_mode"),
                           migration_fd=params.get("migration_fd"),
                           migration_exec_cmd=params.get("migration_exec_cmd_dst"))
     elif not vm.is_alive():    # VM is dead and won't be started, update params

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -87,12 +87,6 @@ class VM(virt_vm.BaseVM):
     # By default we inherit all timeouts from the base VM class except...
     CLOSE_SESSION_TIMEOUT = 30
 
-    # Because we've seen qemu taking longer than 5 seconds to initialize
-    # itself completely, including creating the monitor sockets files
-    # which are used on create(), this timeout is considerably larger
-    # than the one on the base vm class
-    CREATE_TIMEOUT = 20
-
     def __init__(self, name, params, root_dir, address_cache, state=None):
         """
         Initialize the object and set a few attributes.
@@ -1955,7 +1949,7 @@ class VM(virt_vm.BaseVM):
 
     @error.context_aware
     def create(self, name=None, params=None, root_dir=None,
-               timeout=CREATE_TIMEOUT, migration_mode=None,
+               timeout=20, migration_mode=None,
                migration_exec_cmd=None, migration_fd=None,
                mac_source=None):
         """

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -499,7 +499,6 @@ class BaseVM(object):
     COPY_FILES_TIMEOUT = 600
     MIGRATE_TIMEOUT = 3600
     REBOOT_TIMEOUT = 240
-    CREATE_TIMEOUT = 5
 
     def __init__(self, name, params):
         self.name = name


### PR DESCRIPTION
Now we use fix CREATE_TIME = 20s.
But some time this timeout is too short. So
make it configurable.

Signed-off-by: Feng Yang fyang@redhat.com
