### PR TITLE
virsh: Correct metadata --set option

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -4044,7 +4044,7 @@ def metadata(name, uri, options="", key=None, new_metadata=None, **dargs):
     if key:
         cmd += " --key %s" % key
     if new_metadata:
-        cmd += " --set %s" % metadata
+        cmd += " --set '%s'" % new_metadata.replace("\'", "\"")
     return command(cmd, **dargs)
 
 


### PR DESCRIPTION
1. For --set option, the value should be quoted, so unity all single
quote to double quotes.
2. Fix a wrong variable

Signed-off-by: Yanbing Du <ydu@redhat.com>