### PR TITLE
virttest: Turn off export of volume through NFS

### DIFF
--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -335,3 +335,24 @@ def add_rpc_insecure(filepath):
         cmd = "sed -i '/end-volume/i \ \ \ \ option rpc-auth-allow-insecure on' %s" % filepath
         utils.system(cmd)
         utils.system("service glusterd restart; sleep 2")
+
+
+@error.context_aware
+def gluster_nfs_disable(vol_name):
+    """
+    Turn-off export of volume through NFS
+    :param vol_name: name of gluster volume
+    """
+
+    cmd = "gluster volume set %s nfs.disable on" % vol_name
+    error.context("Volume set nfs.disable failed")
+    utils.system(cmd)
+
+    cmd = "gluster volume info"
+    output = utils.system_output(cmd)
+    match = re.findall(r'nfs.disable: on', output)
+
+    if not match:
+        return False
+    else:
+        return True

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -516,6 +516,9 @@ def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
         logging.debug("finish start gluster")
         gluster.gluster_vol_create(vol_name, ip_addr, brick_path, force=True)
         gluster.gluster_allow_insecure(vol_name)
+        gluster.gluster_nfs_disable(vol_name)
+        output = utils.system_output("cat %s" % file_path)
+        logging.debug("The contents of %s: \n%s", file_path, output)
         logging.debug("finish vol create in gluster")
         return ip_addr
     else:


### PR DESCRIPTION
NFS should not be used to support the lock volume used by CTDB as NFS does not currently support locking. Instead, use the Gluster native mount. 

Signed-off-by: Alex Jia <ajia@redhat.com>