### PR TITLE
virttest.utils_misc: Add some code for strip_console_codes

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1007,7 +1007,7 @@ def strip_console_codes(output, custom_codes=None):
     index = 0
     output = "\x1b[m%s" % output
     console_codes = "%[G@8]|\[[@A-HJ-MPXa-hl-nqrsu\`]"
-    console_codes += "|\[[\d;]+[HJKgqnrm]|#8|\([B0UK]|\)"
+    console_codes += "|\[[\d;]+[HJKgqnrm]|#8|\([B0UK]|\)|\[\d+S"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += "|%s" % custom_codes
     while index < len(output):


### PR DESCRIPTION
In my test, the code '^[[1S' can't be recognized by this function, just add it.
