### PR TITLE
Add support for ARM64 (aarch64)

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -33,6 +33,11 @@ variants:
             # Device selection for the NDISTest server machine
             dp_regex_servermsgdev = VirtIO Ethernet Adapter$
             dp_regex_serversupportdev = VirtIO Ethernet Adapter #2$
+        arm64:
+            # Currently arm only supports virtio-net-device
+            nic_model = virtio-net-device
+            # Currently arm does not support msix vectors
+            enable_msix_vectors = no
     - xennet:
         # placeholder
     - spapr-vlan:
@@ -62,6 +67,13 @@ variants:
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
         image_boot=yes
+        arm64:
+            # Direct usage of virtio-blk-device (using mmio transports) is used
+            # on arm64.
+            drive_format=virtio-blk-device
+            image_boot=yes
+            cd_format = scsi-cd
+            scsi_hba = virtio-scsi-device
     - virtio_scsi:
         no WinXP
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -23,3 +23,15 @@ variants:
         usb_type = pci-ohci
         usb_type_usb1 = pci-ohci
         usb_controller_tablet1 = ohci
+    - @arm64:
+        only aarch64
+        auto_cpu_model = "no"
+        cpu_model = host
+        machine_type = virt
+        # No support for VGA yet
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
+        # Currently no USB support
+        usbs =
+        usb_devices =

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -15,3 +15,11 @@ variants:
     - @pseries:
         only ppc64
         machine_type = pseries
+        # No support for VGA yet
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
+        # No support for USB-uhci
+        usb_type = pci-ohci
+        usb_type_usb1 = pci-ohci
+        usb_controller_tablet1 = ohci

--- a/shared/unattended/CentOS-7-0.ks
+++ b/shared/unattended/CentOS-7-0.ks
@@ -48,32 +48,32 @@ prelink
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
-echo "remove rhgb quiet by grubby" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+ECHO "remove rhgb quiet by grubby"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
-echo "dhclient" > /dev/ttyS0
+ECHO "dhclient"
 dhclient
-echo "get repo" > /dev/ttyS0
+ECHO "get repo"
 wget http://fileshare.englab.nay.redhat.com/pub/section2/repo/epel/rhel-autotest.repo -O /etc/yum.repos.d/rhel-autotest.repo
-echo "yum makecache" > /dev/ttyS0
+ECHO "yum makecache"
 yum makecache
-echo "yum install -y stress" > /dev/ttyS0
+ECHO "yum install -y stress"
 yum install -y stress
-echo "chkconfig sshd on" > /dev/ttyS0
+ECHO "chkconfig sshd on"
 chkconfig sshd on
-echo "PermitRootLogin in /etc/ssh/sshd_config" > /dev/ttyS0
+ECHO "PermitRootLogin in /etc/ssh/sshd_config"
 sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config
-echo "iptables -F" > /dev/ttyS0
+ECHO "iptables -F"
 iptables -F
-echo "echo 0 > selinux/enforce" > /dev/ttyS0
+ECHO "echo 0 > selinux/enforce"
 echo 0 > /selinux/enforce
-echo "chkconfig NetworkManager on" > /dev/ttyS0
+ECHO "chkconfig NetworkManager on"
 chkconfig NetworkManager on
-echo "update ifcfg-eth0" > /dev/ttyS0
+ECHO "update ifcfg-eth0"
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
 sed -i "s/^ONBOOT=.*/ONBOOT=yes/g" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo "Disable lock cdrom udev rules" > /dev/ttyS0
+ECHO "Disable lock cdrom udev rules"
 sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/CentOS-7-0.ks
+++ b/shared/unattended/CentOS-7-0.ks
@@ -1,11 +1,10 @@
 install
 KVM_TEST_MEDIUM
-graphical
 poweroff
 lang en_US.UTF-8
 keyboard us
 network --onboot yes --device eth0 --bootproto dhcp
-rootpw redhat
+rootpw 123456
 firewall --enabled --ssh
 selinux --enforcing
 timezone --utc America/New_York

--- a/shared/unattended/Fedora-10.ks
+++ b/shared/unattended/Fedora-10.ks
@@ -25,12 +25,12 @@ poweroff
 ntpdate
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'

--- a/shared/unattended/Fedora-10.ks
+++ b/shared/unattended/Fedora-10.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US.UTF-8
 keyboard us
 key --skip
