### PR TITLE
client.shared.openvswitch: Fix version parsing

### DIFF
--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -150,12 +150,13 @@ class OpenVSwitchControl(object):
         """
         :param version: (int) Converted from version string 1.4.0 => int 140
         """
-        if (isinstance(version, int)):
+        if isinstance(version, int):
             return version
         try:
-            int_ver = int(version.replace(".", ""))
+            a = re.findall('^(\d+)\.?(\d+)\.?(\d+)\-?', version)[0]
+            int_ver = ''.join(a)
         except:
-            raise error.AutotestError("Wrong version format '%s'" % (version))
+            raise error.AutotestError("Wrong version format '%s'" % version)
         return int_ver
 
     @classmethod


### PR DESCRIPTION
With this, we'll be able to handle versions like
2.3.1-git3282e51 correctly.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>