### PR TITLE
libvirt.py: Fixed the bug related to VG recreation failure (moved to setup_or_cleanup_iscsi())

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -470,6 +470,7 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
         _iscsi.emulated_id = _iscsi.get_target_id()
         _iscsi.cleanup()
         utils.run("rm -f %s" % emulated_path)
+        utils.run("vgscan --cache")
     return ""
 
 


### PR DESCRIPTION
The VG creation failure with error 'incorrect metadata area header checksum'
occurred during multiple test runs. The solution is to call 'vgscan --cache'
in order to rebuild the LVM cache after the disk was deleted at the end of
the test