@@ -15,7 +14,6 @@ bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
 zerombr
 clearpart --all --initlabel
 autopart
-reboot
 poweroff
 
 %packages

--- a/shared/unattended/Fedora-11.ks
+++ b/shared/unattended/Fedora-11.ks
@@ -25,13 +25,13 @@ ntpdate
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-11.ks
+++ b/shared/unattended/Fedora-11.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp

--- a/shared/unattended/Fedora-12.ks
+++ b/shared/unattended/Fedora-12.ks
@@ -25,13 +25,13 @@ ntpdate
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-12.ks
+++ b/shared/unattended/Fedora-12.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp

--- a/shared/unattended/Fedora-13.ks
+++ b/shared/unattended/Fedora-13.ks
@@ -25,13 +25,13 @@ ntpdate
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-13.ks
+++ b/shared/unattended/Fedora-13.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp

--- a/shared/unattended/Fedora-14.ks
+++ b/shared/unattended/Fedora-14.ks
@@ -26,13 +26,13 @@ dmidecode
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-14.ks
+++ b/shared/unattended/Fedora-14.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp

--- a/shared/unattended/Fedora-15.ks
+++ b/shared/unattended/Fedora-15.ks
@@ -27,13 +27,13 @@ dmidecode
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-15.ks
+++ b/shared/unattended/Fedora-15.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp

--- a/shared/unattended/Fedora-16.ks
+++ b/shared/unattended/Fedora-16.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp

--- a/shared/unattended/Fedora-16.ks
+++ b/shared/unattended/Fedora-16.ks
@@ -25,13 +25,13 @@ autopart
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-17.ks
+++ b/shared/unattended/Fedora-17.ks
@@ -26,13 +26,13 @@ dmidecode
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-17.ks
+++ b/shared/unattended/Fedora-17.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp --hostname atest-guest

--- a/shared/unattended/Fedora-18.ks
+++ b/shared/unattended/Fedora-18.ks
@@ -26,7 +26,8 @@ dmidecode
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
@@ -34,6 +35,5 @@ iptables -F
 systemctl mask tmp.mount
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-18.ks
+++ b/shared/unattended/Fedora-18.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp --hostname atest-guest

--- a/shared/unattended/Fedora-19.ks
+++ b/shared/unattended/Fedora-19.ks
@@ -25,7 +25,8 @@ dmidecode
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
@@ -33,6 +34,5 @@ iptables -F
 systemctl mask tmp.mount
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-19.ks
+++ b/shared/unattended/Fedora-19.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp --hostname atest-guest

--- a/shared/unattended/Fedora-20.ks
+++ b/shared/unattended/Fedora-20.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp --hostname atest-guest

--- a/shared/unattended/Fedora-20.ks
+++ b/shared/unattended/Fedora-20.ks
@@ -24,7 +24,8 @@ autopart
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
@@ -32,6 +33,5 @@ iptables -F
 systemctl mask tmp.mount
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-8.ks
+++ b/shared/unattended/Fedora-8.ks
@@ -24,12 +24,12 @@ reboot
 ntpdate
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'

--- a/shared/unattended/Fedora-8.ks
+++ b/shared/unattended/Fedora-8.ks
@@ -1,7 +1,7 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
+poweroff
 lang en_US.UTF-8
 keyboard us
 key --skip
@@ -15,7 +15,6 @@ bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
 zerombr
 clearpart --all --initlabel
 autopart
-reboot
 
 %packages
 @base

--- a/shared/unattended/Fedora-9.ks
+++ b/shared/unattended/Fedora-9.ks
@@ -1,7 +1,7 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
+poweroff
 lang en_US.UTF-8
 keyboard us
 key --skip
@@ -15,8 +15,6 @@ bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
 zerombr
 clearpart --all --initlabel
 autopart
-reboot
-poweroff
 
 %packages
 @base

--- a/shared/unattended/Fedora-9.ks
+++ b/shared/unattended/Fedora-9.ks
@@ -25,12 +25,12 @@ poweroff
 ntpdate
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'

--- a/shared/unattended/Fedora-test.ks
+++ b/shared/unattended/Fedora-test.ks
@@ -27,13 +27,13 @@ sg3_utils
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/Fedora-test.ks
+++ b/shared/unattended/Fedora-test.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US
 keyboard us
 network --bootproto dhcp --hostname atest-guest

