### PR TITLE
Add per-disk seclabel support

### DIFF
--- a/virttest/libvirt_xml/accessors.py
+++ b/virttest/libvirt_xml/accessors.py
@@ -802,15 +802,35 @@ class XMLElementList(AccessorGeneratorBase):
                                                 index,
                                                 str(item)))
                     raise xcepts.LibvirtXMLAccessorError(msg)
+
+                # Handle element text values in element_tuple[1].
                 text = None
-                # To support text in element, marshal_from may return
-                # an additional text value, check the length of element tuple
+                new_dict = element_tuple[1].copy()
+                if 'text' in element_tuple[1].keys():
+                    del new_dict['text']
+
+                # To support text in element, marshal_from may return an
+                # additional text value, check the length of element tuple
                 if len(element_tuple) == 3:
                     text = element_tuple[2]
-                xml_utils.ElementTree.SubElement(parent,
-                                                 element_tuple[0],
-                                                 element_tuple[1],
-                                                 text)
+                parent_element = xml_utils.ElementTree.SubElement(
+                    parent,
+                    element_tuple[0],
+                    new_dict,
+                    text)
+
+                # To support child element contains text, create sub element
+                # with text under new created parent element.
+                if 'text' in element_tuple[1].keys():
+                    text_dict = element_tuple[1]['text']
+                    attr_dict = {}
+                    for text_key, text_val in text_dict.items():
+                        xml_utils.ElementTree.SubElement(
+                            parent_element,
+                            text_key,
+                            attr_dict,
+                            text_val)
+
                 index += 1
             self.xmltreefile().write()
 

--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -208,7 +208,16 @@ class Disk(base.TypedDeviceBase):
             del libvirtxml      # not used
             root = item.xmltreefile.getroot()
             if root.tag == 'seclabel':
-                return (root.tag, dict(root.items))
+                new_dict = dict(root.items())
+                text_dict = {}
+                # Put element text into dict under key 'text'
+                for key in ('label', 'baselabel'):
+                    text_val = item.xmltreefile.findtext(key)
+                    if text_val:
+                        text_dict.update({key: text_val})
+                if text_dict:
+                    new_dict['text'] = text_dict
+                return (root.tag, new_dict)
             else:
                 raise xcepts.LibvirtXMLError("Expected a list of seclabel "
                                              "instances, not a %s" % str(item))

