### PR TITLE
virttest.qemu_vm: add support set VGA vram ram vgamem

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -255,7 +255,9 @@ boot_menu = off
 #### SPICE related options valid if display == spice,
 #### you should set vga = qxl to get SPICE in use
 #qxl_dev_nr = 1
-#qxl_dev_memory = 33554432
+#qxl_vgamem_mb = 8
+#qxl_vram_size = 33554432
+#qxl_ram_size = 33554432
 #spice_port = 3001
 #spice_password = 123456
 #spice_addr = 0


### PR DESCRIPTION
For qxl device, we can set global default by params like, qxl_vram_size=67108864 and
qxl_vgamem_mb=16 . For 'std' VGA set vgamem_mb like vga_vgamem_mb=16, 'cirrus'
VGA set like, cirrus-vga_vgamem_mb =16.

Signed-off-by: Xu Tian xutian@redhat.com
