### PR TITLE
CentOS 7.0: Fix kickstart file for unattended install

### DIFF
--- a/shared/unattended/CentOS-7-0.ks
+++ b/shared/unattended/CentOS-7-0.ks
@@ -71,6 +71,7 @@ echo "chkconfig NetworkManager on" > /dev/ttyS0
 chkconfig NetworkManager on
 echo "update ifcfg-eth0" > /dev/ttyS0
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+sed -i "s/^ONBOOT=.*/ONBOOT=yes/g" /etc/sysconfig/network-scripts/ifcfg-eth0
 echo "Disable lock cdrom udev rules" > /dev/ttyS0
 sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
 echo 'Post set up finished' > /dev/ttyS0


### PR DESCRIPTION
   Enable dhclient on boot for eth0 network interface.

Signed-off-by: Igor Derzhavets <igor.derzhavets@ravellosystems.com>