--- a/shared/unattended/JeOS-19.ks
+++ b/shared/unattended/JeOS-19.ks
@@ -170,6 +170,7 @@ net-tools
 %end
 
 %post
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
@@ -202,7 +203,6 @@ yum clean all
 mkdir -p /var/log/journal
 dd if=/dev/zero of=/fill-up-file bs=1M
 rm -f /fill-up-file
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
-echo "OS install is completed" > /dev/ttyS0
+ECHO 'Post set up finished'
+ECHO "OS install is completed"
 %end

--- a/shared/unattended/JeOS-19.ks
+++ b/shared/unattended/JeOS-19.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US.UTF-8
 keyboard us
 network --onboot yes --device eth0 --bootproto dhcp --noipv6 --hostname atest-guest

--- a/shared/unattended/JeOS-20.ks
+++ b/shared/unattended/JeOS-20.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US.UTF-8
 keyboard us
 network --onboot yes --device eth0 --bootproto dhcp --noipv6 --hostname atest-guest

--- a/shared/unattended/JeOS-20.ks
+++ b/shared/unattended/JeOS-20.ks
@@ -171,6 +171,7 @@ net-tools
 %end
 
 %post
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
@@ -203,7 +204,6 @@ yum clean all
 mkdir -p /var/log/journal
 dd if=/dev/zero of=/fill-up-file bs=1M
 rm -f /fill-up-file
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
-echo "OS install is completed" > /dev/ttyS0
+ECHO 'Post set up finished'
+ECHO "OS install is completed"
 %end

--- a/shared/unattended/RHEL-3-series.ks
+++ b/shared/unattended/RHEL-3-series.ks
@@ -28,13 +28,13 @@ ntp
 redhat-lsb
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 cd home
 echo "s0:2345:respawn:/sbin/agetty -L -f /etc/issue 115200 ttyS0 vt100" >> /etc/inittab
 echo "ttyS0" >> /etc/securetty
 dhclient
 chkconfig sshd on
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-3-series.ks
+++ b/shared/unattended/RHEL-3-series.ks
@@ -12,7 +12,7 @@ firstboot --disable
 bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
 clearpart --all --initlabel
 autopart
-reboot
+poweroff
 mouse generic3ps/2
 skipx
 

--- a/shared/unattended/RHEL-4-series.ks
+++ b/shared/unattended/RHEL-4-series.ks
@@ -29,7 +29,8 @@ ntp
 redhat-lsb
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 grubby --args="divider=10" --update-kernel=$(grubby --default-kernel)
 cd home
@@ -48,6 +49,5 @@ make
 make install
 ln -sf /usr/local/bin/python /usr/bin/python
 sleep 10
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-5-series.ks
+++ b/shared/unattended/RHEL-5-series.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US.UTF-8
 keyboard us
 key --skip

--- a/shared/unattended/RHEL-5-series.ks
+++ b/shared/unattended/RHEL-5-series.ks
@@ -47,7 +47,8 @@ libaio-devel
 NetworkManager
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 grubby --args="divider=10 crashkernel=128M@16M" --update-kernel=$(grubby --default-kernel)
 dhclient
@@ -56,6 +57,5 @@ chkconfig NetworkManager on
 iptables -F
 echo 0 > /selinux/enforce
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-6-series.ks
+++ b/shared/unattended/RHEL-6-series.ks
@@ -62,7 +62,8 @@ glibc-static
 scsi-target-utils
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
@@ -70,6 +71,5 @@ iptables -F
 echo 0 > /selinux/enforce
 chkconfig NetworkManager on
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-6-spice.ks
+++ b/shared/unattended/RHEL-6-spice.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US.UTF-8
 keyboard us
 key --skip

--- a/shared/unattended/RHEL-6-spice.ks
+++ b/shared/unattended/RHEL-6-spice.ks
@@ -52,7 +52,8 @@ totem
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
@@ -60,8 +61,6 @@ iptables -F
 echo 0 > /selinux/enforce
 chkconfig NetworkManager on
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
 cat > '/etc/gdm/custom.conf' << EOF
 [daemon]
 AutomaticLogin=test
