### PR TITLE
virt.virttest.qemu_vm: reboot with passed nic when session is None

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3418,8 +3418,11 @@ class VM(virt_vm.BaseVM):
         error.context()
 
         if method == "shell":
-            login = serial and self.serial_login or self.login
-            session = session or login()
+            if not session:
+                if serial:
+                    session = self.serial_login()
+                else:
+                    session = self.login(nic_index=nic_index)
             session.sendline(self.params.get("reboot_command"))
             error.context("waiting for guest to go down", logging.info)
             if not utils_misc.wait_for(


### PR DESCRIPTION
Fix nic_index miss when reboot with session=None.

ID:1183987