### PR TITLE
utils_libguestfs: Unset color environment for guestfish test.

### DIFF
--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -184,6 +184,16 @@ class Guestfish(LibguestfsBase):
         if run_mode not in ['remote', 'interactive']:
             raise AssertionError("run_mode should be remote or interactive")
 
+        # unset GUESTFISH_XXX environment parameters
+        # to avoid color of guestfish shell session for testing
+        color_envs = ["GUESTFISH_PS1", "GUESTFISH_OUTPUT",
+                      "GUESTFISH_RESTORE", "GUESTFISH_INIT"]
+        unset_cmd = ""
+        for env in color_envs:
+            unset_cmd += "unset %s;" % env
+        if unset_cmd:
+            utils.run(unset_cmd, ignore_status=True)
+
         if run_mode == "remote":
             guestfs_exec += " --listen"
         else:


### PR DESCRIPTION
For some Linux release(RHEL7.1), characters will have color
when we enter guestfish shell session. It may cause failure
of testcases. So covering it during testing.

Signed-off-by: Yu Mingfei <yumingfei@cn.fujitsu.com>