### PR TITLE
Add parallel execution of multiple guests with different tests on single host (QEMU backend) 

### DIFF
--- a/run
+++ b/run
@@ -10,6 +10,9 @@ import traceback
 import signal
 import optparse
 import logging
+import tools.parallel
+import virttest.data_dir
+import time
 
 
 class StreamProxy(object):
@@ -336,6 +339,23 @@ class VirtTestRunParser(optparse.OptionParser):
                            help=("Don't clean up tmp files or VM processes at "
                                  "the end of a virt-test execution (useful "
                                  "for debugging)"))
+
+        general.add_option("--jobs-file", action="store",
+                           dest="jobs_file",
+                           help=("Full path to file with "
+                                 "BACKEND;GUEST;MACHINE_TYPE;TEST1 [TEST2][; OTHER]"
+                                 "list for parallel execution"))
+
+        general.add_option("--jobs-max", action="store",
+                           dest="jobs",
+                           type="int",
+                           help=("Max number of parallel jobs"))
+
+        general.add_option("--job-id", action="store",
+                           dest="job_id",
+                           default=None,
+                           type="int",
+                           help=("Job number, for internal use only!"))
 
         self.add_option_group(general)
 
@@ -778,6 +798,10 @@ class VirtTestApp(object):
         if not self.options.vt_config:
             if not self.options.vt_keep_image_between_tests:
                 self.cartesian_parser.assign("restore_image", "yes")
+        # Disable back up for parallel jobs
+        if self.options.job_id:
+            self.cartesian_parser.assign("restore_image", "no")
+            self.cartesian_parser.assign("backup_image_before_testing", "no")
 
     def _process_mem(self):
         self.cartesian_parser.assign("mem", self.options.vt_mem)
@@ -976,4 +1000,55 @@ class VirtTestApp(object):
 
 if __name__ == '__main__':
     app = VirtTestApp()
-    app.main()
+
+    if app.options.jobs_file:
+        if not os.path.exists(app.options.jobs_file):
+            print "There is no", app.options.jobs_file
+            exit(1)
+        parent_logdir = os.path.join(virttest.data_dir.get_root_dir(),
+                                     'logs',
+                                     'parallel-run-' +
+                                     time.strftime('%Y-%m-%d-%H.%M.%S'))
+        os.makedirs(parent_logdir)
+        subprocess_job_id = 1
+        cmd_lines = []
+        input_lines = [line.strip() for line in open(app.options.jobs_file, 'r')]
+        for line in input_lines:
+            value = line.split(';')
+            if len(value) > 4:
+                extra_opts = value[4]
+            else:
+                extra_opts = ""
+            subprocess_cmd_line = ''.join([__file__,
+                                           ' -t ', value[0],
+                                           ' -g ', value[1],
+                                           ' --machine-type=', value[2],
+                                           ' --tests=', value[3],
+                                           ' --job-id ', str(subprocess_job_id),
+                                           ' --logs-dir ', parent_logdir,
+                                           ' ', extra_opts
+                                           ])
+
+            cmd_lines.append(subprocess_cmd_line)
+            subprocess_job_id = subprocess_job_id + 1
+
+        try:
+            dargs = {}
+            if app.options.jobs:
+                dargs['max_simultaneous_procs'] = app.options.jobs
+            else:
+                dargs['max_simultaneous_procs'] = 1
+            dargs['list_of_functions'] = False
+            pe = tools.parallel.ParallelExecute(cmd_lines, **dargs)
+            pe.run_until_completion()
+            print "That's all, folks!"
+            from virttest import standalone_test
+            standalone_test.cleanup_env(app.cartesian_parser, app.options)
+            print "Environment was cleaned."
+        except tools.parallel.ParallelError, err:
+            print "Parallel Run Exception!"
+            sys.exit(1)
+
+        sys.exit(0)
+    else:
+        app.main()

