### PR TITLE
virt.qemu_monitor: Do not call utils_misc.log_line() to log the monitor ...

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -297,7 +297,11 @@ class Monitor:
                     self.open_log_files[log] = open(log, "w")
                 for line in log_str.splitlines():
                     self.open_log_files[log].write("%s: %s\n" % (timestr, line))
-            except Exception:
+            except Exception, err:
+                txt = "Fail to record log to %s.\n" % log
+                txt += "Log content: %s\n" % log_str
+                txt += "Exception error: %s" % err
+                logging.error(txt)
                 self.open_log_files[log].close()
                 self.open_log_files.pop(log)
         finally:
@@ -698,6 +702,7 @@ class HumanMonitor(Monitor):
                     self._passfd = passfd_setup.import_passfd()
                 # If command includes a file descriptor, use passfd module
                 self._passfd.sendfd(self._socket, fd, "%s\n" % cmd)
+                self._log_lines(cmd)
             else:
                 # Send command
                 if debug:
@@ -1410,6 +1415,7 @@ class QMPMonitor(Monitor):
                 # If command includes a file descriptor, use passfd module
                 self._passfd.sendfd(
                     self._socket, fd, json.dumps(cmdobj) + "\n")
+                self._log_lines(str(cmdobj))
             else:
                 self._send(json.dumps(cmdobj) + "\n")
             # Read response

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -372,6 +372,15 @@ def set_log_file_dir(directory):
     _log_file_dir = directory
 
 
+def get_log_file_dir():
+    """
+    get the base directory for log files created by log_line().
+
+    """
+    global _log_file_dir
+    return _log_file_dir
+
+
 def close_log_file(filename):
     global _open_log_files, _log_file_dir, _log_lock
     remove = []


### PR DESCRIPTION
...output

Now we call utils_misc.log_line() to save some logs.
Then script may fail to get log to access _open_log_files, especially when we
want to log many logs.

So handle monitor log in monitor class now.

Signed-off-by: Feng Yang <fyang@redhat.com>