### PR TITLE
virttest.libvirt_vm: Generate random serial log file name

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -869,7 +869,8 @@ class VM(virt_vm.BaseVM):
 
         :param name: The serial port name.
         """
-        return "serial-%s-%s.log" % (name, self.name)
+        return "serial-%s-%s-%s.log" % (name, self.name,
+                                        utils_misc.generate_random_string(4))
 
     def get_serial_console_filenames(self):
         """


### PR DESCRIPTION
Using a deterministic log file name will cause overwrite of serial
log and only the last serial log file will be saved if multiple
log session has been established in one test.

This patch add a random suffix to prevent overwrite.

Signed-off-by: Hao Liu <hliu@redhat.com>