### PR TITLE
Ubuntu 14.04.01 Server i386 (libvirt backend)

### DIFF
--- a/shared/cfg/guest-os/Linux/Ubuntu/14.04.1-server.i386.cfg
+++ b/shared/cfg/guest-os/Linux/Ubuntu/14.04.1-server.i386.cfg
@@ -1,6 +1,6 @@
 - 14.04.1-server.i386:
     image_name += -14.04.1-server-32
-    vm_arch_name = i386
+    vm_arch_name = i686
     os_variant = ubuntutrusty
     unattended_install, svirt_install:
         kernel = images/ubuntu-server-14-04-1-32/vmlinuz


### PR DESCRIPTION
Fix vm_arch_name configuration parameter for compatibility with kernel arch format

Signed-off-by: Igor Derzhavets <igor.derzhavets@ravellosystems.com>