### PR TITLE
virttest.libvirt_xml: Fix misuse of remove_by_xpath

### DIFF
--- a/virttest/libvirt_xml/devices/graphics.py
+++ b/virttest/libvirt_xml/devices/graphics.py
@@ -143,6 +143,6 @@ class Graphics(base.TypedDeviceBase):
         :param vm_name: name of vm
         """
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-        vmxml.xmltreefile.remove_by_xpath('/devices/graphics')
+        vmxml.xmltreefile.remove_by_xpath('/devices/graphics', remove_all=True)
         vmxml.xmltreefile.write()
         vmxml.sync()

--- a/virttest/libvirt_xml/snapshot_xml.py
+++ b/virttest/libvirt_xml/snapshot_xml.py
@@ -115,7 +115,7 @@ class SnapshotXML(SnapshotXMLBase):
         """
         Remove all disks
         """
-        self.xmltreefile.remove_by_xpath('/disks')
+        self.xmltreefile.remove_by_xpath('/disks', remove_all=True)
         self.xmltreefile.write()
 
     class SnapDiskXML(Disk):

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -370,7 +370,7 @@ class VMXMLBase(base.LibvirtXMLBase):
         Remove all devices
         """
         try:
-            self.xmltreefile.remove_by_xpath('/devices')
+            self.xmltreefile.remove_by_xpath('/devices', remove_all=True)
         except (AttributeError, TypeError):
             pass  # Element already doesn't exist
         self.xmltreefile.write()
@@ -452,7 +452,7 @@ class VMXMLBase(base.LibvirtXMLBase):
         Remove the seclabel tag from a domain
         """
         try:
-            self.xmltreefile.remove_by_xpath("/seclabel")
+            self.xmltreefile.remove_by_xpath("/seclabel", remove_all=True)
         except (AttributeError, TypeError):
             pass  # Element already doesn't exist
         self.xmltreefile.write()
@@ -1219,11 +1219,7 @@ class VMXML(VMXMLBase):
         """
         Remove all graphics devices.
         """
-        try:
-            self.xmltreefile.remove_by_xpath('/devices/graphics')
-        except (AttributeError, TypeError):
-            pass  # Element already doesn't exist
-        self.xmltreefile.write()
+        self.remove_all_device_by_type('graphics')
 
     def remove_all_device_by_type(self, device_type):
         """
@@ -1232,7 +1228,10 @@ class VMXML(VMXMLBase):
         :param type: Type name for devices should be removed.
         """
         try:
-            self.xmltreefile.remove_by_xpath('/devices/%s' % device_type)
+            self.xmltreefile.remove_by_xpath(
+                '/devices/%s' % device_type,
+                remove_all=True,
+            )
         except (AttributeError, TypeError):
             pass  # Element already doesn't exist
         self.xmltreefile.write()
@@ -1331,7 +1330,7 @@ class VMXML(VMXMLBase):
         """
         vmxml = VMXML.new_from_dumpxml(vm_name, virsh_instance=virsh_instance)
         try:
-            vmxml.xmltreefile.remove_by_xpath("/memoryBacking")
+            vmxml.xmltreefile.remove_by_xpath("/memoryBacking", remove_all=True)
             vmxml.sync()
         except (AttributeError, TypeError):
             pass  # Element already doesn't exist

--- a/virttest/xml_utils.py
+++ b/virttest/xml_utils.py
@@ -302,13 +302,17 @@ class XMLTreeFile(ElementTree.ElementTree, XMLBackup):
         """
         self.get_parent(element).remove(element)
 
-    def remove_by_xpath(self, xpath):
+    def remove_by_xpath(self, xpath, remove_all=False):
         """
         Remove an element found by xpath
 
         :param xpath: element name or path to remove
         """
-        self.remove(self.find(xpath))  # can't remove root
+        if remove_all:
+            for elem in self.findall(xpath):
+                self.remove(elem)
+        else:
+            self.remove(self.find(xpath))  # can't remove root
 
     def create_by_xpath(self, xpath):
         """


### PR DESCRIPTION
Original implementation of remove_by_xpath() only remove the first
occurrence of found elements. This leads to some misunderstanding and
misuse of this function.

This patch adds an option remove_all to make it able to remove all
found elements but retains the default to remove just once.