### PR TITLE
shared.cfg.guest_os: Add RHEL.7.devel variant

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.devel.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel.cfg
@@ -1,0 +1,35 @@
+- 7.devel:
+    no setup
+    image_name = images/rhel7devel
+    os_variant = rhel7
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        unattended_file = unattended/RHEL-7-series.ks
+        syslog_server_proto = udp
+    nic_hotplug:
+        modprobe_module =
+    block_hotplug:
+        modprobe_module =
+    guest_s3:
+        global_enable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/7/os/`uname -m`/Packages/iasl-20120913-7.el7.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+            s3_support_chk_cmd += " && dmesg -c > /dev/null && grep -q mem /sys/power/state"
+        global_disable_s3:
+            s3_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/7/os/`uname -m`/Packages/iasl-20120913-7.el7.`uname -m`.rpm"
+            s3_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s3_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s3_support_chk_cmd += " && grep "_S3" /tmp/ssdt.dsl"
+    guest_s4:
+        global_enable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/7/os/`uname -m`/Packages/iasl-20120913-7.el7.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"
+            s4_support_chk_cmd += " && dmesg -c > /dev/null && grep -q disk /sys/power/state"
+        global_disable_s4:
+            s4_support_chk_cmd = "rpm --force --nodeps -ivh http://mirrors.sonic.net/centos/7/os/`uname -m`/Packages/iasl-20120913-7.el7.`uname -m`.rpm"
+            s4_support_chk_cmd += " && cat /sys/firmware/acpi/tables/SSDT > /tmp/ssdt"
+            s4_support_chk_cmd += " && iasl -d /tmp/ssdt"
+            s4_support_chk_cmd += " && grep "_S4" /tmp/ssdt.dsl"

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
@@ -1,0 +1,12 @@
+- aarch64:
+    grub_file = /boot/grub/grub.conf
+    vm_arch_name = aarch64
+    image_name += -aarch64
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/rhel7-64/ks.iso
+        kernel = images/rhel7-aarch64/vmlinuz
+        initrd = images/rhel7-aarch64/initrd.img
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        # don't append kernel_params, but override them (otherwise install happens in ttyS0 instead of ttyAMA0)
+        kernel_params = "ks=cdrom:sr1:/ks.cfg text efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait "
+        cdrom_cd1 = isos/linux/RHEL-7-devel-aarch64.iso

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
@@ -1,0 +1,21 @@
+- ppc64:
+    image_name = images/rhel7devel-ppc64
+    vm_arch_name = ppc64
+    os_variant = rhel7
+    no unattended_install..floppy_ks
+    no guest_s3, guest_s4
+    mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
+    netdev_peer_re = "(.*?): .*?\\\s(.*?):"
+    unattended_install:
+        kernel_params = "nicdelay=60 console=hvc0"
+        cdrom_unattended = images/rhel7-ppc64/ks.iso
+        kernel = images/rhel7-ppc64/vmlinuz
+        initrd = images/rhel7-ppc64/initrd.img
+    unattended_install.cdrom:
+        boot_path = ppc/ppc64
+        cdrom_cd1 = isos/linux/RHEL-7-devel-ppc64.iso
+    unattended_install..floppy_ks:
+        floppies = "fl"
+        floppy_name = images/rhel7-ppc64/ks.vfd
+    unattended_install.url:
+        url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/18/Everything/ppc64/os

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/x86_64.cfg
@@ -1,0 +1,13 @@
+- x86_64:
+    grub_file = /boot/grub2/grub.cfg
+    vm_arch_name = x86_64
+    image_name += -64
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/rhel7-64/ks.iso
+        kernel = images/rhel7-64/vmlinuz
+        initrd = images/rhel7-64/initrd.img
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_cd1 = isos/linux/RHEL7-devel-x86_64.iso
+    unattended_install..floppy_ks:
+        floppies = "fl"
+        floppy_name = images/rhel7-64/ks.vfd


### PR DESCRIPTION
This patch adds RHEL.7.devel variant which takes whatever
isos/linux/RHEL7-devel-{x86_64,ppc64,aarch64}.iso image exists and uses
it to install RHEL7-like OS. It's suitable to developers who need to use
the latest versions.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>