### PR TITLE
Fix virtio-win scheme

### DIFF
--- a/shared/cfg/guest-os/Windows/Win2008/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/i386.cfg
@@ -24,11 +24,10 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win2008-sp1-32/autounattend.iso"
         - sp2:
             image_name += -sp2-32
@@ -44,9 +43,8 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win2008-sp2-32/autounattend.iso"

--- a/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
@@ -29,11 +29,10 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win2008-sp1-64/autounattend.iso"
 
         - sp2:
@@ -50,11 +49,10 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win2008-sp2-64/autounattend.iso"
 
         - r2:
@@ -71,9 +69,8 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win2008-r2-64/autounattend.iso"

--- a/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
@@ -14,11 +14,10 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win2012-64/autounattend.iso"
     sysprep:
         unattended_file = unattended/win2012-autounattend.xml
@@ -36,9 +35,8 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win2012r2-64/autounattend.iso"

--- a/shared/cfg/guest-os/Windows/Win7/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/i386.cfg
@@ -13,11 +13,10 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win7-32/autounattend.iso"
     whql.submission:
         dd_data_logoarch = X86
@@ -44,12 +43,11 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     cd_format = ide
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win7-32-sp1/autounattend.iso"
                     q35:
                         cd_format = ahci

--- a/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
@@ -23,11 +23,10 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win7-64/autounattend.iso"
     whql.submission:
         dd_data_logoarch = AMD64
@@ -56,12 +55,11 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     cd_format = ide
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win7-64-sp1/autounattend.iso"
                     q35:
                         cd_format = ahci

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -11,11 +11,10 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win8-32/autounattend.iso"
     whql.submission:
         dd_data_logoarch = X86
@@ -42,9 +41,8 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win8.1-32/autounattend.iso"

--- a/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
@@ -19,11 +19,10 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win8-64/autounattend.iso"
     whql.submission:
         dd_data_logoarch = AMD64
@@ -50,9 +49,8 @@
                 extra_cdrom_ks:
                     floppies = ""
                     unattended_delivery_method = cdrom
-                    cdroms = "cd1 winutils unattended virtio"
+                    cdroms = "cd1 winutils unattended"
                     drive_index_cd1 = 1
                     drive_index_winutils = 2
                     drive_index_unattended = 3
-                    drive_index_virtio = 4
                     cdrom_unattended = "images/win8.1-64/autounattend.iso"

--- a/shared/cfg/virtio-win.cfg
+++ b/shared/cfg/virtio-win.cfg
@@ -50,8 +50,8 @@ unattended_install.cdrom, whql.support_vm_install:
         # This assumes the virtio iso will be at the data dir.
         cdrom_virtio = isos/windows/virtio-win.iso
 
-        # This ensures the iso will appear to the guest as F:
-        drive_index_virtio = 3
+        # This ensures the iso will appear to the guest as G:
+        drive_index_virtio = 4
 
         # Need to put CDs on the regular IDE bus for Windows to find it
         cd_format = ide
@@ -78,7 +78,7 @@ unattended_install.cdrom, whql.support_vm_install:
 
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_network_path = 'F:\NetKVM\xp\x86'
+                virtio_network_path = 'G:\NetKVM\xp\x86'
 
             x86_64:
                 # This is a label used on the oemsetup.ini file, inside your
@@ -88,7 +88,7 @@ unattended_install.cdrom, whql.support_vm_install:
 
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_network_path = 'F:\NetKVM\2k3\amd64'
+                virtio_network_path = 'G:\NetKVM\2k3\amd64'
 
         Win2003:
             # This assumes the virtio floppy will be at the data dir.
@@ -104,7 +104,7 @@ unattended_install.cdrom, whql.support_vm_install:
 
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_network_path = 'F:\NetKVM\2k3\x86'
+                virtio_network_path = 'G:\NetKVM\2k3\x86'
 
             x86_64:
                 # This is a label used on the oemsetup.ini file, inside your
@@ -114,64 +114,64 @@ unattended_install.cdrom, whql.support_vm_install:
 
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_network_path = 'F:\NetKVM\2k3\amd64'
+                virtio_network_path = 'G:\NetKVM\2k3\amd64'
 
         WinVista, Win7:
             i386:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\w7\x86'
-                virtio_storage_path = 'F:\viostor\w7\x86'
-                virtio_network_path = 'F:\NetKVM\w7\x86'
+                virtio_scsi_path = 'G:\vioscsi\w7\x86'
+                virtio_storage_path = 'G:\viostor\w7\x86'
+                virtio_network_path = 'G:\NetKVM\w7\x86'
 
             x86_64:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\w7\amd64'
