### PR TITLE
utils_params.object: Avoid quotation marks for object paramters.

### DIFF
--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -31,7 +31,7 @@ class Params(UserDict.IterableUserDict):
         :param key: The name of the key whose value lists the objects
                 (e.g. 'nics').
         """
-        return self.get(key, "").split()
+        return self.get(key, "").strip('"').split()
 
     def object_params(self, obj_name):
         """


### PR DESCRIPTION
For parameter like "vms", if we pass value in this format:
vms = "vm1 vm2 vm3",
vms will be recognised as '"vm1', 'vm2' and 'vm3"'.
So strip it when analysing.

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
