### PR TITLE
shared.cfg: Increase RHEL.7.devel install_timeout on aarch64

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
@@ -2,6 +2,7 @@
     grub_file = /boot/grub/grub.conf
     vm_arch_name = aarch64
     image_name += -aarch64
+    install_timeout = 7200
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_unattended = images/rhel7-64/ks.iso
         kernel = images/rhel7-aarch64/vmlinuz


### PR DESCRIPTION
Current RHEL.7.devel installation takes about 70-90 minutes right now.
Default timeout is 80min, which generates lots of false-negatives. This
patch increases the timeout to 120 minutes, which should be safe.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>