### PR TITLE
virttest.utils_misc: Update the machine type pattern in get_support_mach...

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1769,7 +1769,7 @@ def get_support_machine_type(qemu_binary="/usr/libexec/qemu-kvm"):
     Get the machine type the host support,return a list of machine type
     """
     o = utils.system_output("%s -M ?" % qemu_binary)
-    s = re.findall("(\S*)\s*RHEL\s", o)
+    s = re.findall("(\S*)\s*RHEL[-\s]", o)
     c = re.findall("(RHEL.*PC)", o)
     return (s, c)
 


### PR DESCRIPTION
...ine_type

Now the output of qemu-kvm -M ? include some string that can not be covered
by current pattern. Need update it.
