### PR TITLE
Bug fix for add-drive-opts readonly

### DIFF
--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -501,7 +501,7 @@ class GuestfishPersistent(Guestfish):
         """
         cmd = "add-drive-opts %s" % filename
 
-        if readonly:
+        if readonly and readonly != 'no':
             cmd += " readonly:true"
         else:
             cmd += " readonly:false"


### PR DESCRIPTION
readonly = params.get("gf_add_readonly", "no")

if readonly:

These will cause readonly never set to NULL