### PR TITLE
utils_test.libvirt: Ignore vgscan failure

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -470,7 +470,7 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
         _iscsi.emulated_id = _iscsi.get_target_id()
         _iscsi.cleanup()
         utils.run("rm -f %s" % emulated_path)
-        utils.run("vgscan --cache")
+        utils.run("vgscan --cache", ignore_status=True)
     return ""
 
 


### PR DESCRIPTION
As lvmetad could not running, the vgscan will fail, do not raise
error and fail then.

Signed-off-by: Wayne Sun <gsun@redhat.com>