### PR TITLE
virttest/utils_libguestfs: fix bug for guestfish

### DIFF
--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -193,7 +193,8 @@ class Guestfish(LibguestfsBase):
             unset_cmd += "unset %s;" % env
         if run_mode == "interactive" and unset_cmd:
             guestfs_exec = unset_cmd + " " + guestfs_exec
-        elif run_mode == "remote":
+
+        if run_mode == "remote":
             guestfs_exec += " --listen"
         else:
             if uri:


### PR DESCRIPTION
The c51a2b2 introduces a bug,
which leads program would never enter 'else' block.
So, even if we specify option '-i',
it still report the following error message,
  libguestfs:
  error: umount_all: call launch before using this function
  (in guestfish, don't forget to use the 'run' command)