### PR TITLE
shared.cfg.guest_os: Merge kernel_params for all RHEL versions

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -7,5 +7,11 @@
         modprobe_module = acpiphp
         no block_scsi
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        kernel_params = "ks=cdrom nicdelay=60 "
+        aarch64:
+            kernel_params += " efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
+        ppc64:
+            kernel_params += " console=hvc0"
+        x86_64, i386:
+            kernel_params += " console=ttyS0,115200 console=tty0"
         boot_path = images/pxeboot
-        kernel_params = "ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0"

--- a/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
@@ -7,7 +7,6 @@
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
     unattended_install:
-        kernel_params = "nicdelay=60 console=hvc0"
         cdrom_unattended = images/rhel70-ppc64/ks.iso
         kernel = images/rhel70-ppc64/vmlinuz
         initrd = images/rhel70-ppc64/initrd.img

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
@@ -8,6 +8,4 @@
         kernel = images/rhel7-aarch64/vmlinuz
         initrd = images/rhel7-aarch64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        # don't append kernel_params, but override them (otherwise install happens in ttyS0 instead of ttyAMA0)
-        kernel_params = "ks=cdrom:sr1:/ks.cfg text efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait "
         cdrom_cd1 = isos/linux/RHEL-7-devel-aarch64.iso

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
@@ -7,7 +7,6 @@
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
     unattended_install:
-        kernel_params = "nicdelay=60 console=hvc0"
         cdrom_unattended = images/rhel7-ppc64/ks.iso
         kernel = images/rhel7-ppc64/vmlinuz
         initrd = images/rhel7-ppc64/initrd.img


### PR DESCRIPTION
Hello guys,

with multiple systems configs are becoming less readable. This patch consolidates common arch-specific setting of RHEL machines. There is no but one minor adjustment. Apart from that all params stayed the same, they are only defined on different place.

Regards,
Lukáš