@@ -80,4 +79,5 @@ modprobe snd-mixer-oss
 modprobe snd-seq-oss
 EOF
 chmod +x /etc/rc.modules
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-6.3.ks
+++ b/shared/unattended/RHEL-6.3.ks
@@ -1,7 +1,6 @@
 install
 KVM_TEST_MEDIUM
 text
-reboot
 lang en_US.UTF-8
 keyboard us
 key --skip

--- a/shared/unattended/RHEL-6.3.ks
+++ b/shared/unattended/RHEL-6.3.ks
@@ -45,7 +45,8 @@ totem
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
@@ -53,8 +54,6 @@ iptables -F
 echo 0 > /selinux/enforce
 chkconfig NetworkManager on
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
 cat > '/etc/gdm/custom.conf' << EOF
 [daemon]
 AutomaticLogin=test
@@ -73,4 +72,5 @@ modprobe snd-mixer-oss
 modprobe snd-seq-oss
 EOF
 chmod +x /etc/rc.modules
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -48,29 +48,29 @@ prelink
 %end
 
 %post
-echo "OS install is completed" > /dev/ttyS0
-echo "remove rhgb quiet by grubby" > /dev/ttyS0
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+ECHO "remove rhgb quiet by grubby"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
-echo "dhclient" > /dev/ttyS0
+ECHO "dhclient"
 dhclient
-echo "get repo" > /dev/ttyS0
+ECHO "get repo"
 wget http://fileshare.englab.nay.redhat.com/pub/section2/repo/epel/rhel-autotest.repo -O /etc/yum.repos.d/rhel-autotest.repo
-echo "yum makecache" > /dev/ttyS0
+ECHO "yum makecache"
 yum makecache
-echo "yum install -y stress" > /dev/ttyS0
+ECHO "yum install -y stress"
 yum install -y stress
-echo "chkconfig sshd on" > /dev/ttyS0
+ECHO "chkconfig sshd on"
 chkconfig sshd on
-echo "iptables -F" > /dev/ttyS0
+ECHO "iptables -F"
 iptables -F
-echo "echo 0 > selinux/enforce" > /dev/ttyS0
+ECHO "echo 0 > selinux/enforce"
 echo 0 > /selinux/enforce
-echo "chkconfig NetworkManager on" > /dev/ttyS0
+ECHO "chkconfig NetworkManager on"
 chkconfig NetworkManager on
-echo "update ifcfg-eth0" > /dev/ttyS0
+ECHO "update ifcfg-eth0"
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
-echo "Disable lock cdrom udev rules" > /dev/ttyS0
+ECHO "Disable lock cdrom udev rules"
 sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
-echo 'Post set up finished' > /dev/ttyS0
-echo Post set up finished > /dev/hvc0
+ECHO 'Post set up finished'
 %end

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -1,11 +1,10 @@
 install
 KVM_TEST_MEDIUM
-graphical
 poweroff
 lang en_US.UTF-8
 keyboard us
 network --onboot yes --device eth0 --bootproto dhcp
-rootpw redhat
+rootpw --plaintext 123456
 firewall --enabled --ssh
 selinux --enforcing
 timezone --utc America/New_York

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -810,7 +810,7 @@ def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
 
     if restore_image:
         logging.info("")
-        step += 2
+        step += 1
         logging.info("%s - Verifying (and possibly downloading) guest image",
                      step)
         for os_info in get_guest_os_info_list(test_name, guest_os):

--- a/virttest/qemu_devices/qbuses.py
+++ b/virttest/qemu_devices/qbuses.py
@@ -422,6 +422,20 @@ class QStrictCustomBus(QSparseBus):
         self._set_device_props(device, addr)
 
 
