### PR TITLE
virt-test: some update for SLES.12 cfg.

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES/12.0.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/12.0.x86_64.cfg
@@ -5,6 +5,7 @@
     unattended_install, svirt_install:
         unattended_file = unattended/SLES-12.xml
         cdrom_unattended = images/sles-12-0-64/autoyast.iso
+        kernel_params = "autoyast=device://sr1/autoinst.xml console=ttyS0,115200 console=tty0"
         kernel = images/sles-12-0-64/linux
         initrd = images/sles-12-0-64/initrd
         boot_path = boot/x86_64/loader
@@ -12,6 +13,9 @@
         cdrom_cd1 = isos/linux/SLE-12-Server-DVD-x86_64-GM-DVD1.iso
         md5sum_cd1 = 64b50e62b9c5b603d83fe128adb7dc6c
         md5sum_1m_cd1 = da6b5dbb740819b22188f859cc5711c2
+    unattended_install.url, unattended_install.nfs:
+        kernel_params = "autoyast=device://sr0/autoinst.xml console=ttyS0,115200 console=tty0"
+
     unattended_install..floppy_ks:
         kernel_params = "autoyast=device://fd0/autoinst.xml console=ttyS0,115200 console=tty0"
         floppies = "fl"


### PR DESCRIPTION
In SLES.12, iso is called "/dev/sr*" now instead of
the old name "/dev/scd*", which is same as RHEL.7 now.

Signed-off-by: Cong Li <coli@redhat.com>