### PR TITLE
two commits about pci passthrough

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -691,15 +691,13 @@ def pci_label_from_address(address_dict, radix=10):
         radix = 16
         return = pci_0000_08_10_0
     """
-    if not set(['domain', 'bus', 'slot', 'function']).issubset(
-            address_dict.keys()):
-        raise error.TestError("Param %s does not contain keys of "
-                              "['domain', 'bus', 'slot', 'function']." %
-                              str(address_dict))
-    domain = int(address_dict['domain'], radix)
-    bus = int(address_dict['bus'], radix)
-    slot = int(address_dict['slot'], radix)
-    function = int(address_dict['function'], radix)
+    try:
+        domain = int(address_dict['domain'], radix)
+        bus = int(address_dict['bus'], radix)
+        slot = int(address_dict['slot'], radix)
+        function = int(address_dict['function'], radix)
+    except (TypeError, KeyError), detail:
+        raise error.TestError(detail)
     pci_label = ("pci_%04x_%02x_%02x_%01x" % (domain, bus, slot, function))
     return pci_label
 


### PR DESCRIPTION
1) libvirt_xml/nodedev_xml: Add virt_functions in PCIXML class.
    
    This function had been reverted to fix conflicts.
    But it's useful and needed by pci-passthrough cases.
    so i modified it and pushed it again.
    Refer to commit e1152a766ef46e092634d8 for more details.

2)utils_test/libvirt: using try/except to deal with KeyError