--- a/virt.py
+++ b/virt.py
@@ -74,7 +74,7 @@ class virt(test.test):
         else:
             env_path = params.get("vm_type")
         env_filename = os.path.join(self.bindir, "backends", env_path,
-                                    params.get("env", "env"))
+                                    (params.get("env", "env") + str(params.get("job_id"))))
         env = utils_env.Env(env_filename, self.env_version)
         other_subtests_dirs = params.get("other_tests_dirs", "")
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -732,6 +732,22 @@ def preprocess(test, params, env):
         else:
             kernel_extra_params_remove += " pci=nomsi"
 
+    # Create new image for specific job with backing_file option
+    if params.get('job_id') != "":
+        base_dir = data_dir.get_data_dir()
+        image_filename = storage.get_image_filename(params, base_dir)
+        if params.get('subtest') == "io-github-autotest-qemu.unattended_install":
+            params["image_size"] = "50G"
+        else:
+            params["has_backing_file"] = "yes"
+            params["image_name_backing_file"] = params.get('image_name')
+            params["image_format_backing_file"] = params.get("image_format", "qcow2")
+        params["image_name"] = params.get('image_name') + "_job_" + str(params.get('job_id'))
+        new_job_image = qemu_storage.QemuImg(params, base_dir, '')
+        job_image_filename, create_result = new_job_image.create(params)
+        if create_result.exit_status != 0:
+            raise error.TestError("Failed to create backing image")
+
     if kernel_extra_params_add or kernel_extra_params_remove:
         global kernel_cmdline, kernel_modified
         image_filename = storage.get_image_filename(params,

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -36,6 +36,28 @@ class QemuImg(storage.QemuImg):
                              verbose=False)
         self.help_text = q_result.stdout
 
