### PR TITLE
virt: update autoinstall.xml for sles10

### DIFF
--- a/shared/unattended/SLES-10.xml
+++ b/shared/unattended/SLES-10.xml
@@ -556,6 +556,9 @@ sed -i -e 's/\(PasswordAuthentication\s\)no/\1yes/g'  /etc/ssh/sshd_config
 service sshd restart
 service network restart
 service NetworkManager restart
+mv /etc/sysconfig/network/ifcfg-eth-id-* /etc/sysconfig/network/ifcfg-eth0
+sed -i '/_nm_name/d' -e '/UNIQUE/d' /etc/sysconfig/network/ifcfg-eth0
+ln -sf /dev/null /etc/udev/rules.d/30-net_persistent_names.rules
 ]]></source>
       </script>
     </init-scripts>


### PR DESCRIPTION
clean net udev rules and rename eth configuration to
make guest get ip address from dhcp server by default.

Signed-off-by: Xu Tian <xutian@redhat.com>