### PR TITLE
unattended_install: Change serial log name accordingly

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1057,14 +1057,7 @@ def run(test, params, env):
 
     start_time = time.time()
 
-    try:
-        serial_name = vm.serial_ports[0]
-    except IndexError:
-        raise virt_vm.VMConfigMissingError(vm.name, "isa_serial")
-
-    log_file = utils_misc.get_path(test.debugdir,
-                                   "serial-%s-%s.log" % (serial_name,
-                                                         vm.name))
+    log_file = utils_misc.get_path(test.debugdir, vm.serial_console.log_file)
     logging.debug("Monitoring serial console log for completion message: %s",
                   log_file)
     serial_log_msg = ""


### PR DESCRIPTION
Serial log file name has been changed with a random suffix in commit
b2a48d5, but the reference to this log file in unattended install has
not changed accordingly.

This patch fix this problem and remove an unnecessary check of serial
ports since this is already on in vm.create_serial_console()

Signed-off-by: Hao Liu <hliu@redhat.com>