### PR TITLE
virttest: Unify defaults.DEFAULT_GUEST_OS and avoid running without 7za

### DIFF
--- a/run
+++ b/run
@@ -188,8 +188,7 @@ class VirtTestRunParser(optparse.OptionParser):
         optparse.OptionParser.__init__(self, usage='Usage: %prog [options]')
         from virttest import data_dir
         import virttest.defaults
-        os_info = virttest.defaults.get_default_guest_os_info()
-        self.default_guest_os = os_info['variant']
+        self.default_guest_os = virttest.defaults.DEFAULT_GUEST_OS
 
         try:
             qemu_bin_path = _find_default_qemu_paths()[0]

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -110,13 +110,18 @@ def verify_recommended_programs(t_type):
                              "source. Aliases searched: %s", cmd_aliases)
 
 
-def verify_mandatory_programs(t_type):
+def verify_mandatory_programs(t_type, guest_os):
     failed_cmds = []
     cmds = mandatory_programs[t_type]
     for cmd in cmds:
         try:
             logging.info(utils_misc.find_command(cmd))
         except ValueError:
+            if cmd == '7za' and guest_os != defaults.DEFAULT_GUEST_OS:
+                logging.warn("Command 7za (required to uncompress JeOS) "
+                             "missing. You can still use virt-test with guest"
+                             " OS's other than JeOS.")
+                continue
             logging.error("Required command %s is missing. You must "
                           "install it", cmd)
             failed_cmds.append(cmd)
@@ -759,7 +764,7 @@ def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
     logging.info("")
     step += 1
     logging.info("%d - Checking the mandatory programs and headers", step)
-    verify_mandatory_programs(test_name)
+    verify_mandatory_programs(test_name, guest_os)
 
     logging.info("")
     step += 1

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -1,17 +1,20 @@
 from autotest.client.shared import distro
 
+
 DEFAULT_MACHINE_TYPE = "i440fx"
-DEFAULT_GUEST_OS = "JeOS.19"
+DEFAULT_GUEST_OS = None     # populated below
 
 
 def get_default_guest_os_info():
     """
     Gets the default asset and variant information depending on host OS
     """
-    os_info = {'asset': 'jeos-19-64', 'variant': DEFAULT_GUEST_OS}
+    os_info = {'asset': 'jeos-19-64', 'variant': "JeOS.19"}
 
     detected = distro.detect()
     if detected.name == 'fedora' and int(detected.version) >= 20:
         os_info = {'asset': 'jeos-21-64', 'variant': 'JeOS.21'}
 
     return os_info
+
+DEFAULT_GUEST_OS = get_default_guest_os_info()['variant']

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -667,8 +667,6 @@ def bootstrap_tests(options):
         check_modules = None
     online_docs_url = "https://github.com/autotest/virt-test/wiki"
 
-    os_info = defaults.get_default_guest_os_info()
-
     kwargs = {'test_name': options.type,
               'test_dir': test_dir,
               'base_dir': data_dir.get_data_dir(),
@@ -680,7 +678,7 @@ def bootstrap_tests(options):
                                    options.keep_image),
               'interactive': False,
               'update_providers': options.update_providers,
-              'guest_os': options.guest_os or os_info['variant']}
+              'guest_os': options.guest_os or defaults.DEFAULT_GUEST_OS}
 
     # Tolerance we have without printing a message for the user to wait (3 s)
     tolerance = 3


### PR DESCRIPTION
Hi guys,

this patchset unifies the `defaults.DEFAULT_GUEST_OS` and most importantly (to me) allows running virt-test on systems without `7za`. (so far I'd been using `touch /usr/local/7za` to workaround it, but it really is not a nice solution)

@lmr, @ypu would you please verify I'm not crucially wrong about the `defaults`? I grepped for all `defaults.DEFAULT...` and `defaults.get_default...` occurrences and IMO this solution reflects the usage properly.

regards,
Lukáš