### PR TITLE
virttest.env_process: Refactor and enhance inactivity_watcher

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -17,7 +17,6 @@ variants:
         machine_type = pseries
         # No support for VGA yet
         vga = none
-        inactivity_watcher = none
         take_regular_screendumps = no
         # No support for USB-uhci
         usb_type = pci-ohci
@@ -30,7 +29,6 @@ variants:
         machine_type = virt
         # No support for VGA yet
         vga = none
-        inactivity_watcher = none
         take_regular_screendumps = no
         # Currently no USB support
         usbs =

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1173,7 +1173,7 @@ def _take_screendumps(test, params, env):
             counter[vm.instance] += 1
             filename = "%04d.jpg" % counter[vm.instance]
             screendump_filename = os.path.join(screendump_dir, filename)
-            vm.verify_bsod(screendump_filename)
+            vm.verify_bsod(temp_filename)
             image_hash = utils.hash_file(temp_filename)
             if image_hash in cache:
                 time_inactive = time.time() - inactivity[vm.instance]


### PR DESCRIPTION
This patchset refactors the screendump process' code and extends it to check serial port output too. As an outcome it enables inactivity_check for display-less machine types.

Please read the details in corresponding patches.