-                virtio_storage_path = 'F:\viostor\w7\amd64'
-                virtio_network_path = 'F:\NetKVM\w7\amd64'
+                virtio_scsi_path = 'G:\vioscsi\w7\amd64'
+                virtio_storage_path = 'G:\viostor\w7\amd64'
+                virtio_network_path = 'G:\NetKVM\w7\amd64'
 
         Win2008:
             i386:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\2k8\x86'
-                virtio_storage_path = 'F:\viostor\2k8\x86'
-                virtio_network_path = 'F:\NetKVM\2k8\x86'
+                virtio_scsi_path = 'G:\vioscsi\2k8\x86'
+                virtio_storage_path = 'G:\viostor\2k8\x86'
+                virtio_network_path = 'G:\NetKVM\2k8\x86'
 
             x86_64:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\2k8\amd64'
-                virtio_storage_path = 'F:\viostor\2k8\amd64'
-                virtio_network_path = 'F:\NetKVM\2k8\amd64'
+                virtio_scsi_path = 'G:\vioscsi\2k8\amd64'
+                virtio_storage_path = 'G:\viostor\2k8\amd64'
+                virtio_network_path = 'G:\NetKVM\2k8\amd64'
 
                 r2:
                     # Look at your cd structure and see where the drivers are
                     # actually located
-                    virtio_scsi_path = 'F:\vioscsi\2k8R2\amd64'
-                    virtio_storage_path = 'F:\viostor\2k8R2\amd64'
-                    virtio_network_path = 'F:\NetKVM\2k8R2\amd64'
+                    virtio_scsi_path = 'G:\vioscsi\2k8R2\amd64'
+                    virtio_storage_path = 'G:\viostor\2k8R2\amd64'
+                    virtio_network_path = 'G:\NetKVM\2k8R2\amd64'
 
         Win8:
             i386:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\w8\x86'
-                virtio_storage_path = 'F:\viostor\w8\x86'
-                virtio_network_path = 'F:\NetKVM\w8\x86'
+                virtio_scsi_path = 'G:\vioscsi\w8\x86'
+                virtio_storage_path = 'G:\viostor\w8\x86'
+                virtio_network_path = 'G:\NetKVM\w8\x86'
 
             x86_64:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\w8\amd64'
-                virtio_storage_path = 'F:\viostor\w8\amd64'
-                virtio_network_path = 'F:\NetKVM\w8\amd64'
+                virtio_scsi_path = 'G:\vioscsi\w8\amd64'
+                virtio_storage_path = 'G:\viostor\w8\amd64'
+                virtio_network_path = 'G:\NetKVM\w8\amd64'
 
         Win2012:
             x86_64:
                 # Look at your cd structure and see where the drivers are
                 # actually located
-                virtio_scsi_path = 'F:\vioscsi\2k12\amd64'
-                virtio_storage_path = 'F:\viostor\2k12\amd64'
-                virtio_network_path = 'F:\NetKVM\2k12\amd64'
+                virtio_scsi_path = 'G:\vioscsi\2k12\amd64'
+                virtio_storage_path = 'G:\viostor\2k12\amd64'
+                virtio_network_path = 'G:\NetKVM\2k12\amd64'

--- a/shared/downloads/virtio-win.ini
+++ b/shared/downloads/virtio-win.ini
@@ -1,4 +1,4 @@
 [virtio-win]
-title = Windows Virtio Drivers ISO
-url = http://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/virtio-win-0.1-74.iso
+title = Windows Virtio Stable Drivers ISO
+url = http://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
 destination = isos/windows/virtio-win.iso

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -726,7 +726,8 @@ class UnattendedInstallConfig(object):
                     if self.install_virtio == "yes":
                         boot_disk.setup_virtio_win2008(self.virtio_floppy,
                                                        self.cdrom_virtio)
-                    self.cdrom_virtio = None
+                    else:
+                        self.cdrom_virtio = None
                 else:
                     boot_disk = utils_disk.FloppyDisk(self.floppy,
                                                       self.qemu_img_binary,


### PR DESCRIPTION
1. virtio-win.ini: Update URL.
2. virtio-win.cfg: Update paths for virtio-win-0.1-100.iso.
3. unattended_install.py: Prevent overwriting of self.cdrom_virtio attribute.
4. shared/cfg/guest-os/Windows: Fix virtio CD drive indexing in Windows guest config files.

Tested on Windows 2008 R2.