### PR TITLE
Fix typo error and add a new helper function remove_all_device_by_type

### DIFF
--- a/virttest/libvirt_xml/accessors.py
+++ b/virttest/libvirt_xml/accessors.py
@@ -507,7 +507,7 @@ class XMLAttribute(AccessorGeneratorBase):
                                              self.tag_name, create=False)
             value = element.get(self.attribute, None)
             if value is None:
-                raise xcepts.LibvirtXMLNotFoundError("Attribute %s not found"
+                raise xcepts.LibvirtXMLNotFoundError("Attribute %s not found "
                                                      "on element %s"
                                                      % (self.attribute,
                                                         element.tag))

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1181,6 +1181,18 @@ class VMXML(VMXMLBase):
             pass  # Element already doesn't exist
         self.xmltreefile.write()
 
+    def remove_all_device_by_type(self, device_type):
+        """
+        Remove all devices of a given type.
+
+        :param type: Type name for devices should be removed.
+        """
+        try:
+            self.xmltreefile.remove_by_xpath('/devices/%s' % device_type)
+        except (AttributeError, TypeError):
+            pass  # Element already doesn't exist
+        self.xmltreefile.write()
+
     def add_hostdev(self, source_address, mode='subsystem',
                     hostdev_type='pci',
                     managed='yes'):

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -134,7 +134,7 @@ def handle_prompts(session, username, password, prompt, timeout=10,
                 [r"[Aa]re you sure", r"[Pp]assword:\s*",
                  r"\(or (press|type) Control-D to continue\):\s*$",  # Prompt of rescue mode for Red Hat.
                  r"[Gg]ive.*[Ll]ogin:\s*$",  # Prompt of rescue mode for SUSE.
-                 r"(?<![Ll]ast).*[Ll]ogin:\s*$",  # Don't match "Last Login:"
+                 r"(?<![Ll]ast )[Ll]ogin:\s*$",  # Don't match "Last Login:"
                  r"[Cc]onnection.*closed", r"[Cc]onnection.*refused",
                  r"[Pp]lease wait", r"[Ww]arning", r"[Ee]nter.*username",
                  r"[Ee]nter.*password", r"[Cc]onnection timed out", prompt],


### PR DESCRIPTION
Please refer to commit messages for the reasoning.