### PR TITLE
shared/cfg/guest-os/Linux/RHEL.cfg: Revert change from 04350d9718

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -8,8 +8,10 @@
         no block_scsi
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         kernel_params = "ks=cdrom"
-        extra_cdrom_ks:
-            kernel_params += ":sr1:/ks.cfg"
+        # The below config breaks RHEL6 x86, so it's commented out until we figure out a decent
+        # solution that works across the board.
+        #extra_cdrom_ks:
+        #    kernel_params += ":sr1:/ks.cfg"
         kernel_params += " nicdelay=60 "
         aarch64:
             kernel_params += " efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"


### PR DESCRIPTION
This reverts one change made on 04350d9718 to unify kernel params
for RHEL versions.

Apparently RHEL6 x86 anaconda doesn't like ks=cdrom:sr1:/ks.cfg and
can't find the kickstart anymore. I can't really leave the x86 case
broken, so I'll have to revert this particular change. The change
was tested and reported to work on RHEL7 x86.

CC: Lukas Doktor <ldoktor@redhat.com>
Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>