### PR TITLE
virttest: return os.path.exists()'s result directly

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1158,9 +1158,7 @@ class PciAssignable(object):
         """
         base_dir = "/sys/bus/pci"
         stub_path = os.path.join(base_dir, "drivers/%s" % self.device_driver)
-        if os.path.exists(os.path.join(stub_path, full_id)):
-            return True
-        return False
+        return os.path.exists(os.path.join(stub_path, full_id))
 
     @error.context_aware
     def sr_iov_setup(self):

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3136,9 +3136,7 @@ class VFIOController(object):
         """
         Check whether given vfio group has been established.
         """
-        if os.path.exists("/dev/vfio/%s" % group_id):
-            return True
-        return False
+        return os.path.exists("/dev/vfio/%s" % group_id)
 
 
 class SELinuxBoolean(object):

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -523,10 +523,7 @@ class Interface(object):
         Check Whether this Interface is a bridge port_to_br
         """
         path = os.path.join(SYSFS_NET_PATH, self.name)
-        if os.path.exists(os.path.join(path, "brport")):
-            return True
-        else:
-            return False
+        return os.path.exists(os.path.join(path, "brport"))
 
     def __netlink_pack(self, msgtype, flags, seq, pid, data):
         '''


### PR DESCRIPTION
library function os.path.exists() will return True if
path refers to an existing path. Otherwise, return False.
in other words,
no boolean conditional statements for os.path.exists() is OK.