### PR TITLE
utils_test.libvirt: Fix PEP8 W503

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -835,8 +835,8 @@ class PoolVolumeTest(object):
                 utils.run("pvremove %s" % pv, ignore_status=True)
             # These types used iscsi device
             # If we did not provide block device
-            if (pool_type in ["logical", "fs", "disk"]
-                    and device_name.count("EXAMPLE")):
+            if (pool_type in ["logical", "fs", "disk"] and
+                    device_name.count("EXAMPLE")):
                 setup_or_cleanup_iscsi(is_setup=False,
                                        emulated_image=emulated_image)
             # Used iscsi device anyway


### PR DESCRIPTION
This PEP8 error is merged because this PR is checked as pass
on Travis CI before W503 is introduced in pep8.

Signed-off-by: Hao Liu <hliu@redhat.com>