### PR TITLE
virttest: Refactorize guest agent related functions

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1548,12 +1548,15 @@ def set_guest_agent(vm):
 
     :param vm: the vm object
     """
+    logging.warning("This function is going to be deprecated. "
+                    "Please use vm.prepare_guest_agent() instead.")
     # reset domain state
     if vm.is_alive():
         vm.destroy(gracefully=False)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
     logging.debug("Attempting to set guest agent channel")
-    vmxml.set_agent_channel(vm.name)
+    vmxml.set_agent_channel()
+    vmxml.sync()
     vm.start()
     session = vm.wait_for_login()
     # Check if qemu-ga already started automatically


### PR DESCRIPTION
Guest agent is vastly used in the tests so a single function call
to prepare guest agent is needed. Current using method set_guest_agent()
in virttest.util_test.libvirt is not so flexible. For example for tests
requiring a guest with agent channel but no agent service etc.

In this patch we implemented a method prepare_guest_agent() in libvirt_vm
class to setup guest agent as required for guest.

Major changes including:
1)  Changes get_agent_channels() and remove_agent_channels() from
    static method back to normal method since using static method
    is not straightforward. There are many misuses of static method
    in libvirt_xml module and We should change them later since
    code dependence is tangled.

2)  Besides the prepare_guest_agent() method mentioned above, two new
    methods install_package() and remove_package() are implemented
    for easily handling packages in the guest system. It only supports
    yum based package manager and others are expected to be supported
    later.

3)  The original set_guest_agent() will report a deprecate warning in
    case it is used accidentally after change.

4)  Added getenforce() and setenforce() in libvirt_xml module to
    retrieve or change guest SELinux mode for later use.

Signed-off-by: Hao Liu <hliu@redhat.com>