--- a/virttest/libvirt_xml/devices/seclabel.py
+++ b/virttest/libvirt_xml/devices/seclabel.py
@@ -4,11 +4,38 @@ seclabel device support class(es)
 http://libvirt.org/formatdomain.html#seclabel
 """
 
+from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base
 
 
 class Seclabel(base.TypedDeviceBase):
-    # TODO: Write this class
-    __metaclass__ = base.StubDeviceMeta
-    _device_tag = 'seclabel'
-    _def_type_name = 'static'
+
+    """
+    Seclabel XML class
+
+    Properties:
+        model:
+            string, security driver model
+        relabel:
+            string, 'yes' or 'no'
+        baselabel:
+            string, base label string
+        label:
+            string, the sec label string
+    """
+
+    __slots__ = ('model', 'relabel', 'baselabel', 'label')
+
+    def __init__(self, type_name='dynamic', virsh_instance=base.base.virsh):
+        accessors.XMLAttribute('model', self, parent_xpath='/',
+                               tag_name='seclabel', attribute='model')
+        accessors.XMLAttribute('relabel', self, parent_xpath='/',
+                               tag_name='seclabel', attribute='relabel')
+        accessors.XMLElementText('baselabel', self, parent_xpath='/',
+                                 tag_name='baselabel')
+        accessors.XMLElementText('label', self, parent_xpath='/',
+                                 tag_name='label')
+        super(Seclabel, self).__init__(device_tag='seclabel',
+                                       type_name=type_name,
+                                       virsh_instance=virsh_instance)
+        self.xml = '<seclabel></seclabel>'

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -45,6 +45,7 @@ from virttest.libvirt_xml import IPXML
 from virttest.libvirt_xml.devices import disk
 from virttest.libvirt_xml.devices import hostdev
 from virttest.libvirt_xml.devices import controller
+from virttest.libvirt_xml.devices import seclabel
 from __init__ import ping
 try:
     from autotest.client import lv_utils
@@ -1287,6 +1288,7 @@ def create_disk_xml(params):
         diskxml.snapshot = snapshot_attr
     source_attrs = {}
     source_host = []
+    source_seclabel = []
     auth_attrs = {}
     driver_attrs = {}
     try:
@@ -1320,7 +1322,25 @@ def create_disk_xml(params):
         source_startupPolicy = params.get("source_startupPolicy")
         if source_startupPolicy:
             source_attrs['startupPolicy'] = source_startupPolicy
+
+        sec_model = params.get("sec_model")
+        relabel = params.get("relabel")
+        label = params.get("sec_label")
+        if sec_model or relabel:
+            sec_dict = {}
+            sec_xml = seclabel.Seclabel()
+            if sec_model:
+                sec_dict.update({'model': sec_model})
+            if relabel:
+                sec_dict.update({'relabel': relabel})
+            if label:
+                sec_dict.update({'label': label})
+            sec_xml.update(sec_dict)
+            logging.debug("The sec xml is %s", sec_xml.xmltreefile)
+            source_seclabel.append(sec_xml)
+
         diskxml.source = diskxml.new_disk_source(attrs=source_attrs,
+                                                 seclabels=source_seclabel,
                                                  hosts=source_host)
         auth_user = params.get("auth_user")
         secret_type = params.get("secret_type")

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1624,13 +1624,19 @@ def set_vm_disk(vm, params, tmp_dir=None):
     blk_source = first_disk['source']
     disk_xml = vmxml.devices.by_device_tag('disk')[0]
     src_disk_format = disk_xml.xmltreefile.find('driver').get('type')
+    sec_model = params.get('sec_model')
+    relabel = params.get('relabel')
+    sec_label = params.get('sec_label')
     disk_params = {'device_type': disk_device,
                    'disk_snapshot_attr': disk_snapshot_attr,
                    'type_name': disk_type,
                    'target_dev': disk_target,
                    'target_bus': disk_target_bus,
                    'driver_type': disk_format,
-                   'driver_cache': 'none'}
+                   'driver_cache': 'none',
+                   'sec_model': sec_model,
+                   'relabel': relabel,
+                   'sec_label': sec_label}
 
     if not tmp_dir:
         tmp_dir = data_dir.get_tmp_dir()
@@ -1721,8 +1727,8 @@ def set_vm_disk(vm, params, tmp_dir=None):
         src_file_path = "%s/%s" % (mnt_path, dist_img)
         disk_params_src = {'source_file': src_file_path}
     else:
-        raise error.TestNAError("Disk source protocol %s not supported in "
-                                "current test" % disk_src_protocol)
+        # use current source file with update params
+        disk_params_src = {'source_file': blk_source}
 
     # Delete disk elements
     disks = vmxml.get_devices(device_type="disk")


### PR DESCRIPTION
As libvirt xml support per-disk seclabel setting, implement seclabel class which include multiple element texts and attributes.
Handle the element texts in marshal_from_seclabel and XMLElementList, update both to handle extra dict under key 'text'.
e.g.
There are text element 'label' and 'baselabel' in seclabel:
```
      <source path='/tmp/file'>
        <seclabel model='dac' relabel='no'>
          <label>0:0</label>
          <baselabel>0:0</baselabel>
        </seclabel>
      </source>
```
both text element under parent tag 'seclabel' and with text value.
the return tuple of marshal_from_seclabel will be:
```
('seclabel', {'text': {'label': '0:0', 'baselabel': '0:0'}, 'model': 'dac', 'relabel': 'yes'})
```
and XMLElementList will create child element text after create seclabel element with attribute.


This update is different to PR:
https://github.com/autotest/virt-test/pull/1902

which handle only one text element just under the parent tag. 

e.g.
the text element hostname with only one value, and multiple hostname elements.
```
          <host ip='192.168.122.2'>
            <hostname>myhost</hostname>
            <hostname>myhostalias</hostname>
          </host>
```

the 2 return tuple of marshal_from_hostname will be
```
("hostname", {}, 'myhost')
```
and 
```
("hostname", {}, 'myhostalias')
```
then handle by XMLElementList to create element without attribute but with text under tag hostname.