+    def _get_image_size_info(self, params, file_name=None):
+        if file_name is None:
+            file_name = self.image_filename
+        cmd = utils_misc.get_qemu_img_binary(params)
+        cmd += " info"
+        cmd += " %s" % file_name
+
+        try:
+            output = utils.system_output(cmd)
+        except error.CmdError, err:
+            logging.error("Get info of image '%s' failed: %s", file_name, str(err))
+            return None
+
+        sub_info = "virtual size" + ": (.*)"
+        matches = re.findall(sub_info, output)
+        if matches:
+            size_line = matches[0].split(':')
+            img_size = size_line[0].split(' ')
+            return img_size[0]
+        else:
+            return self.img_size
+
     @error.context_aware
     def create(self, params, ignore_errors=False):
         """
@@ -95,6 +117,7 @@ class QemuImg(storage.QemuImg):
             encrypted = params.get("encrypted", "off")
             image_extra_params = params.get("image_extra_params", "")
             has_backing_file = params.get('has_backing_file')
+            new_image_size = self.size
 
             qemu_img_cmd += " -o "
             if self.image_format == "qcow2":
@@ -115,6 +138,7 @@ class QemuImg(storage.QemuImg):
                     qemu_img_cmd += "backing_file=%s," % backing_file
 
                     qemu_img_cmd += "backing_fmt=%s," % backing_fmt
+                    new_image_size = self._get_image_size_info(params, backing_file)
 
             if image_extra_params:
                 qemu_img_cmd += "%s," % image_extra_params
@@ -129,7 +153,7 @@ class QemuImg(storage.QemuImg):
 
             qemu_img_cmd += " %s" % self.image_filename
 
-            qemu_img_cmd += " %s" % self.size
+            qemu_img_cmd += " %s" % new_image_size
 
         if (params.get("image_backend", "filesystem") == "filesystem"):
             image_dirname = os.path.dirname(self.image_filename)

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -128,6 +128,8 @@ class Test(object):
         self.logfile = None
         self.file_handler = None
         self.background_errors = Queue.Queue()
+        if options.job_id:
+            self.job_id = options.job_id
 
     def set_debugdir(self, debugdir):
         self.debugdir = os.path.join(debugdir, self.tag)
@@ -170,6 +172,11 @@ class Test(object):
     def run_once(self):
         params = self.params
 
+        if hasattr(self, 'job_id'):
+            params['job_id'] = str(self.job_id)
+        else:
+            params['job_id'] = ""
+
         # If a dependency test prior to this test has failed, let's fail
         # it right away as TestNA.
         if params.get("dependency_failed") == 'yes':
@@ -195,7 +202,7 @@ class Test(object):
         # Open the environment file
         env_filename = os.path.join(
             data_dir.get_backend_dir(params.get("vm_type")),
-            params.get("env", "env"))
+            (params.get("env", "env") + params.get('job_id')))
         env = utils_env.Env(env_filename, self.env_version)
 
         test_passed = False
@@ -510,7 +517,7 @@ def configure_console_logging(loglevel=logging.DEBUG):
     return stream_handler
 
 
-def configure_file_logging(logfile, loglevel=logging.DEBUG):
+def configure_file_logging(logfile, loglevel=logging.DEBUG, infofile=None):
     """
     Simple helper for adding a file logger to the root logger.
     """
@@ -523,6 +530,12 @@ def configure_file_logging(logfile, loglevel=logging.DEBUG):
 
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
+
+    if infofile:
+        info_handler = logging.FileHandler(filename=infofile)
+        info_handler.setLevel(logging.INFO)
+        info_handler.setFormatter(formatter)
+        logger.addHandler(info_handler)
 
     return file_handler
 
@@ -779,6 +792,23 @@ def cleanup_env(parser, options):
                      "files and VM processes...")
         logging.info("")
     else:
+        logging.info("Cleaning env files...")
+        if parser is not None:
+            d = parser.get_dicts().next()
+            if hasattr(options, 'job_id'):
+                job_id_str = str(options.job_id)
+            else:
+                job_id_str = ""
+            env_filename = os.path.join(data_dir.get_root_dir(),
+                                        options.type, (d.get("env", "env") + job_id_str))
+            env = utils_env.Env(filename=env_filename, version=Test.env_version)
+            env.destroy()
+        # Kill all tail_threads which env constructor recreate, for standalone test only
+        if hasattr(options, 'job_id'):
+            if options.job_id is not None:
+                logging.info("Don't clean tmp files per job...")
+                return
+
         logging.info("Cleaning tmp files and VM processes...")
         d = parser.get_dicts().next()
         env_filename = os.path.join(data_dir.get_root_dir(),
@@ -794,7 +824,7 @@ def cleanup_env(parser, options):
         logging.info("")
 
 
-def _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed):
+def _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed, job_id=None):
     """
     Print to stdout and run log stats of our test job.
 
