### PR TITLE
shared.cfg.guest_os: Cleanup and fixups in RHEL kickstarts

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -7,5 +7,14 @@
         modprobe_module = acpiphp
         no block_scsi
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        kernel_params = "ks=cdrom"
+        extra_cdrom_ks:
+            kernel_params += ":sr1:/ks.cfg"
+        kernel_params += " nicdelay=60 "
+        aarch64:
+            kernel_params += " efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
+        ppc64:
+            kernel_params += " console=hvc0"
+        x86_64, i386:
+            kernel_params += " console=ttyS0,115200 console=tty0"
         boot_path = images/pxeboot
-        kernel_params = "ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0"

--- a/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
@@ -7,7 +7,6 @@
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
     unattended_install:
-        kernel_params = "nicdelay=60 console=hvc0"
         cdrom_unattended = images/rhel70-ppc64/ks.iso
         kernel = images/rhel70-ppc64/vmlinuz
         initrd = images/rhel70-ppc64/initrd.img

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
@@ -8,6 +8,4 @@
         kernel = images/rhel7-aarch64/vmlinuz
         initrd = images/rhel7-aarch64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        # don't append kernel_params, but override them (otherwise install happens in ttyS0 instead of ttyAMA0)
-        kernel_params = "ks=cdrom:sr1:/ks.cfg text efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait "
         cdrom_cd1 = isos/linux/RHEL-7-devel-aarch64.iso

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
@@ -7,7 +7,6 @@
     mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
     netdev_peer_re = "(.*?): .*?\\\s(.*?):"
     unattended_install:
-        kernel_params = "nicdelay=60 console=hvc0"
         cdrom_unattended = images/rhel7-ppc64/ks.iso
         kernel = images/rhel7-ppc64/vmlinuz
         initrd = images/rhel7-ppc64/initrd.img

--- a/shared/unattended/CentOS-7-0.ks
+++ b/shared/unattended/CentOS-7-0.ks
@@ -1,5 +1,6 @@
 install
 KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
 poweroff
 lang en_US.UTF-8
 keyboard us

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -1,5 +1,6 @@
 install
 KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
 poweroff
 lang en_US.UTF-8
 keyboard us

--- a/shared/unattended/RHEL-7-spice.ks
+++ b/shared/unattended/RHEL-7-spice.ks
@@ -1,9 +1,10 @@
 install
 KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
 poweroff
 lang en_US.UTF-8
 keyboard us
-network --bootproto dhcp 
+network --bootproto dhcp
 rootpw --plaintext 123456
 firstboot --disable
 user --name=test --password=123456

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -9,7 +9,7 @@ import shutil
 import xml.dom.minidom
 from autotest.client.shared import error, iso9660
 from autotest.client import utils
-from virttest import virt_vm, utils_misc, utils_disk
+from virttest import arch, virt_vm, utils_misc, utils_disk
 from virttest import qemu_monitor, remote, syslog_server
 from virttest import http_server, data_dir, utils_net, utils_test
 from virttest import funcatexit, storage
@@ -139,7 +139,7 @@ class UnattendedInstallConfig(object):
                            'process_check', 'vfd_size', 'cdrom_mount_point',
                            'floppy_mount_point', 'cdrom_virtio',
                            'virtio_floppy', 're_driver_match',
-                           're_hardware_id', 'driver_in_floppy']
+                           're_hardware_id', 'driver_in_floppy', 'vga']
 
         for a in self.attributes:
             setattr(self, a, params.get(a, ''))
@@ -340,6 +340,13 @@ class UnattendedInstallConfig(object):
             else:
                 l = ''
             contents = re.sub(dummy_logging_re, l, contents)
+
+        dummy_graphical_re = re.compile('GRAPHICAL_OR_TEXT')
+        if dummy_graphical_re.search(contents):
+            if not self.vga or self.vga.lower() == "none":
+                contents = dummy_graphical_re.sub('text', contents)
+            else:
+                contents = dummy_graphical_re.sub('graphical', contents)
 
         logging.debug("Unattended install contents:")
         for line in contents.splitlines():


### PR DESCRIPTION
Hi guys,

this pull request contains 2 changes. First one is a bugfix found by @swapnakrishnan2k and it sets graphical or text installation based on "vga" param.

The second is RHEL kickstart refactor and minor issue fix.

Regards,
Lukáš