### PR TITLE
Add parallel execution of multiple guests with different tests on single host (QEMU)

### DIFF
--- a/run
+++ b/run
@@ -10,6 +10,9 @@ import traceback
 import signal
 import optparse
 import logging
+import tools.parallel
+import virttest.data_dir
+import time
 
 
 class StreamProxy(object):
@@ -340,6 +343,23 @@ class VirtTestRunParser(optparse.OptionParser):
                            help=("Don't clean up tmp files or VM processes at "
                                  "the end of a virt-test execution (useful "
                                  "for debugging)"))
+
+        general.add_option("--jobs-file", action="store",
+                           dest="jobs_file",
+                           help=("Full path to file with "
+                                 "GUEST;TEST1 [TEST2] [TEST3]"
+                                 "list for parallel execution"))
+
+        general.add_option("--jobs-max", action="store",
+                           dest="jobs",
+                           type="int",
+                           help=("Max number of parallel jobs"))
+
+        general.add_option("--job-id", action="store",
+                           dest="job_id",
+                           default=None,
+                           type="int",
+                           help=("Job number, for internal use only!"))
 
         self.add_option_group(general)
 
@@ -996,4 +1016,55 @@ class VirtTestApp(object):
 
 if __name__ == '__main__':
     app = VirtTestApp()
-    app.main()
+
+    if app.options.jobs_file:
+      if not os.path.exists(app.options.jobs_file):
+        print "There is no",app.options.jobs_file
+        exit(1)
+      parent_logdir = os.path.join(virttest.data_dir.get_root_dir(),
+                                    'logs',
+                                    'parallel-run-' + \
+                                    time.strftime('%Y-%m-%d-%H.%M.%S'))
+      os.makedirs(parent_logdir)
+      subprocess_job_id = 1
+      cmd_lines = []
+      input_lines = [line.strip() for line in open(app.options.jobs_file,'r')]
+      for line in input_lines:
+        value = line.split(';')
+        if len(value) > 4:
+          extra_opts = value[4]
+        else:
+          extra_opts = ""
+        subprocess_cmd_line = ''.join([__file__,
+                                      ' -t ', value[0],
+                                      ' -g ', value[1],
+                                      ' --machine-type=',value[2],
+                                      ' --tests=',value[3],
+                                      ' --job-id ',str(subprocess_job_id),
+                                      ' --logs-dir ', parent_logdir,
+                                      ' ', extra_opts
+                                      ])
+
+        cmd_lines.append(subprocess_cmd_line)
+        subprocess_job_id = subprocess_job_id + 1
+
+      try:
+        dargs = {}
+        if app.options.jobs:
+          dargs['max_simultaneous_procs'] = app.options.jobs
+        else:
+          dargs['max_simultaneous_procs'] = 1
+        dargs['list_of_functions'] = False
+        pe = tools.parallel.ParallelExecute(cmd_lines, **dargs)
+        pe.run_until_completion()
+        print "That's all, folks!"
+        from virttest import standalone_test
+        standalone_test.cleanup_env(app.cartesian_parser, app.options)
+        print "Environment was cleaned."
+      except tools.parallel.ParallelError, err:
+        print "Parallel Run Exception!"
+        sys.exit(1)
+
+      sys.exit(0)
+    else:
+      app.main()

--- a/run
+++ b/run
@@ -782,6 +782,10 @@ class VirtTestApp(object):
         if not self.options.config:
             if not self.options.keep_image_between_tests:
                 self.cartesian_parser.assign("restore_image", "yes")
+        # Disable back up for parallel jobs
+        if self.options.job_id:
+          self.cartesian_parser.assign("restore_image", "no")
+          self.cartesian_parser.assign("backup_image_before_testing", "no")
 
     def _process_mem(self):
         self.cartesian_parser.assign("mem", self.options.mem)

--- a/virt.py
+++ b/virt.py
@@ -74,7 +74,7 @@ class virt(test.test):
         else:
             env_path = params.get("vm_type")
         env_filename = os.path.join(self.bindir, "backends", env_path,
-                                    params.get("env", "env"))
+                                    (params.get("env", "env") + str(params.get("job_id"))))
         env = utils_env.Env(env_filename, self.env_version)
         other_subtests_dirs = params.get("other_tests_dirs", "")
 


### PR DESCRIPTION
   This pull request extends virt-test functionality to parallel execution of various tests for different guests.
   In general, it get JOBS (guest + test) from text file and executes it by 'run' script (forking initial run process). It separates execution environment for each job. In order to avoid corruption of guest images it creates snapshots of original image with job_ID suffix.
   It was tested with ping and unattended test for CentOS and Ubuntu guests by qemu backend.
 
You can start parallel execution of VIRT-TEST jobs by:
    ./run --jobs-file [jobs_file] --jobs-max [maximal number of jobs run in parallel]

   [jobs_file] - text file where each line contains BACKEND;GUEST;MACHINE_TYPE;TEST[;OTHER OPTIONS] sequence in VIRT-TEST format (see parallel_run.txt), this file should not contain more than 1000 lines.

   [maximal number of jobs run in parallel] - maximal number of tests which could be executed simultaneously. If this parameter is equal to one, all tests will be executed in serial manner.

parallel_run.txt:
qemu;Ubuntu.14.04.1-server.x86_64;i440fx;io-github-autotest-qemu.ping.default_ping;--mem 2048 -v
qemu;Ubuntu.14.04.1-server.x86_64;i440fx;io-github-autotest-qemu.ping.default_ping;--mem 1024 -v
qemu;Ubuntu.14.04.1-server.i386;i440fx;io-github-autotest-qemu.unattended_install.cdrom.extra_cdrom_ks.default_install.aio_native;
qemu;Ubuntu.14.04.1-server.i386;i440fx;io-github-autotest-qemu.unattended_install.cdrom.extra_cdrom_ks.default_install.aio_native;

