### PR TITLE
virttest.qemu_qtree: Remove the quotations in image name

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -222,7 +222,7 @@ class QtreeDisk(QtreeDev):
         self.params['drive_format'] = self.qtree.get('type')
 
     def get_qname(self):
-        return self.qtree.get('drive')
+        return re.sub("['\"]", "", self.qtree.get('drive'))
 
 
 class QtreeContainer(object):


### PR DESCRIPTION
Corrently the image name will include two quotations in the string.
And this will failed the parse. So remove the quotations to make
it work as expect.