### PR TITLE
virttest.qemu_vm: Fix migration for RHEL7 host

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3361,9 +3361,10 @@ class VM(virt_vm.BaseVM):
                         continue
                     # spice_migrate_info requires host_ip, dest_port
                     # client_migrate_info also requires protocol
-                    cmdline = "%s hostname=%s" % (command, host_ip)
+                    cmdline = "%s " % (command)
                     if command == "client_migrate_info":
-                        cmdline += " ,protocol=%s" % self.params['display']
+                        cmdline += " protocol=%s," % self.params['display']
+                    cmdline += " hostname=%s" % (host_ip)
                     if dest_port:
                         cmdline += ",port=%s" % dest_port
                     if dest_tls_port:


### PR DESCRIPTION
The command sent to qemu monitor for RHEL7 host 
during migration of RHEL6 guests was incorrect. 
"__com.redhat_spice_migrate_info", "spice_migrate_info" 
and "client_migrate_info" are the commands sent to 
qemu monitor during migration. While running on
 RHEL7 host, the first 2 commands are coming up
 as not supported and "client_migrate_info" is the 
command that is sent and the command is
 framed incorrectly for RHEL7. 

Reviewed By: Swapna Krishnan <skrishna@redhat.com>