### PR TITLE
virttest.utils_test.libvirt: Add helper function to check command result

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1129,6 +1129,48 @@ class MigrationTest(object):
         vm.connect_uri = srcuri
 
 
+def check_result(result, expected_fails=[], skip_if=[], any_error=False):
+    """
+    Check the result of a command and check command error message against
+    expectation.
+
+    :param result: Command result instance.
+    :param expected_fails: list of regex of expected stderr patterns. The check
+                           will pass if any of these patterns matches.
+    :param skip_if: list of regex of expected patterns. The check will raise a
+                    TestNAError if any of these patterns matches.
+    :param any_error: Whether expect on any error message. Setting to True will
+                      will override expected_fails
+    """
+    logging.debug("Command result:\n%s" % result)
+    if skip_if:
+        for patt in skip_if:
+            if re.search(patt, result.stderr):
+                raise error.TestNAError("Test skipped: found '%s' in test "
+                                        "result:\n%s" %
+                                        (patt, result.stderr))
+    if any_error:
+        if result.exit_status:
+            return
+        else:
+            raise error.TestFail("Expect should fail but got:\n%s" % result)
+
+    if result.exit_status:
+        if expected_fails:
+            if not any(re.search(patt, result.stderr)
+                       for patt in expected_fails):
+                raise error.TestFail("Expect should fail with one of %s, "
+                                     "but failed with:\n%s" %
+                                     (expected_fails, result))
+        else:
+            raise error.TestFail("Expect should succeed, but got:\n%s" % result)
+    else:
+        if expected_fails:
+            raise error.TestFail("Expect should fail with one of %s, "
+                                 "but succeeded:\n%s" %
+                                 (expected_fails, result))
+
+
 def check_exit_status(result, expect_error=False):
     """
     Check the exit status of virsh commands.


### PR DESCRIPTION
This helper function is an enhanced version to existing function
check_exit_status().

The original one only tests whether the exit status matches expectation.
The newer one also consider the content of the error messages if the
command is expected be fail.

Add expected fail patterns (regex) as a list for expected_fails
argument.  If test stderr matches non of these, an TestFail will emit.
If this list is empty. Command is expected to be successful. If the
command is expected be fail but the error pattern does not matter,
setting any_error to True will suffice.

If any of the skip_if list of regex matches command stderr. The test
will skip.

Signed-off-by: Hao Liu <hliu@redhat.com>