### PR TITLE
utils_test.libvirt: skip inactive pools in get_all_vol_paths

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -691,7 +691,7 @@ def preprocess(test, params, env):
             except test_setup.PolkitRulesSetupError, e:
                 logging.error("e")
             except Exception, e:
-                logging.error("Unexpected error:" % e)
+                logging.error("Unexpected error: '%s'" % e)
             libvirtd_inst.restart()
 
     if vm_type == "libvirt":

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2284,6 +2284,9 @@ def get_all_vol_paths():
     vol_path = []
     sp = libvirt_storage.StoragePool()
     for pool_name in sp.list_pools().keys():
+        if sp.list_pools()[pool_name]['State'] != "active":
+            logging.warning("Inactive pool '%s' cannot be processed" % pool_name)
+            continue
         pv = libvirt_storage.PoolVolume(pool_name)
         for path in pv.list_volumes().values():
             vol_path.append(path)


### PR DESCRIPTION
Inactive pool checking added to get_all_vol_paths() function.
Minor fix in logging outpout in preprocess() function