### PR TITLE
virttest: Improve the ppc64le support

### DIFF
--- a/virttest/arch.py
+++ b/virttest/arch.py
@@ -3,7 +3,7 @@ from virttest import utils_misc
 
 ARCH = platform.machine()
 
-if ARCH == "ppc64" or ARCH == "ppc64le":
+if ARCH in ('ppc64', 'ppc64le'):
     # From include/linux/sockios.h
     SIOCSIFHWADDR = 0x8924
     SIOCGIFHWADDR = 0x8927
@@ -78,5 +78,5 @@ def get_kvm_module_list():
         arch_convert = {'GenuineIntel': 'intel', 'AuthenticAMD': 'amd'}
         host_cpu_type = utils_misc.get_cpu_vendor(verbose=False)
         return ["kvm", "kvm-%s" % arch_convert[host_cpu_type]]
-    elif ARCH == 'ppc64' or ARCH == "ppc64le":
+    elif ARCH in ('ppc64', 'ppc64le'):
         return ["kvm"]

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -718,7 +718,7 @@ class DevContainer(object):
                 i += 1
 
         for i in xrange(i / 7):     # Autocreated lsi hba
-            if arch.ARCH == 'ppc64':
+            if arch.ARCH in ('ppc64', 'ppc64le'):
                 _name = 'spapr-vscsi%s' % i
                 bus = qbuses.QSCSIBus("scsi.0", 'SCSI', [8, 16384],
                                       atype='spapr-vscsi')
@@ -1223,7 +1223,7 @@ class DevContainer(object):
                                  "support; ignoring bus/unit/port. (%s)", name)
                     bus, unit, port = None, None, None
                 # In case we hotplug, lsi wasn't added during the startup hook
-                if arch.ARCH == 'ppc64':
+                if arch.ARCH in ('ppc64', 'ppc64le'):
                     _ = define_hbas('SCSI', 'spapr-vscsi', None, None, None,
                                     qbuses.QSCSIBus, pci_bus, [8, 16384])
                 else:
@@ -1325,7 +1325,7 @@ class DevContainer(object):
             if fmt == 'ide':
                 devices[-1].parent_bus = ({'type': fmt.upper(), 'atype': fmt},)
             elif fmt == 'scsi':
-                if arch.ARCH == 'ppc64':
+                if arch.ARCH in ('ppc64', 'ppc64le'):
                     devices[-1].parent_bus = ({'atype': 'spapr-vscsi',
                                                'type': 'SCSI'},)
                 else:

--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -490,7 +490,7 @@ class QtreeDisksContainer(object):
             """ checks the drive format according to qtree info """
             expected = params.get('drive_format')
             if expected == 'scsi':
-                if arch.ARCH == 'ppc64':
+                if arch.ARCH in ('ppc64', 'ppc64le'):
                     expected = 'spapr-vscsi'
                 else:
                     expected = 'lsi53c895a'

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -417,7 +417,7 @@ class VM(virt_vm.BaseVM):
             return cmd
 
         def add_serial(devices, name, filename):
-            if (arch.ARCH in ('ppc64', 'aarch64') or
+            if (arch.ARCH in ('ppc64', 'ppc64le', 'aarch64') or
                     not devices.has_option("chardev")):
                 return " -serial unix:'%s',server,nowait" % filename
 

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1798,8 +1798,8 @@ def get_host_cpu_models():
             pattern += r".+(\b%s\b)" % i
         return pattern
 
-    if ARCH == 'ppc64':
-        return ['POWER7']
+    if ARCH in ('ppc64', 'ppc64le'):
+        return []     # remove -cpu and leave it on qemu to decide
 
     cpu_types = {"AuthenticAMD": ["Opteron_G5", "Opteron_G4", "Opteron_G3",
                                   "Opteron_G2", "Opteron_G1"],

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2003,7 +2003,7 @@ def get_qemu_best_cpu_model(params):
         if host_cpu_model in qemu_cpu_models:
             return host_cpu_model
     # If no host cpu model can be found on qemu_cpu_models, choose the default
-    return params.get("default_cpu_model", "qemu64")
+    return params.get("default_cpu_model", None)
 
 
 def check_if_vm_vcpu_match(vcpu_desire, vm):


### PR DESCRIPTION
The first patch is related to `-cpu` defaults, which are not exactly optimal (inspired by: https://github.com/autotest/virt-test/pull/2131#issuecomment-93384466 )

The second adds checks for `ppc64le` wherever we check for `ppc64`.

I tested this on Power8 running RHEL7.1, unattended_install works fine without -cpu using `le` host os.