+class QNoAddrCustomBus(QSparseBus):
+
+    """
+    This is the opposite of QStrictCustomBus. Even when addr is set it's not
+    updated in the device's params.
+    """
+
+    def _set_device_props(self, device, addr):
+        pass
+
+    def _update_device_props(self, device, addr):
+        pass
+
+
 class QUSBBus(QSparseBus):
 
     """

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -19,6 +19,7 @@ from utils import (DeviceError, DeviceHotplugError, DeviceInsertError,
 import os
 import qbuses
 import qdevices
+import shutil
 
 
 #
@@ -817,6 +818,42 @@ class DevContainer(object):
                                )
             return devices
 
+        def machine_aarch64(cmd=False):
+            """
+            aarch64 (arm64) doesn't support PCI bus, only MMIO transports.
+            Also it requires pflash for EFI boot.
+            :param cmd: If set uses "-M $cmd" to force this machine type
+            :return: List of added devices (including default buses)
+            """
+            logging.warn('Support for aarch64 is highly experimental!')
+            devices = []
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd))
+            # EFI pflash
+            aavmf_code = ("-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,"
+                          "if=pflash,format=raw,unit=0,readonly=on")
+            devices.append(qdevices.QStringDevice('AAVMF_CODE',
+                                                  cmdline=aavmf_code))
+            aavmf_vars = os.path.join(data_dir.DATA_DIR, 'images',
+                                      '%s_AAVMF_VARS.fd' % self.vmname)
+            if not os.path.exists(aavmf_vars):
+                shutil.copy2('/usr/share/AAVMF/AAVMF_VARS.fd', aavmf_vars)
+            aavmf_vars = ("-drive file=%s,if=pflash,format=raw,unit=1"
+                          % aavmf_vars)
+            devices.append(qdevices.QStringDevice('AAVMF_VARS',
+                                                  cmdline=aavmf_vars))
+            # Add virtio-bus
+            # TODO: Currently this uses QNoAddrCustomBus and does not
+            # set the device's properties. This means that the qemu qtree
+            # and autotest's representations are completelly different and
+            # can't be used.
+            bus = qbuses.QNoAddrCustomBus('bus', [['addr'], [32]],
+                                          'virtio-mmio-bus', 'virtio-bus',
+                                          'virtio-mmio-bus')
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
+                                                  child_bus=bus,
+                                                  aobject="virtio-mmio-bus"))
+            return devices
+
         def machine_other(cmd=False):
             """
             isapc or unknown machine type. This type doesn't add any default
@@ -843,6 +880,8 @@ class DevContainer(object):
                     cmd = ""
                 if 'q35' in machine_type:   # Q35 + ICH9
                     devices = machine_q35(cmd)
+                elif arch.ARCH == 'aarch64':
+                    devices = machine_aarch64(cmd)
                 elif 'isapc' not in machine_type:   # i440FX
                     devices = machine_i440FX(cmd)
                 else:   # isapc (or other)
@@ -1050,8 +1089,8 @@ class DevContainer(object):
         :param num_queues: performace option for virtio-scsi-pci
         :param bus_extra_params: options want to add to virtio-scsi-pci bus
         """
-        def define_hbas(qtype, atype, bus, unit, port, qbus, addr_spec=None,
-                        pci_bus='pci.0', num_queues=None,
+        def define_hbas(qtype, atype, bus, unit, port, qbus, pci_bus,
+                        addr_spec=None, num_queues=None,
                         bus_extra_params=None):
             """
             Helper for creating HBAs of certain type.
@@ -1082,14 +1121,14 @@ class DevContainer(object):
                             bus_params[key] = value
                     if addr_spec:
                         dev = qdevices.QDevice(params=bus_params,
-                                               parent_bus={'aobject': pci_bus},
+                                               parent_bus=pci_bus,
                                                child_bus=qbus(busid=bus_name,
                                                               bus_type=qtype,
                                                               addr_spec=addr_spec,
                                                               atype=atype))
                     else:
                         dev = qdevices.QDevice(params=bus_params,
-                                               parent_bus={'aobject': pci_bus},
+                                               parent_bus=pci_bus,
                                                child_bus=qbus(busid=bus_name))
                     devices.append(dev)
                 bus = _hba % bus
@@ -1152,6 +1191,8 @@ class DevContainer(object):
                          "(disk %s)", name)
             bus = none_or_int(pci_addr)
 
+        pci_bus = {'aobject': pci_bus}
+
         #
         # HBA
         # fmt: ide, scsi, virtio, scsi-hd, ahci, usb1,2,3 + hba
@@ -1169,10 +1210,10 @@ class DevContainer(object):
                 # In case we hotplug, lsi wasn't added during the startup hook
                 if arch.ARCH == 'ppc64':
                     _ = define_hbas('SCSI', 'spapr-vscsi', None, None, None,
-                                    qbuses.QSCSIBus, [8, 16384])
+                                    qbuses.QSCSIBus, pci_bus, [8, 16384])
                 else:
                     _ = define_hbas('SCSI', 'lsi53c895a', None, None, None,
-                                    qbuses.QSCSIBus, [8, 16384])
+                                    qbuses.QSCSIBus, pci_bus, [8, 16384])
                 devices.extend(_[0])
         elif fmt == "ide":
             if bus:
