### PR TITLE
shared.cfg: Small fix for s3_support_chk_cmd

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -103,7 +103,7 @@
         kill_test_s4_cmd = taskkill /IM ping.exe /F
         services_up_timeout = 30
     guest_s3, guest_s3_time_drift, check_suspend, balloon_fix_value:
-        s3_support_chk_cmd = 'wevtutil cl system && powercfg /h off & powercfg -a | findstr /I /C:"The following sleep states are available on this system: Standby ( S3 )"'
+        s3_support_chk_cmd = 'wevtutil cl system && powercfg /h off & powershell -command " & { powercfg -a | select-string 'The following sleep states are available on this system:' -context 0,1 | findstr /I /C:'S3' } "'
         s3_start_cmd = "rundll32.exe PowrProf.dll,SetSuspendState 0,1,0"
         s3_bg_program_setup_cmd = 'start /B ping -t localhost'
         s3_bg_program_chk_cmd = 'tasklist | findstr /I /C:"ping.exe"'


### PR DESCRIPTION
For latest windows guest, s3 support log in multi lines, like:
    The following sleep states are available on this system:
        Standby (S3)

old s3_support_chk_cmd cannot find str for multi lines,
so update it.
