### PR TITLE
virttest.utils_test: Add option m to the tar command

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -570,7 +570,7 @@ def run_autotest(vm, session, control_path, timeout,
         dirname = os.path.dirname(remote_path)
         session.cmd("cd %s" % dirname)
         session.cmd("mkdir -p %s" % os.path.dirname(dest_dir))
-        e_cmd = "tar xjvf %s -C %s" % (basename, os.path.dirname(dest_dir))
+        e_cmd = "tar xjvmf %s -C %s" % (basename, os.path.dirname(dest_dir))
         output = session.cmd(e_cmd, timeout=240)
         autotest_dirname = ""
         for line in output.splitlines()[1:]:


### PR DESCRIPTION
Sometime the different setup in guest and host will cause the timestamp
in the future when we extract auotest package inside guest when we
try to run autotest inside guest. As this is not the test point and we
don't want this to influence our testing, add the option m to the tar
command to ignore this.