### PR TITLE
Modify the md5chk_cmd for windows guest

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -175,7 +175,7 @@
         set_online_cmd += " diskpart /s cmd"
         testfile_name = "I:\\format_disk-test.txt"
         writefile_cmd = "echo %s > %s"
-        md5chk_cmd = "D:\coreutils\md5sum.exe I:\format_disk-test.txt"
+        md5chk_cmd = "cd I:\ && D:\coreutils\md5sum.exe format_disk-test.txt"
         readfile_cmd = "type %s"
         mount_cmd = ""
         umount_cmd = ""


### PR DESCRIPTION
Some windows guest (such as win7) can not excute the md5chk_cmd = "D:\coreutils\md5sum.exe I:\format_disk-test.txt" successfully.
Signed-off-by: Yang Xue <yaxue@redhat.com>