### PR TITLE
utils_net , virt_vm: Finding correct guest IP using also ARP lookup

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2620,9 +2620,14 @@ def parse_arp():
     for line in arp_cache:
         mac = line.split()[3]
         ip = line.split()[0]
+        flag = line.split()[2]
 
         # Skip the header
         if mac.count(":") != 5:
+            continue
+
+        # Skip the incomplete ARP entries
+        if flag == "0x0":
             continue
 
         ret[mac] = ip


### PR DESCRIPTION
A check for filtering incomplete ARP entries (flag 0x0) is added
into parse_arp(). Without this check the returned dictionary may
contain invalid (incomplete) IP addresses after parsing /proc/net/arp

virt_vm get_address() now will try to get the correct IP address
of the guest from the current ARP table in case if the DHCP assigned a
new address to guest after it's reboot, and the address_cache contains
old entries (additional check condition is added into the if-block).

An unnecessary checking loop is deleted.