### PR TITLE
shared.unattended: fix ubuntu timeout lost issue

### DIFF
--- a/shared/unattended/Ubuntu-12-04.preseed
+++ b/shared/unattended/Ubuntu-12-04.preseed
@@ -49,10 +49,6 @@ d-i debian-installer/exit/poweroff boolean true
 d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
-echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "respawn exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
-echo "#!/bin/sh -e" > /target/etc/rc.local; \
-echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
-echo "exit 0" >> /target/etc/rc.local; \
-sed -i "s/ alias/ #alias/g" /target/root/.bashrc
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub

--- a/shared/unattended/Ubuntu-12-04.preseed
+++ b/shared/unattended/Ubuntu-12-04.preseed
@@ -31,8 +31,7 @@ d-i mirror/udeb/components multiselect main, restricted, universe, multiverse
 tasksel tasksel/first multiselect standard
 
 d-i pkgsel/include string openssh-server build-essential lvm2 ethtool \
-sg3-utils lsscsi libaio-dev libtime-hires-perl acpid nfs-kernel-server \
-tgt linux-tools-generic
+sg3-utils lsscsi libaio-dev libtime-hires-perl acpid nfs-kernel-server tgt
 
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true

--- a/shared/unattended/Ubuntu-14-04.preseed
+++ b/shared/unattended/Ubuntu-14-04.preseed
@@ -49,11 +49,6 @@ d-i debian-installer/exit/poweroff boolean true
 d-i preseed/late_command string \
 echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
-sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/g' /target/etc/ssh/sshd_config; \
-echo "respawn" >> /target/etc/init/ttyS0.conf; \
-echo "exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "respawn exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
-echo "#!/bin/sh -e" > /target/etc/rc.local; \
-echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
-echo "exit 0" >> /target/etc/rc.local; \
-sed -i "s/ alias/ #alias/g" /target/root/.bashrc
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub

--- a/shared/unattended/Ubuntu-14-04.preseed
+++ b/shared/unattended/Ubuntu-14-04.preseed
@@ -31,8 +31,7 @@ d-i mirror/udeb/components multiselect main, restricted, universe, multiverse
 tasksel tasksel/first multiselect standard
 
 d-i pkgsel/include string openssh-server build-essential lvm2 ethtool \
-sg3-utils lsscsi libaio-dev libtime-hires-perl acpid nfs-kernel-server \
-tgt linux-tools-generic
+sg3-utils lsscsi libaio-dev libtime-hires-perl acpid tgt
 
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true


### PR DESCRIPTION
In system_set_bootable test, recordfail set to 1 when reset guest before guest boot into OS, and make_timeout function in /etc/grub.d/00_header will set timeout to -1 if GRUB_RECORDFAIL_TIMEOUT not set. And grub wait  user to select boot OS. Now set GRUB_RECORDFAIL_TIMEOUT and update grub before finished install to fix this issue.

Signed-off-by: Xu Tian <xutian@redhat.com>