### PR TITLE
virttest: Update check_guests_proc_scsi in qemu_qtree

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -445,6 +445,12 @@ class QtreeDisksContainer(object):
             if (disk.get_qtree()['type'].startswith('scsi') or
                     disk.get_qtree()['type'].startswith('usb2')):
                 props = disk.get_qtree()
+                # New output from qtree will include hex number. Should
+                # remove it in this function.
+                for item in props:
+                    if re.match("\d+\s+\(.*?\)", props[item]):
+                        props[item] = re.findall("\d+", props[item])[0]
+
                 disks.add('%d-%d-%d' % (int(props.get('channel')),
                                         int(props.get('scsi-id')),
                                         int(props.get('lun'))))


### PR DESCRIPTION
Current output of qtree will include hex numbers and this makes
the transfer from string to int failed. So remove it to make the function
works as expect.
