### PR TITLE
virttest.staging.utils_memory: strengthen get_num_anon_huge_pages()

### DIFF
--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -80,8 +80,13 @@ def get_num_huge_pages_rsvd():
     return read_from_meminfo('HugePages_Rsvd')
 
 
-def get_num_anon_huge_pages(pid):
-    return read_from_smaps(pid, 'AnonHugePages')
+def get_num_anon_huge_pages(pid=0):
+    if int(pid) > 1:
+        # get AnonHugePages usage of specified process
+        return read_from_smaps(pid, 'AnonHugePages')
+    else:
+        # invalid pid, so return AnonHugePages of the host
+        return read_from_meminfo('AnonHugePages')
 
 
 def get_transparent_hugepage():


### PR DESCRIPTION
This function is intended to obtain the AnonHugePages usage of VM.
Sometime, we want to get the AnonHugePages usage of Host,
so this patch can achieve this purpose.
