### PR TITLE
virttest.iscsi: Ignore status for iscsiadm.

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -38,7 +38,7 @@ def iscsi_get_nodes():
     """
     cmd = "iscsiadm --mode node"
 
-    output = utils.system_output(cmd)
+    output = utils.system_output(cmd, ignore_status=True)
     pattern = r"(\d+\.\d+\.\d+\.\d+|\W:{2}\d\W):\d+,\d+\s+([\w\.\-:\d]+)"
     nodes = []
     if "No records found" not in output:

--- a/virttest/iscsi_unittest.py
+++ b/virttest/iscsi_unittest.py
@@ -55,7 +55,8 @@ class iscsi_test(unittest.TestCase):
         utils.system_output.expect_call(out_cmd).and_return("successful")
         out_cmd = "iscsiadm --mode node"
         ret_str = "127.0.0.1:3260,1 %s" % iscsi_obj.target
-        utils.system_output.expect_call(out_cmd
+        utils.system_output.expect_call(out_cmd,
+                                        ignore_status=True
                                         ).and_return(ret_str)
         out_cmd = "iscsiadm -m node -o delete -T %s " % iscsi_obj.target
         out_cmd += "--portal 127.0.0.1"


### PR DESCRIPTION
Get rid of exception if iscsiadm command fails to excute
during iscsi cleanup process.