### PR TITLE
utils_net , virt_vm: Finding correct guest IP using also ARP lookup

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2620,9 +2620,14 @@ def parse_arp():
     for line in arp_cache:
         mac = line.split()[3]
         ip = line.split()[0]
+        flag = line.split()[2]
 
         # Skip the header
         if mac.count(":") != 5:
+            continue
+
+        # Skip the incomplete ARP entries
+        if flag == "0x0":
             continue
 
         ret[mac] = ip

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -635,6 +635,9 @@ class BaseVM(object):
         :raise VMAddressVerificationError: If the MAC-IP address mapping cannot
                 be verified (using arping)
         """
+        # Make sure the IP address is assigned to one or more macs
+        # for this guest
+        macs = self.virtnet.mac_list()
         nic = self.virtnet[index]
         self.ip_version = self.params.get("ip_version", "ipv4").lower()
         # TODO: Determine port redirection in use w/o checking nettype
@@ -652,24 +655,14 @@ class BaseVM(object):
             arp_ip = self.address_cache.get(nic.mac.lower())
             if not arp_ip:
                 arp_ip = self.address_cache.get(nic.mac.upper())
-            if not arp_ip or os.geteuid() != 0:
+            if not arp_ip or not utils_net.verify_ip_address_ownership(arp_ip, macs) or os.geteuid() != 0:
                 # For non-root, tcpdump won't work for finding IP address,
                 # or IP missed in address_cache, try to find it from arp table.
-                arping_bin = utils_misc.find_command("arping")
-                # Check IP not got DHCPACK packet to ensure no ip/mac
-                # table missed in address_cache.
-                for ip in copy.deepcopy(self.address_cache.get("ip_pool")):
-                    arping_cmd = "%s -f -c 5 " % arping_bin
-                    arping_cmd += "-I %s %s" % (nic.netdst, ip)
-                    utils.system(arping_cmd, ignore_status=True)
                 ip_map = utils_net.parse_arp()
                 arp_ip = ip_map.get(nic.mac.lower())
             if not arp_ip:
                 raise VMIPAddressMissingError(nic.mac)
 
-            # Make sure the IP address is assigned to one or more macs
-            # for this guest
-            macs = self.virtnet.mac_list()
 
             # SR-IOV cards may not be in same subnet with the card used by
             # host by default, so arp checks won't work. Therefore, do not


### PR DESCRIPTION
A check for filtering incomplete ARP entries (flag 0x0) is added
into parse_arp(). Without this check the returned dictionary may
contain invalid (incomplete) IP addresses after parsing /proc/net/arp

virt_vm get_address() now will try to get the correct IP address
of the guest from the current ARP table in case if the DHCP assigned a
new address to guest after it's reboot, and the address_cache contains
old entries (additional check condition is added into the if-block).

An unnecessary checking loop is deleted.