### PR TITLE
Unattended fixes 2015-03-03

### DIFF
--- a/run
+++ b/run
@@ -861,11 +861,10 @@ class VirtTestApp(object):
                 default_userspace_paths = ["/usr/bin/virt-v2v"]
 
             if not self.options.config:
-                download_image = not self.options.no_downloads
-                keep_image = not self.options.keep_image
+                restore_image = not(self.options.no_downloads or
+                                    self.options.keep_image)
             else:
-                download_image = False
-                keep_image = False
+                restore_image = False
 
             test_dir = data_dir.get_backend_dir(self.options.type)
             bootstrap.bootstrap(test_name=self.options.type, test_dir=test_dir,
@@ -874,9 +873,8 @@ class VirtTestApp(object):
                                 check_modules=check_modules,
                                 online_docs_url=online_docs_url,
                                 interactive=interactive,
-                                download_image=download_image,
                                 selinux=self.options.selinux_setup,
-                                restore_image=keep_image,
+                                restore_image=restore_image,
                                 verbose=self.options.verbose,
                                 update_providers=self.options.update_providers,
                                 guest_os=(self.options.guest_os or

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -718,7 +718,7 @@ def verify_selinux(datadir, imagesdir, isosdir, tmpdir,
 
 def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
               check_modules, online_docs_url, restore_image=False,
-              download_image=True, interactive=True, selinux=False,
+              interactive=True, selinux=False,
               verbose=False, update_providers=False,
               guest_os=defaults.DEFAULT_GUEST_OS):
     """
@@ -808,7 +808,7 @@ def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
         create_subtests_cfg(test_name)
         create_guest_os_cfg(test_name)
 
-    if download_image or restore_image:
+    if restore_image:
         logging.info("")
         step += 2
         logging.info("%s - Verifying (and possibly downloading) guest image",

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -667,11 +667,6 @@ def bootstrap_tests(options):
         check_modules = None
     online_docs_url = "https://github.com/autotest/virt-test/wiki"
 
-    if not options.config:
-        restore_image = not options.keep_image
-    else:
-        restore_image = False
-
     os_info = defaults.get_default_guest_os_info()
 
     kwargs = {'test_name': options.type,
@@ -680,9 +675,9 @@ def bootstrap_tests(options):
               'default_userspace_paths': None,
               'check_modules': check_modules,
               'online_docs_url': online_docs_url,
-              'download_image': not options.no_downloads,
               'selinux': options.selinux_setup,
-              'restore_image': restore_image,
+              'restore_image': not(options.no_downloads or
+                                   options.keep_image),
               'interactive': False,
               'update_providers': options.update_providers,
               'guest_os': options.guest_os or os_info['variant']}

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1057,7 +1057,14 @@ def run(test, params, env):
 
     start_time = time.time()
 
-    log_file = utils_misc.get_path(test.debugdir, vm.serial_console.log_file)
+    try:
+        serial_name = vm.serial_ports[0]
+    except IndexError:
+        raise virt_vm.VMConfigMissingError(vm.name, "isa_serial")
+
+    log_file = utils_misc.get_path(test.debugdir,
+                                   "serial-%s-%s.log" % (serial_name,
+                                                         vm.name))
     logging.debug("Monitoring serial console log for completion message: %s",
                   log_file)
     serial_log_msg = ""


### PR DESCRIPTION
This reverts the commit 93b821d and adds @ldoktor's 'Change logic of download_image and restore_image'. Both were necessary for me to successfully install JeOS 21 using `virt-test`.