### PR TITLE
cartesian_config: Pylint W0142 no longer need disable

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -1861,7 +1861,6 @@ class Parser(object):
 
         # Check previously failed filters
         for i, failed_case in enumerate(node.failed_cases):
-            # pylint: disable=W0142
             if not might_pass(*failed_case):
                 self._debug("\n*    this subtree has failed before %s\n"
                             "         content: %s\n"


### PR DESCRIPTION
Newest pylint remove the rule W0142
(https://bitbucket.org/logilab/pylint/commits/b6fbdc48d643a764bba1d47da87610ccbfb7555e)

This commit remove the original pylint disable line to make it
accord with the new rule and silence the CI error.

Signed-off-by: Hao Liu <hliu@redhat.com>