### PR TITLE
Bug fix: libvirt_vm.py in add_serial() method

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -503,6 +503,8 @@ class VM(virt_vm.BaseVM):
         def add_serial(help_text):
             if has_option(help_text, "serial"):
                 return " --serial pty"
+            else:
+                return ""
 
         def add_kernel_cmdline(help_text, cmdline):
             return " -append %s" % cmdline


### PR DESCRIPTION
add_serial() method returned None in case VM lacks --serial option, it caused concatenation error in make_create_command() method.

Signed-off-by: Igor Derzhavets <igor.derzhavets@ravellosystems.com>