### PR TITLE
virttest: Support iothread in qemu command

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1392,7 +1392,10 @@ class DevContainer(object):
         devices[-1].set_param('min_io_size', min_io_size)
         devices[-1].set_param('opt_io_size', opt_io_size)
         devices[-1].set_param('bootindex', bootindex)
-        devices[-1].set_param('x-data-plane', x_data_plane, bool)
+        if x_data_plane in ["yes", "no", "on", "off"]:
+            devices[-1].set_param('x-data-plane', x_data_plane, bool)
+        else:
+            devices[-1].set_param('iothread', x_data_plane)
         if 'serial' in options:
             devices[-1].set_param('serial', serial)
             devices[-2].set_param('serial', None)   # remove serial from drive

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1347,6 +1347,14 @@ class VM(virt_vm.BaseVM):
             for dev in devices.usbc_by_params(usb_name, usb_params):
                 devices.insert(dev)
 
+        for iothread in params.get("iothreads", "").split():
+            cmd = "-object iothread,"
+            iothread_id = params.get("%s_id" % iothread.strip())
+            if not iothread_id:
+                iothread_id = iothread.strip()
+            cmd += "id=%s" % iothread_id
+            devices.insert(StrDev("IOthread_%s" % iothread_id, cmdline=cmd))
+
         # Add images (harddrives)
         for image_name in params.objects("images"):
             # FIXME: Use qemu_devices for handling indexes


### PR DESCRIPTION
Now we can set x-data-plane in following two ways:

iothreads = "iothread1 iotherad2"
iothread1_id = id_iothread1
x-data-plane = id_iothread1
Set x-data-plane to id of iothread1, will create command:
-object iothread,id=id_iothread1
-device virtio-blk-pci,id=image1,drive=drive_image1,bootindex=0,iothread=id_iothread1,bus=pci.0,addr=04

images += " disk1"
image_name_disk1 = images/storage
image_size_disk1 = 10G
x-data-plane_disk1 = yes

In rhel6 we only support x-data-plane = on/off. Set x-data-plane to yes,
will create command:
-device virtio-blk-pci,id=disk1,drive=drive_disk1,bootindex=1,x-data-plane=on,bus=pci.0,addr=05

Signed-off-by: Feng Yang <fyang@redhat.com>