### PR TITLE
Adding virtio-scsi controller support for libvirt for install and import using virt-install

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -72,10 +72,12 @@ variants:
         drive_format=scsi-hd
         cd_format=scsi-cd
         scsi_hba=virtio-scsi-pci
+        libvirt_controller=virtio-scsi
     - spapr_vscsi:
         drive_format=scsi-hd
         cd_format=scsi-cd
         scsi_hba=spapr-vscsi
+        libvirt_controller=spapr-vscsi
         only pseries
     - lsi_scsi:
         no Host_RHEL


### PR DESCRIPTION
The respective controller was not getting added to the virt-install
command line and due to which the automated installation of virtio-scsi(ppc64) was not
possible, this patch addresses the automatic choosing of virtio-scsi controller
in libvirt when it is chosen as disk type and respectively for other disk types.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>