### PR TITLE
Adding support for iothreads

### DIFF
--- a/run
+++ b/run
@@ -410,6 +410,10 @@ class VirtTestRunParser(optparse.OptionParser):
                         default="on",
                         help=("Enable qemu sandboxing "
                               "(on/off). Default: %default"))
+        qemu.add_option("--iothreads", action="store", dest="iothreads",
+                        default="off",
+                        help=("Enable qemu device threading "
+                            "(on/off). Default: %default"))
         self.add_option_group(qemu)
 
         libvirt = optparse.OptionGroup(self, 'Options specific to the libvirt test')
@@ -647,6 +651,13 @@ class VirtTestApp(object):
         else:
             logging.info("Config provided, ignoring \"--sandbox <on|off>\" option")
 
+    def _process_iothreads(self):
+        if not self.options.config:
+            if self.options.iothreads == "on":
+                self.cartesian_parser.assign("iothreads", "on")
+        else:
+            logging.info("Config provided, ignoring \"--iothreads <on|off>\" option")
+
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
                                      self.options.malloc_perturb)
@@ -668,6 +679,7 @@ class VirtTestApp(object):
         self._process_vhost()
         self._process_malloc_perturb()
         self._process_qemu_sandbox()
+        self._process_iothreads()
 
     def _process_lvsb_specific_options(self):
         """

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1064,7 +1064,7 @@ class DevContainer(object):
                                    readonly=None, scsiid=None, lun=None, aio=None,
                                    strict_mode=None, media=None, imgfmt=None,
                                    pci_addr=None, scsi_hba=None, x_data_plane=None,
-                                   blk_extra_params=None, scsi=None,
+                                   iothread_id=None, blk_extra_params=None, scsi=None,
                                    pci_bus='pci.0', drv_extra_params=None,
                                    num_queues=None, bus_extra_params=None,
                                    force_fmt=None):
@@ -1104,6 +1104,8 @@ class DevContainer(object):
         :param scsi_hba: Custom scsi HBA
         :param num_queues: performace option for virtio-scsi-pci
         :param bus_extra_params: options want to add to virtio-scsi-pci bus
+        :param x_data_plane: required for iothreads
+        :param iothread: name of the thread assinged to the device
         """
         def define_hbas(qtype, atype, bus, unit, port, qbus, pci_bus,
                         addr_spec=None, num_queues=None,
@@ -1391,7 +1393,10 @@ class DevContainer(object):
         devices[-1].set_param('min_io_size', min_io_size)
         devices[-1].set_param('opt_io_size', opt_io_size)
         devices[-1].set_param('bootindex', bootindex)
-        devices[-1].set_param('x-data-plane', x_data_plane, bool)
+        if iothread_id is not None:
+            iothread_object = "iothread%s" % str(iothread_id)
+            devices[-1].set_param('x-data-plane', x_data_plane, bool)
+            devices[-1].set_param('iothread', iothread_object)
         if 'serial' in options:
             devices[-1].set_param('serial', serial)
             devices[-2].set_param('serial', None)   # remove serial from drive
@@ -1464,6 +1469,7 @@ class DevContainer(object):
                                                image_params.get("scsi_hba"),
                                                image_params.get(
                                                    "x-data-plane"),
+                                               image_params.get("iothread_id"),
                                                image_params.get(
                                                    "blk_extra_params"),
                                                image_params.get("virtio-blk-pci_scsi"),
@@ -1545,6 +1551,7 @@ class DevContainer(object):
                                                image_params.get("scsi_hba"),
                                                image_params.get(
                                                    "x-data-plane"),
+                                               image_params.get("iothread_id"),
                                                image_params.get(
                                                    "blk_extra_params"),
                                                image_params.get("virtio-blk-pci_scsi"),


### PR DESCRIPTION
This patch introduces full support for iothreads in virt-test. If
--iothreads=on is passed to ./run.py, the main disk_images for qemu boot
will start with -object iothread,id=iothread1 and then assigned the
iothread id to the device.

This patch is the base support for the test multi_disk_random_hotplug to
use iothreads as well.

Signed-off-by: Eduardo Otubo <eduardo.otubo@profitbricks.com>