### PR TITLE
virttest/libvirt_vm: check if install package successfully

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2326,7 +2326,9 @@ class VM(virt_vm.BaseVM):
             # Install the package if it does not exists
             cmd = "rpm -q %s || yum install -y %s" % (name, name)
             status, output = session.cmd_status_output(cmd, timeout=300)
-            if status != 0:
+            # Just check status is not enough
+            # It's necessary to check if install successfully
+            if status != 0 or session.cmd_status("rpm -q %s" % name) != 0:
                 raise virt_vm.VMError("Installation of package %s failed:\n%s" %
                                       (name, output))
         finally:


### PR DESCRIPTION
Just check the status is not safe,
although the status is zero, but package is not installed.
for example,
the ouput of session.cmd_status_output() as follow,

03:18:59 DEBUG| Sending command: rpm -q qemu-guest-agent ||
yum install -y qemu-guest-agent
03:18:59 DEBUG| Sending command: echo $?
(0, 'rpm -q qemu-guest-agent || yum install -y
qemu-guest-agen<qemu-guest-agent || yum install -y qemu-guest-agent
\x08\0x08\0x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\npackage
qemu-guest-agent is not installed\n
Loaded plugins: product-id, security, subscription-manager\n
This system is not registered to Red Hat Subscription
Management. You can use subscription-manager to register.\n
Setting up Install Process\n
No package qemu-guest-agent available.\nNothing to do\n')

so it's necessary to run 'rpm -q qemu-guest-agent' again on guest.