### PR TITLE
Fix bc4bfb8, run unset under the same process for guestfish

### DIFF
--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -191,10 +191,9 @@ class Guestfish(LibguestfsBase):
         unset_cmd = ""
         for env in color_envs:
             unset_cmd += "unset %s;" % env
-        if unset_cmd:
-            utils.run(unset_cmd, ignore_status=True)
-
-        if run_mode == "remote":
+        if run_mode == "interactive" and unset_cmd:
+            guestfs_exec = unset_cmd + " " + guestfs_exec
+        elif run_mode == "remote":
             guestfs_exec += " --listen"
         else:
             if uri:


### PR DESCRIPTION
@yumingfei Sorry, i haven't check your PR carefully, unset command shouldn't execute by utils.run, this function will fork a subprocess to run your command which will have no effect on current process and subprocess we created later like guestfish.