### PR TITLE
Add CentOS 7.0 support

### DIFF
--- a/shared/cfg/guest-os/Linux/CentOS.cfg
+++ b/shared/cfg/guest-os/Linux/CentOS.cfg
@@ -1,0 +1,11 @@
+- CentOS:
+    no setup
+    shell_prompt = "^\[.*\][\#\$]\s*$"
+    nic_hotplug, multi_nics_hotplug:
+        modprobe_module = acpiphp
+    block_hotplug:
+        modprobe_module = acpiphp
+        no block_scsi
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        boot_path = images/pxeboot
+        kernel_params = "ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0"

--- a/shared/cfg/guest-os/Linux/CentOS/7.0.cfg
+++ b/shared/cfg/guest-os/Linux/CentOS/7.0.cfg
@@ -1,0 +1,35 @@
+- 7.0:
+    no setup
+    image_name = images/centos70
+    os_variant = centos7
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        unattended_file = unattended/CentOS-7-0.ks
+        syslog_server_proto = udp
+    nic_hotplug:
+        modprobe_module =
+    block_hotplug:
+        modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/6/os/`uname -m`/Packages/iasl-20090123-3.1.el6.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/CentOS/7.0/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/CentOS/7.0/x86_64.cfg
@@ -1,0 +1,14 @@
+- x86_64:
+    grub_file = /boot/grub/grub.conf
+    vm_arch_name = x86_64
+    image_name += -64
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/centos70-64/ks.iso
+        kernel = images/centos70-64/vmlinuz
+        initrd = images/centos70-64/initrd.img
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_cd1 = isos/linux/CentOS-7.0-1406-x86_64-DVD.iso
+        md5sum_cd1 = 713ea7847adcdd1700e92429f212721a
+    unattended_install..floppy_ks:
+        floppies = "fl"
+        floppy_name = images/rhel70-64/ks.vfd

--- a/shared/downloads/centos70-64.ini
+++ b/shared/downloads/centos70-64.ini
@@ -1,0 +1,4 @@
+[centos70-64]
+title = CentOS 7.0 amd64
+url = http://mirror.isoc.org.il/pub/centos/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-DVD.iso
+destination = isos/linux/CentOS-7.0-1406-x86_64-DVD.iso

--- a/shared/unattended/CentOS-7-0.ks
+++ b/shared/unattended/CentOS-7-0.ks
@@ -1,0 +1,78 @@
+install
+KVM_TEST_MEDIUM
+graphical
+poweroff
+lang en_US.UTF-8
+keyboard us
+network --onboot yes --device eth0 --bootproto dhcp
+rootpw redhat
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+clearpart --all --initlabel
+autopart
+xconfig --startxonboot
+
+%packages --ignoremissing
+@base
+@core
+@development
+@additional-devel
+@debugging-tools
+@network-tools
+@fonts
+@x11
+@gnome-desktop
+lftp
+gcc
+gcc-c++
+patch
+make
+git
+nc
+NetworkManager
+ntpdate
+redhat-lsb
+numactl-libs
+numactl
+sg3_utils
+hdparm
+lsscsi
+libaio-devel
+perl-Time-HiRes
+flex
+prelink
+%end
+
+%post
+echo "OS install is completed" > /dev/ttyS0
+echo "remove rhgb quiet by grubby" > /dev/ttyS0
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+echo "dhclient" > /dev/ttyS0
+dhclient
+echo "get repo" > /dev/ttyS0
+wget http://fileshare.englab.nay.redhat.com/pub/section2/repo/epel/rhel-autotest.repo -O /etc/yum.repos.d/rhel-autotest.repo
+echo "yum makecache" > /dev/ttyS0
+yum makecache
+echo "yum install -y stress" > /dev/ttyS0
+yum install -y stress
+echo "chkconfig sshd on" > /dev/ttyS0
+chkconfig sshd on
+echo "PermitRootLogin in /etc/ssh/sshd_config" > /dev/ttyS0
+sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config
+echo "iptables -F" > /dev/ttyS0
+iptables -F
+echo "echo 0 > selinux/enforce" > /dev/ttyS0
+echo 0 > /selinux/enforce
+echo "chkconfig NetworkManager on" > /dev/ttyS0
+chkconfig NetworkManager on
+echo "update ifcfg-eth0" > /dev/ttyS0
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+echo "Disable lock cdrom udev rules" > /dev/ttyS0
+sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
+echo 'Post set up finished' > /dev/ttyS0
+echo Post set up finished > /dev/hvc0
+%end


### PR DESCRIPTION
Added CentOS 7.0 x86_64 guest to virt-test infrastructure, it is based on RHEL 7.0 x86_64 guest configuration.

Signed-off-by: Igor Derzhavets <igor.derzhavets@ravellosystems.com>