@@ -803,6 +833,12 @@ def _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed):
     :param n_tests_skipped: Total Number of tests skipped.
     :param n_tests_passed: Number of tests that passed.
     """
+
+    if job_id is not None:
+        job_id_header = "[ JOB %d ]" % job_id
+    else:
+        job_id_header = ''
+
     minutes, seconds = divmod(job_elapsed_time, 60)
     hours, minutes = divmod(minutes, 60)
 
@@ -817,7 +853,7 @@ def _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed):
     if hours or minutes:
         total_time_str += " (%s)" % pretty_time
 
-    print_header(total_time_str)
+    print_header(job_id_header + total_time_str)
     logging.info("Job total elapsed time: %.2f s", job_elapsed_time)
 
     n_tests_passed = n_tests - n_tests_skipped - n_tests_failed
@@ -826,11 +862,11 @@ def _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed):
         success_rate = ((float(n_tests_passed) /
                          float(n_tests - n_tests_skipped)) * 100)
 
-    print_header("TESTS PASSED: %d" % n_tests_passed)
-    print_header("TESTS FAILED: %d" % n_tests_failed)
+    print_header(job_id_header + "TESTS PASSED: %d" % n_tests_passed)
+    print_header(job_id_header + "TESTS FAILED: %d" % n_tests_failed)
     if n_tests_skipped:
-        print_header("TESTS SKIPPED: %d" % n_tests_skipped)
-    print_header("SUCCESS RATE: %.2f %%" % success_rate)
+        print_header(job_id_header + "TESTS SKIPPED: %d" % n_tests_skipped)
+    print_header(job_id_header + "SUCCESS RATE: %.2f %%" % success_rate)
 
     logging.info("Tests passed: %d", n_tests_passed)
     logging.info("Tests failed: %d", n_tests_failed)
@@ -851,6 +887,8 @@ def run_tests(parser, options):
     test_start_time = time.strftime('%Y-%m-%d-%H.%M.%S')
     logdir = options.vt_log_dir or os.path.join(data_dir.get_root_dir(), 'logs')
     debugbase = 'run-%s' % test_start_time
+    if options.job_id:
+        debugbase = '%d' % options.job_id + '-' + debugbase
     debugdir = os.path.join(logdir, debugbase)
     latestdir = os.path.join(logdir, "latest")
     if not os.path.isdir(debugdir):
@@ -862,8 +900,12 @@ def run_tests(parser, options):
     os.symlink(debugbase, latestdir)
 
     debuglog = os.path.join(debugdir, "debug.log")
+    if options.job_id:
+        brieflog = os.path.join(debugdir, "info.log")
+    else:
+        brieflog = None
     loglevel = options.vt_log_level
-    configure_file_logging(debuglog, loglevel)
+    configure_file_logging(debuglog, loglevel, brieflog)
 
     print_stdout(bcolors.HEADER +
                  "DATA DIR: %s" % data_dir.get_backing_data_dir() +
@@ -1048,6 +1090,6 @@ def run_tests(parser, options):
 
     job_end_time = time.time()
     job_elapsed_time = job_end_time - job_start_time
-    _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed)
+    _job_report(job_elapsed_time, n_tests, n_tests_skipped, n_tests_failed, options.job_id)
 
     return not failed


### PR DESCRIPTION
   This commit extends virt-test functionality to parallel execution of various tests for different guests.
   In general, it get JOBS (guest + test) from text file and executes it by 'run' script (forking initial run process). It separates execution environment for each job. In order to avoid corruption of guest images it creates snapshots of original image with job_ID suffix.
   It was tested with ping and unattended test for CentOS and Ubuntu guests by qemu backend.

   You can start parallel execution of VIRT-TEST jobs by:

   ./run --jobs-file [jobs_file] --jobs-max [maximal number of jobs run in parallel]

   [jobs_file] - text file where each line contains BACKEND;GUEST;MACHINE_TYPE;TEST[;OTHER OPTIONS] sequence in VIRT-TEST format (see parallel_run.txt), this file should not contain more than 1000 lines.

      BACKEND - virt-test backend name (like for "-t" option of run script), tested only with "qemu".
      GUEST - name of guest OS in format of virt-test (run "./run -t qemu --list-guests").
      MACHINE_TYPE - QEMU machine architecture [ i440fx | q35 ].
      TEST - test name in format of virt-test (run "./run -t qemu --list-tests").
      OTHER OPTIONS - extra options which would be passed to run script.

   [maximal number of jobs run in parallel] - maximal number of tests which could be executed simultaneously. If this parameter is equal to one, all tests will be executed in serial manner.

parallel_run.txt:
qemu;Ubuntu.14.04.1-server.x86_64;i440fx;io-github-autotest-qemu.ping.default_ping;--mem 2048 -v
qemu;Ubuntu.14.04.1-server.x86_64;i440fx;io-github-autotest-qemu.ping.default_ping;--mem 1024 -v
qemu;Ubuntu.14.04.1-server.i386;i440fx;io-github-autotest-qemu.unattended_install.cdrom.extra_cdrom_ks.default_install.aio_native;
qemu;Ubuntu.14.04.1-server.i386;i440fx;io-github-autotest-qemu.unattended_install.cdrom.extra_cdrom_ks.default_install.aio_native;