### PR TITLE
escape '?' wildcard when querying qemu devices

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -82,7 +82,8 @@ class DevContainer(object):
         self.__state = -1    # -1 synchronized, 0 synchronized after hotplug
         self.__qemu_help = utils.system_output("%s -help" % qemu_binary,
                                                timeout=10, ignore_status=True)
-        self.__device_help = utils.system_output("%s -device ? 2>&1"
+        # escape the '?' otherwise it will fail if we have a single-char filename in cwd
+        self.__device_help = utils.system_output("%s -device \? 2>&1"
                                                  % qemu_binary, timeout=10,
                                                  ignore_status=True)
         self.__machine_types = utils.system_output("%s -M ?" % qemu_binary,

--- a/virttest/qemu_devices_unittest.py
+++ b/virttest/qemu_devices_unittest.py
@@ -566,7 +566,7 @@ class Container(unittest.TestCase):
         qcontainer.utils.system_output.expect_call('%s -help' % qemu_cmd,
                                                    timeout=10, ignore_status=True
                                                    ).and_return(QEMU_HELP)
-        qcontainer.utils.system_output.expect_call("%s -device ? 2>&1"
+        qcontainer.utils.system_output.expect_call("%s -device \? 2>&1"
                                                    % qemu_cmd, timeout=10,
                                                    ignore_status=True
                                                    ).and_return(QEMU_DEVICES)


### PR DESCRIPTION
qemu -device ? will fail if there is a single
char file in the cwd.

Triggered by running a command with 2&>1 which
generated a file named '1' in the cwd.

This caused us to call 'qemu -device 1' which
fails.

Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>