### PR TITLE
Fixup: changed default cpu model to 'host' as it pickup unknown model

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -15,6 +15,8 @@ variants:
     - @pseries:
         only ppc64
         machine_type = pseries
+        auto_cpu_model = "no"
+        cpu_model = host
         # No support for VGA yet
         vga = none
         inactivity_watcher = none


### PR DESCRIPTION
Fixup: changed default cpu model to 'host' as it pickup unknown model