### PR TITLE
Adding virtio-scsi controller support for libvirt for install and import...

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -84,10 +84,12 @@ variants:
         drive_format=scsi-hd
         cd_format=scsi-cd
         scsi_hba=virtio-scsi-pci
+        libvirt_controller=virtio-scsi
     - spapr_vscsi:
         drive_format=scsi-hd
         cd_format=scsi-cd
         scsi_hba=spapr-vscsi
+        libvirt_controller=spapr-vscsi
         only pseries
     - lsi_scsi:
         no Host_RHEL

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -413,6 +413,35 @@ class VM(virt_vm.BaseVM):
             else:
                 return ""
 
+        def add_controller(model=None):
+            """
+            Add controller option for virt-install command line.
+
+            :param model: string, controller model.
+            :return: string, empty or controller option.
+            """
+            if model == 'virtio-scsi':
+                return " --controller type=scsi,model=virtio-scsi"
+            else:
+                return ""
+
+        def check_controller(virt_install_cmd_line, controller):
+            """
+            Check for the controller already available in virt-install
+            command line.
+
+            :param virt_install_cmd_line: string, virt-install command line.
+            :param controller: string, controller model.
+            :return: True if succeed of False if failed.
+            """
+            found = False
+            output = re.findall(r"controller\stype=(\S+),model=(\S+)", virt_install_cmd_line)
+            for item in output:
+                if controller in item[1]:
+                    found = True
+                    break
+            return found
+
         def add_drive(help_text, filename, pool=None, vol=None, device=None,
                       bus=None, perms=None, size=None, sparse=False,
                       cache=None, fmt=None):
@@ -761,12 +790,21 @@ class VM(virt_vm.BaseVM):
             if image_params.get("boot_drive") == "no":
                 continue
             if filename:
+                libvirt_controller = image_params.get("libvirt_controller", None)
+                _drive_format = image_params.get("drive_format")
+                if libvirt_controller:
+                    if not check_controller(virt_install_cmd, libvirt_controller):
+                        virt_install_cmd += add_controller(libvirt_controller)
+                    #this will reset the scsi-hd to scsi as we are adding controller
+                    # to mention the drive format
+                    if 'scsi' in _drive_format:
+                        _drive_format = "scsi"
                 virt_install_cmd += add_drive(help_text,
                                               filename,
                                               None,
                                               None,
                                               None,
-                                              image_params.get("drive_format"),
+                                              _drive_format,
                                               None,
                                               image_params.get("image_size"),
                                               image_params.get("drive_sparse"),


### PR DESCRIPTION
The respective controller was not getting added to the virt-install
command line and due to which the automated installation of virtio-scsi(ppc64) was not
possible, this patch addresses the automatic choosing of virtio-scsi controller
in libvirt when it is chosen as disk type and respectively for other disk types.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>