### PR TITLE
utils_test: Revert a mistakenly removed import

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -36,12 +36,10 @@ from virttest import aexpect, utils_misc, virt_vm, data_dir, utils_net
 from virttest import storage, asset, bootstrap, remote
 import virttest
 
-
-try:
-    from virttest.staging import utils_cgroup
-except ImportError:
-    # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from autotest.client.shared import utils_cgroup
+# Import submodules, should not be considered as unused import
+import libvirt
+import qemu
+import libguestfs
 
 try:
     from virttest.staging import utils_memory


### PR DESCRIPTION
import of submodules are mistakenly removed as unused import in 95509f0a94aea9d60dd726a6e0de30dcfcf2f251.

And a unused import of utils_cgroup is removed.

Signed-off-by: Hao Liu <hliu@redhat.com>