### PR TITLE
libvirt_xml.devices.interface: Add filterref xml class

### DIFF
--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -2,9 +2,10 @@
 interface device support class(es)
 
 http://libvirt.org/formatdomain.html#elementsNICS
+http://libvirt.org/formatnwfilter.html#nwfconceptsvars
 """
 
-from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml import accessors, xcepts
 from virttest.libvirt_xml.devices import base, librarian
 
 
@@ -12,7 +13,8 @@ class Interface(base.TypedDeviceBase):
 
     __slots__ = ('source', 'mac_address', 'bandwidth',
                  'model', 'link_state', 'target',
-                 'driver', 'address', 'boot_order')
+                 'driver', 'address', 'boot_order',
+                 'filterref')
 
     def __init__(self, type_name, virsh_instance=base.base.virsh):
         super(Interface, self).__init__(device_tag='interface',
@@ -58,6 +60,12 @@ class Interface(base.TypedDeviceBase):
                                  subclass=self.Driver,
                                  subclass_dargs={
                                      'virsh_instance': virsh_instance})
+        accessors.XMLElementNest("filterref", self,
+                                 parent_xpath='/',
+                                 tag_name='filterref',
+                                 subclass=self.Filterref,
+                                 subclass_dargs={
+                                     'virsh_instance': virsh_instance})
         accessors.XMLAttribute(property_name="model",
                                libvirtxml=self,
                                forbidden=None,
@@ -85,6 +93,15 @@ class Interface(base.TypedDeviceBase):
         Return a new interafce driver instance from dargs
         """
         new_one = self.Driver(virsh_instance=self.virsh)
+        for key, value in dargs.items():
+            setattr(new_one, key, value)
+        return new_one
+
+    def new_filterref(self, **dargs):
+        """
+        Return a new interafce filterref instance from dargs
+        """
+        new_one = self.Filterref(virsh_instance=self.virsh)
         for key, value in dargs.items():
             setattr(new_one, key, value)
         return new_one
@@ -136,3 +153,52 @@ class Interface(base.TypedDeviceBase):
                                      tag_name="guest")
             super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<driver/>'
+
+    class Filterref(base.base.LibvirtXMLBase):
+
+        """
+        Interface filterref xml class.
+
+        Properties:
+
+        name:
+            string. filter name
+        parameters:
+            list. parameters element dict list
+        """
+        __slots__ = ("name", "parameters")
+
+        def __init__(self, virsh_instance=base.base.virsh):
+            accessors.XMLAttribute(property_name="name",
+                                   libvirtxml=self,
+                                   forbidden=None,
+                                   parent_xpath='/',
+                                   tag_name='filterref',
+                                   attribute='filter')
+            accessors.XMLElementList(property_name='parameters',
+                                     libvirtxml=self,
+                                     parent_xpath='/',
+                                     marshal_from=self.marshal_from_parameter,
+                                     marshal_to=self.marshal_to_parameter)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
+            self.xml = '<filterref/>'
+
+        @staticmethod
+        def marshal_from_parameter(item, index, libvirtxml):
+            """Convert a dictionary into a tag + attributes"""
+            del index           # not used
+            del libvirtxml      # not used
+            if not isinstance(item, dict):
+                raise xcepts.LibvirtXMLError("Expected a dictionary of parameter "
+                                             "attributes, not a %s"
+                                             % str(item))
+            return ('parameter', dict(item))  # return copy of dict, not reference
+
+        @staticmethod
+        def marshal_to_parameter(tag, attr_dict, index, libvirtxml):
+            """Convert a tag + attributes into a dictionary"""
+            del index                    # not used
+            del libvirtxml               # not used
+            if tag != 'parameter':
+                return None              # skip this one
+            return dict(attr_dict)       # return copy of dict, not reference


### PR DESCRIPTION
Libvirt support apply filter rules to specific interface by adding
filterref xml in domain interface, add new Filterref class under
Interface class to support set and get interface filterref rules.

About filterref xml with variables, check reference:
http://libvirt.org/formatnwfilter.html#nwfconceptsvars

Signed-off-by: Wayne Sun <gsun@redhat.com>