### PR TITLE
capability_xml: Update get_os_arch_machine_map() to return more info

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -594,7 +594,7 @@ class VM(virt_vm.BaseVM):
         arch_name = params.get("vm_arch_name", utils.get_current_kernel_arch())
         capabs = libvirt_xml.CapabilityXML()
         try:
-            support_machine_type = capabs.os_arch_machine_map[hvm_or_pv][arch_name]
+            support_machine_type = capabs.guest_capabilities[hvm_or_pv][arch_name]['machine']
         except KeyError, detail:
             if detail.args[0] == hvm_or_pv:
                 raise KeyError("No libvirt support for %s virtualization, "

--- a/virttest/libvirt_xml_unittest.py
+++ b/virttest/libvirt_xml_unittest.py
@@ -547,19 +547,26 @@ class TestLibvirtXML(LibvirtXMLTestBase):
                           lvxml.__delitem__,
                           'uuid')
 
-    def test_os_arch_machine_map(self):
+    def test_guest_capabilities(self):
         lvxml = self._from_scratch()
-        expected = {'hvm': {'x86_64': ['rhel6.3.0', 'pc']}}
-        test_oamm = lvxml.os_arch_machine_map
-        self.assertEqual(test_oamm, expected)
-        test_oamm = lvxml['os_arch_machine_map']
-        self.assertEqual(test_oamm, expected)
+        expected_os = 'hvm'
+        expected_arch = 'x86_64'
+        expected_guest = {'wordsize': '64',
+                          'emulator': '/usr/libexec/qemu-kvm',
+                          'machine': ['rhel6.3.0', 'pc'],
+                          'domain_qemu': {},
+                          'domain_kvm': {'emulator': '/usr/libexec/qemu-kvm'}}
+        expected = {expected_os: {expected_arch: expected_guest}}
+        test_guest_capa = lvxml.guest_capabilities
+        self.assertEqual(test_guest_capa, expected)
+        test_guest_capa = lvxml['guest_capabilities']
+        self.assertEqual(test_guest_capa, expected)
         self.assertRaises(xcepts.LibvirtXMLForbiddenError,
                           lvxml.__setattr__,
-                          'os_arch_machine_map', 'foobar')
+                          'guest_capabilities', 'foobar')
         self.assertRaises(xcepts.LibvirtXMLForbiddenError,
                           lvxml.__delitem__,
-                          'os_arch_machine_map')
+                          'guest_capabilities')
 
 
 class TestVMXML(LibvirtXMLTestBase):


### PR DESCRIPTION
1. Update the function to get guest wordsize, emulator, machine and
domain that the host supported
2. Also rename the function to get_guest_capabilities()

Signed-off-by: Yanbing Du <ydu@redhat.com>