@@ -1182,7 +1223,7 @@ class DevContainer(object):
             dev_parent = {'type': 'IDE', 'atype': 'ide'}
         elif fmt == "ahci":
             devs, bus, dev_parent = define_hbas('IDE', 'ahci', bus, unit, port,
-                                                qbuses.QAHCIBus)
+                                                qbuses.QAHCIBus, pci_bus)
             devices.extend(devs)
         elif fmt.startswith('scsi-'):
             if not scsi_hba:
@@ -1194,9 +1235,12 @@ class DevContainer(object):
                 addr_spec = [8, 16384]
             elif scsi_hba == 'virtio-scsi-pci':
                 addr_spec = [256, 16384]
+            elif scsi_hba == 'virtio-scsi-device':
+                addr_spec = [256, 16384]
+                pci_bus = {'type': 'virtio-bus'}
             _, bus, dev_parent = define_hbas('SCSI', scsi_hba, bus, unit, port,
-                                             qbuses.QSCSIBus, addr_spec,
-                                             num_queues=num_queues,
+                                             qbuses.QSCSIBus, pci_bus,
+                                             addr_spec, num_queues=num_queues,
                                              bus_extra_params=bus_extra_params)
             devices.extend(_)
         elif fmt in ('usb1', 'usb2', 'usb3'):
@@ -1211,7 +1255,9 @@ class DevContainer(object):
             elif fmt == 'usb3':
                 dev_parent = {'type': 'xhci'}
         elif fmt == 'virtio':
-            dev_parent = {'aobject': pci_bus}
+            dev_parent = pci_bus
+        elif fmt == 'virtio-blk-device':
+            dev_parent = {'type': 'virtio-bus'}
         else:
             dev_parent = {'type': fmt}
 
@@ -1274,7 +1320,7 @@ class DevContainer(object):
                 devices[-1].parent_bus = ({'type': fmt},)
             elif fmt == 'virtio':
                 devices[-1].set_param('addr', pci_addr)
-                devices[-1].parent_bus = ({'aobject': pci_bus},)
+                devices[-1].parent_bus = (pci_bus,)
             if not media == 'cdrom':
                 logging.warn("Using -drive fmt=xxx for %s is unsupported "
                              "method, false errors might occur.", name)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -417,7 +417,8 @@ class VM(virt_vm.BaseVM):
             return cmd
 
         def add_serial(devices, name, filename):
-            if arch.ARCH == 'ppc64' or not devices.has_option("chardev"):
+            if (arch.ARCH in ('ppc64', 'aarch64') or
+                    not devices.has_option("chardev")):
                 return " -serial unix:'%s',server,nowait" % filename
 
             serial_id = "serial_id_%s" % name
@@ -540,7 +541,9 @@ class VM(virt_vm.BaseVM):
                 # libvirt gains the pci_slot, free_pci_addr here,
                 # value by parsing the xml file, i.e. counting all the
                 # pci devices and store the number.
-                if model != 'spapr-vlan':
+                if model == 'virtio-net-device':
+                    dev.parent_bus = {'type': 'virtio-bus'}
+                elif model != 'spapr-vlan':
                     dev.parent_bus = pci_bus
                     dev.set_param('addr', pci_addr)
                 if nic_extra_params:


### PR DESCRIPTION
This pull request is based on https://github.com/autotest/virt-test/pull/2012 please review only the last commit here.

__BEWARE: You need the latest qemu to test this version as it requires patches for UEFI to support `-kernel` and loading of gzipped kernels (I have a version which uses the unpacked kernel in my tree, but as this support is upstream I decided not to use include it here)__

It defines aarch64 (arm64) machine. Currently qemu on arm64 doesn't
support any buses except the 'virtio-bus', thus more intrusive changes
were necessarily.

1) machine_type=virt, cpu_model=host, vga=none, usbs=none
2) instead of "virtio-*-pci" devices, "virtio-*-device" are used
   without the possibility of setting address.
3) AAVMF EFI bios is copied from installed location (/usr/share/AAVMF)
4) When provided install CD doesn't contain 'isolinux' directory,
   non-bootable CD is created. This works fine with UEFI boot.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>