### PR TITLE
utils_misc: Fix get_cpu_info when without session

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1272,10 +1272,10 @@ def get_cpu_info(session=None):
     cpu_info = {}
     cmd = "lscpu"
     if session is None:
-        output = utils.system_output(cmd, ignore_status=True)
+        output = utils.system_output(cmd, ignore_status=True).splitlines()
     else:
         try:
-            output = session.cmd_output(cmd).strip().splitlines()
+            output = session.cmd_output(cmd).splitlines()
         finally:
             session.close()
     cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":")], output))


### PR DESCRIPTION
The system_output return string, while map need output to be list
of output lines.

Signed-off-by: Wayne Sun <gsun@redhat.com>