### PR TITLE
virttest.iscsi: Add iscsi node record cleanup function

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -62,6 +62,31 @@ def iscsi_login(target_name):
     return target_login
 
 
+def iscsi_node_del(target_name=None):
+    """
+    Delete target node record, if the target name is not set then delete
+    all target node records.
+
+    :params target_name: Name of the target.
+    """
+    node_list = iscsi_get_nodes()
+    cmd = ''
+    if target_name:
+        for node_tup in node_list:
+            if target_name in node_tup:
+                cmd = "iscsiadm -m node -o delete -T %s " % target_name
+                cmd += "--portal %s" % node_tup[0]
+                utils.system(cmd)
+        if not cmd:
+            logging.error("The target '%s' for delete is not in target node"
+                          " record", target_name)
+    else:
+        for node_tup in node_list:
+            cmd = "iscsiadm -m node -o delete -T %s " % node_tup[1]
+            cmd += "--portal %s" % node_tup[0]
+            utils.system(cmd)
+
+
 def iscsi_logout(target_name=None):
     """
     Logout from a target. If the target name is not set then logout all
@@ -417,6 +442,7 @@ class Iscsi(object):
         Clean up env after iscsi used.
         """
         self.logout()
+        iscsi_node_del(self.target)
         if os.path.isfile("/etc/iscsi/initiatorname.iscsi-%s" % self.id):
             cmd = " mv /etc/iscsi/initiatorname.iscsi-%s" % self.id
             cmd += " /etc/iscsi/initiatorname.iscsi"

--- a/virttest/iscsi_unittest.py
+++ b/virttest/iscsi_unittest.py
@@ -53,6 +53,13 @@ class iscsi_test(unittest.TestCase):
 
         out_cmd = "iscsiadm --mode node --logout -T %s" % iscsi_obj.target
         utils.system_output.expect_call(out_cmd).and_return("successful")
+        out_cmd = "iscsiadm --mode node"
+        ret_str = "127.0.0.1:3260,1 %s" % iscsi_obj.target
+        utils.system_output.expect_call(out_cmd
+                                        ).and_return(ret_str)
+        out_cmd = "iscsiadm -m node -o delete -T %s " % iscsi_obj.target
+        out_cmd += "--portal 127.0.0.1"
+        utils.system.expect_call(out_cmd).and_return("")
         os.path.isfile.expect_call(fname).and_return(False)
         s_cmd = "tgtadm --lld iscsi --mode target --op show"
         utils.system_output.expect_call(s_cmd


### PR DESCRIPTION
Add clean iscsi node record function and use it in cleanup.

Signed-off-by: Wayne Sun gsun@redhat.com
