### PR TITLE
virttest: Update the method of guess_type for QtreeDev

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -163,9 +163,11 @@ class QtreeDev(QtreeNode):
         super(QtreeDev, self).add_child(child)
 
     def guess_type(self):
-        if ('drive' in self.qtree and
-                self.qtree['type'] != 'usb-storage' and
-                self.qtree['type'] != 'virtio-blk-device'):
+        if self.qtree['type'] == 'virtio-blk-device':
+            return QtreeDisk
+        elif ('drive' in self.qtree and
+              self.qtree['type'] != 'usb-storage' and
+              self.qtree['type'] != 'virtio-blk-pci'):
             # ^^ HOOK when usb-storage-containter is detected as disk
             return QtreeDisk
         else:


### PR DESCRIPTION
As the newest version of qemu-kvm updated the info qtree output for
virtio block device. So we need update the function to fit it.
