### PR TITLE
virttest: Fix the wrong indent in handle_prompts

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -194,7 +194,7 @@ def handle_prompts(session, username, password, prompt, timeout=10,
         except aexpect.ExpectProcessTerminatedError, e:
             raise LoginProcessTerminatedError(e.status, e.output)
 
-        return output
+    return output
 
 
 def remote_login(client, host, port, username, password, prompt, linesep="\n",


### PR DESCRIPTION
The last of the function should be moved outside of the while loop.
Otherwise it will never be executed.

