### PR TITLE
Fix vm_arch_name configuration parameter for various guests

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/19.i386.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/19.i386.cfg
@@ -1,6 +1,6 @@
 - 19.i386:
     image_name = images/f19-32
-    vm_arch_name = i386
+    vm_arch_name = i686
     os_variant = fedora19
     no unattended_install..floppy_ks
     unattended_install, svirt_install:

--- a/shared/cfg/guest-os/Linux/Fedora/20.i386.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/20.i386.cfg
@@ -1,6 +1,6 @@
 - 20.i386:
     image_name = images/f20-32
-    vm_arch_name = i386
+    vm_arch_name = i686
     no unattended_install..floppy_ks
     unattended_install:
         kernel_params = "repo=cdrom:/dev/sr0 ks=cdrom:/dev/sr1 nicdelay=60 console=ttyS0,115200 console=tty0"

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel/i386.cfg
@@ -1,6 +1,6 @@
 - i386:
     grub_file = /boot/grub/grub.conf
-    vm_arch_name = i386
+    vm_arch_name = i686
     image_name += -32
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_unattended = images/rhel6devel-64/ks.iso

--- a/shared/cfg/guest-os/Linux/Ubuntu/12.04-server.i386.cfg
+++ b/shared/cfg/guest-os/Linux/Ubuntu/12.04-server.i386.cfg
@@ -1,6 +1,6 @@
 - 12.04-server.i386:
     image_name += -12.04-server-32
-    vm_arch_name = i386
+    vm_arch_name = i686
     os_variant = ubuntuprecise
     no virtio_scsi
     unattended_install, svirt_install:

--- a/shared/cfg/guest-os/Linux/Ubuntu/14.04-server.i386.cfg
+++ b/shared/cfg/guest-os/Linux/Ubuntu/14.04-server.i386.cfg
@@ -1,6 +1,6 @@
 - 14.04-server.i386:
     image_name += -14.04-server-32
-    vm_arch_name = i386
+    vm_arch_name = i686
     os_variant = ubuntutrusty
     unattended_install, svirt_install:
         kernel = images/ubuntu-server-14-04-32/vmlinuz


### PR DESCRIPTION
This fix required for compatibility with libvirt backend.
Arch name of 32-bit kernels for specified guests has i686 signature.

Signed-off-by: Igor Derzhavets <igor.derzhavets@ravellosystems.com>