### PR TITLE
libvirt_xml.vm_xml: fix typo that leads to attribute error

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1389,7 +1389,7 @@ class VMCPUXML(base.LibvirtXMLBase):
                                  libvirtxml=self,
                                  parent_xpath='numa',
                                  marshal_from=self.marshal_from_cell,
-                                 marshal_to=self.mashal_to_cell)
+                                 marshal_to=self.marshal_to_cell)
         # This will skip self.get_feature_list() defined below
         accessors.AllForbidden(property_name="feature_list",
                                libvirtxml=self)


### PR DESCRIPTION
The commit e310f272f9 introduces this problem.
The error message as following,
  AttributeError: 'VMCPUXML' object has no attribute 'mashal_to_cell'