### PR TITLE
virttest.qemu_devices: Image format is mandatory now

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1181,7 +1181,6 @@ class DevContainer(object):
             if media is None:
                 media = "disk"
         else:       # Skip default variables
-            imgfmt = None
             if media != 'cdrom':    # ignore only 'disk'
                 media = None
 


### PR DESCRIPTION
The image format is mandatory in the latest qemu but in virt-test it's only
set in strict_mode. This patch enables it in non-strict mode too.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>