### PR TITLE
utils_test/libguestfs: check if file exists before removing

### DIFF
--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -143,7 +143,8 @@ def cleanup_vm(vm_name=None, disk=None):
         logging.error("Undefine %s failed:%s", vm_name, detail)
     try:
         if disk is not None:
-            os.remove(disk)
+            if os.path.exists(disk):
+                os.remove(disk)
     except IOError, detail:
         logging.error("Remove disk %s failed:%s", disk, detail)
 


### PR DESCRIPTION
check is compulsory, otherwise,
it will report the following in same cases,
  OSError: [Errno 2] No such file or directory