### PR TITLE
CentOS 7.0: Fix unattended install

### DIFF
--- a/shared/cfg/guest-os/Linux/CentOS/7.0/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/CentOS/7.0/x86_64.cfg
@@ -7,8 +7,8 @@
         kernel = images/centos70-64/vmlinuz
         initrd = images/centos70-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/CentOS-7.0-1406-x86_64-DVD.iso
-        md5sum_cd1 = 713ea7847adcdd1700e92429f212721a
+        cdrom_cd1 = isos/linux/CentOS-7-x86_64-Minimal-1503-01.iso
+        md5sum_cd1 = d07ab3e615c66a8b2e9a50f4852e6a77
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel70-64/ks.vfd

--- a/shared/downloads/centos70-64.ini
+++ b/shared/downloads/centos70-64.ini
@@ -1,4 +1,4 @@
 [centos70-64]
 title = CentOS 7.0 amd64
-url = http://mirror.isoc.org.il/pub/centos/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-DVD.iso
-destination = isos/linux/CentOS-7.0-1406-x86_64-DVD.iso
+url = http://mirror.isoc.org.il/pub/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1503-01.iso
+destination = isos/linux/CentOS-7-x86_64-Minimal-1503-01.iso

--- a/shared/unattended/CentOS-7-0.ks
+++ b/shared/unattended/CentOS-7-0.ks
@@ -1,17 +1,21 @@
+#version=RHEL7
 install
 KVM_TEST_MEDIUM
 GRAPHICAL_OR_TEXT
 poweroff
 lang en_US.UTF-8
-keyboard us
-network --onboot yes --device eth0 --bootproto dhcp
-rootpw 123456
-firewall --enabled --ssh
-selinux --enforcing
-timezone --utc America/New_York
-firstboot --disable
-bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+keyboard --vckeymap=us --xlayouts='us'
 zerombr
+eula --agreed
+firewall --disabled
+selinux --disabled
+services --enabled=NetworkManager,sshd
+poweroff
+
+rootpw 123456
+timezone --utc America/New_York
+
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
 clearpart --all --initlabel
 autopart
 xconfig --startxonboot
@@ -76,4 +80,6 @@ sed -i "s/^ONBOOT=.*/ONBOOT=yes/g" /etc/sysconfig/network-scripts/ifcfg-eth0
 ECHO "Disable lock cdrom udev rules"
 sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
 ECHO 'Post set up finished'
+echo 'Post set up finished' > /dev/ttyS0
+echo 'Post set up finished' > /dev/hvc0
 %end


### PR DESCRIPTION
1. Fix kickstart file for unattended install.
2. Replace DVD install media by minimal CD.

Signed-off-by: Igor Derzhavets <igor.derzhavets@ravellosystems.com>