### PR TITLE
JeOS 21

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/21.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/21.x86_64.cfg
@@ -1,0 +1,20 @@
+- 21.x86_64:
+    image_name = images/f21-64
+    vm_arch_name = x86_64
+    os_variant = fedora21
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'repo=cdrom:/dev/disk/by-label/Fedora-S-21-x86_64'
+        kernel_params += ' ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0'
+        unattended_file = unattended/Fedora-21.ks
+        cdrom_unattended = images/f21-64/ks.iso
+        kernel = images/f21-64/vmlinuz
+        initrd = images/f21-64/initrd.img
+        syslog_server_proto = tcp
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-DVD-x86_64-21.iso
+        md5sum_cd1 = 09a6b5d5aedac0e2827bdc78d2e18a73
+        md5sum_1m_cd1 = f65cf0a7263cd9b91ef7be0b8ea9ab1b
+    unattended_install.url:
+        kernel_params = 'ks=cdrom:/dev/disk/by-label/CDROM nicdelay=60 console=ttyS0,115200 console=tty0'
+        url = http://dl.fedoraproject.org/pub/fedora/linux/releases/21/Server/x86_64/os/

--- a/shared/cfg/guest-os/Linux/JeOS/21.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/JeOS/21.x86_64.cfg
@@ -1,0 +1,23 @@
+- 21.x86_64:
+    image_name = images/jeos-21-64
+    os_variant = fedora21
+    vm_arch_name = x86_64
+    shell_prompt = "^\[.*\][\#\$]\s*$"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'repo=cdrom:/dev/disk/by-label/Fedora-S-21-x86_64'
+        kernel_params += ' ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0'
+        boot_path = "images/pxeboot"
+        anaconda_log = "yes"
+        unattended_file = unattended/JeOS-21.ks
+        cdrom_unattended = images/jeos-21-64/ks.iso
+        kernel = images/jeos-21-64/vmlinuz
+        initrd = images/jeos-21-64/initrd.img
+        syslog_server_proto = tcp
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-DVD-x86_64-21.iso
+        md5sum_cd1 = 09a6b5d5aedac0e2827bdc78d2e18a73
+        md5sum_1m_cd1 = f65cf0a7263cd9b91ef7be0b8ea9ab1b
+    unattended_install.url:
+        kernel_params = 'ks=cdrom:/dev/disk/by-label/CDROM nicdelay=60 console=ttyS0,115200 console=tty0'
+        url = http://dl.fedoraproject.org/pub/fedora/linux/releases/21/Server/x86_64/os/

--- a/shared/downloads/jeos-21-64.ini
+++ b/shared/downloads/jeos-21-64.ini
@@ -1,0 +1,6 @@
+[jeos-21-64]
+title = JeOS 21 x86_64
+url = http://lmr.fedorapeople.org/jeos/jeos-21-64.qcow2.7z
+sha1_url = http://lmr.fedorapeople.org/jeos/SHA1SUM_JEOS21
+destination = images/jeos-21-64.qcow2.7z
+destination_uncompressed = images/jeos-21-64.qcow2

--- a/shared/unattended/Fedora-21.ks
+++ b/shared/unattended/Fedora-21.ks
@@ -1,0 +1,37 @@
+install
+KVM_TEST_MEDIUM
+text
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+autopart
+
+%packages
+@standard
+@development-tools
+%end
+
+%post
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+ECHO 'Post set up finished'
+%end

--- a/shared/unattended/JeOS-21.ks
+++ b/shared/unattended/JeOS-21.ks
@@ -1,0 +1,182 @@
+install
+KVM_TEST_MEDIUM
+text
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+autopart
+
+%packages
+gpgme
+hardlink
+dmidecode
+ethtool
+tcpdump
+tar
+bzip2
+pciutils
+usbutils
+bind-utils
+net-tools
+patch
+rsync
+-yum-utils
+-cryptsetup
+-dump
+-mlocate
+-stunnel
+-rng-tools
+-ntfs-3g
+-sos
+-jwhois
+-fedora-release-notes
+-pam_pkcs11
+-wireless-tools
+-rdist
+-mdadm
+-dmraid
+-ftp
+-system-config-network-tui
+-pam_krb5
+-nano
+-nc
+-PackageKit-yum-plugin
+-btrfs-progs
+-ypbind
+-yum-presto
+-microcode_ctl
+-finger
+-krb5-workstation
+-ntfsprogs
+-iptstate
+-fprintd-pam
+-irqbalance
+-dosfstools
+-mcelog
+-smartmontools
+-lftp
+-unzip
+-rsh
+-telnet
+-setuptool
+-bash-completion
+-pinfo
+-rdate
+-system-config-firewall-tui
+-system-config-firewall-base
+-nfs-utils
+-words
+-cifs-utils
+-prelink
+-wget
+-dos2unix
+-passwdqc
+-coolkey
+-symlinks
+-pm-utils
+-bridge-utils
+-zip
+-numactl
+-mtr
+-sssd
+-pcmciautils
+-tree
+-hunspell
+-irda-utils
+-time
+-man-pages
+-yum-langpacks
+-talk
+-wpa_supplicant
+-slang
+-authconfig
+-newt
+-newt-python
+-ntsysv
+-libnl3
+-tcp_wrappers
+-quota
+-libpipeline
+-man-db
+-groff
+-less
+-plymouth-core-libs
+-plymouth
+-plymouth-scripts
+-libgudev1
+-ModemManager
+-NetworkManager-glib
+-selinux-policy
+-selinux-policy-targeted
+-crontabs
+-cronie
+-cronie-anacron
+-cyrus-sasl
+-sendmail
+-netxen-firmware
+-linux-firmware
+-libdaemon
+-avahi-autoipd
+-libpcap
+-ppp
+-libsss_sudo
+-sudo
+-at
+-psacct
+-parted
+-passwd
+-tmpwatch
+-bc
+-acl
+-attr
+-traceroute
+-mailcap
+-quota-nls
+-mobile-broadband-provider-info
+-audit
+-e2fsprogs-libs
+-e2fsprogs
+-biosdevname
+-dbus-glib
+-libdrm
+-setserial
+-lsof
+-ed
+-cyrus-sasl-plain
+-dnsmasq
+-system-config-firewall-base
+-hesiod
+-libpciaccess
+-policycoreutils
+-m4
+-checkpolicy
+-procmail
+-libuser
+-polkit
+-rsyslog
+%end
+
+%post
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+ECHO 'Post set up finished'
+%end

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -12,6 +12,6 @@ def get_default_guest_os_info():
 
     detected = distro.detect()
     if detected.name == 'fedora' and int(detected.version) >= 20:
-        os_info = {'asset': 'jeos-20-64', 'variant': 'JeOS.20'}
+        os_info = {'asset': 'jeos-21-64', 'variant': 'JeOS.21'}
 
     return os_info


### PR DESCRIPTION
Update JeOS, and make the necessary changes to make it the default JeOS in recent versions of Fedora.

I have some fixes I had to make to virt-test to make unattended install to actually work again, will have to publish them separately. I don't have the time to update the alternate arch versions of Fedora 21, so I'll have to trust the community to help finish this up.