### PR TITLE
virttest.utils_spice: Add support for RHEL7

### DIFF
--- a/virttest/utils_spice.py
+++ b/virttest/utils_spice.py
@@ -304,7 +304,7 @@ def clear_interface_linux(vm, login_timeout, timeout):
     else:
         command = "Xorg"
         pgrep_process = "Xorg"
-   
+
     try:
         pid = session.cmd("pgrep %s" % pgrep_process)
         session.cmd("killall %s" % command)


### PR DESCRIPTION
For spice tests on RHEL7, adding EPEL support for RHEL7
and restarting gdm in RHEL7 is required. 

Reviewed By: Swapna Krishnan <skrishna@redhat.com>