### PR TITLE
shared.unattended: Updating RHEL-6-spice.ks for RHEL 6.7

### DIFF
--- a/shared/unattended/RHEL-6-spice.ks
+++ b/shared/unattended/RHEL-6-spice.ks
@@ -60,6 +60,7 @@ iptables -F
 echo 0 > /selinux/enforce
 chkconfig NetworkManager on
 sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+sed -i "s/^/#/g" /etc/udev/rules.d/70-persistent-net.rules
 cat > '/etc/gdm/custom.conf' << EOF
 [daemon]
 AutomaticLogin=test
@@ -76,6 +77,9 @@ modprobe snd-aloop
 modprobe snd-pcm-oss
 modprobe snd-mixer-oss
 modprobe snd-seq-oss
+EOF
+cat >> '/etc/rc.local' << EOF
+sed -i "s/^/#/g" /etc/udev/rules.d/70-persistent-net.rules
 EOF
 chmod +x /etc/rc.modules
 ECHO 'Post set up finished'


### PR DESCRIPTION
Autotest generates a random mac address for the nic device. Udev rules
will generate a new interface for each "new" device when guest boots
up. So the nic interface changes and this confuses the network manager
inside guest which leads to system will not get "new" interface get IP
address automatically.

To avoid this, we comment out the rule being created with each boot.
This will allow the device to get IP address automatically.

Reviewed By: Swapna Krishnan <skrishna@redhat.com>