### PR TITLE
virttest/nfs: replace shutil.rmtree with safe_rmdir

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -227,7 +227,7 @@ class Nfs(object):
         if self.nfs_setup and self.unexportfs_in_clean:
             self.exportfs.reset_export()
         if self.mk_mount_dir and os.path.isdir(self.mount_dir):
-            shutil.rmtree(self.mount_dir)
+            utils.safe_rmdir(self.mount_dir)
 
 
 class NFSClient(object):


### PR DESCRIPTION
It's not safe that call shutil.rmtree to delete dir on NFS,
which maybe suffer from error 39 (directory not empty).
Please refer to the docstring of safe_rmdir for details.