### PR TITLE
get volume virtual size correctly

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2203,11 +2203,12 @@ def get_image_info(image_file):
         cmd = "qemu-img info %s" % image_file
         image_info = utils.run(cmd, ignore_status=False).stdout.strip()
         image_info_dict = {}
+        vsize = None
         if image_info:
             for line in image_info.splitlines():
                 if line.find("file format") != -1:
                     image_info_dict['format'] = line.split(':')[-1].strip()
-                elif line.find("virtual size") != -1:
+                elif line.find("virtual size") != -1 and vsize is None:
                     # Use the value in (xxxxxx bytes) since it's the more
                     # realistic value. For a "1000k" disk, qemu-img will
                     # show 1.0M and 1024000 bytes. The 1.0M will translate


### PR DESCRIPTION
For some format volume(vmdk, etc.), 'qemu-img info' output looks like:
$ qemu-img info /tmp/vmdk-v4.img
image: /tmp/vmdk-v4.img
file format: vmdk
virtual size: 1.0M (1048576 bytes)
disk size: 12K
cluster_size: 65536
Format specific information:
    cid: 1418280048
    parent cid: 4294967295
    create type: monolithicSparse
    extents:
        [0]:
            virtual size: 1048576
            filename: /tmp/vmdk-v4.img
            cluster size: 65536
            format:

and only the first line of 'virtual size' is what we want.

Signed-off-by: Yanbing Du ydu@redhat.com
