### PR TITLE
utils_test.libvirt: Enable persistent option for LibvirtNetwork

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -95,7 +95,7 @@ class LibvirtNetwork(object):
         ip = utils_net.get_ip_address_by_interface(self.iface)
         return ip, net_xml
 
-    def __init__(self, net_type, address=None, iface=None):
+    def __init__(self, net_type, address=None, iface=None, persistent=False):
         self.name = 'virt-test-%s' % net_type
         self.address = address
         self.iface = iface
@@ -114,13 +114,18 @@ class LibvirtNetwork(object):
             self.ip, net_xml = self.create_bridge_xml()
         else:
             raise error.TestError('Unknown libvirt network type %s' % net_type)
-        net_xml.create()
+        if persistent:
+	    net_xml.define()
+	    net_xml.start()
+        else:
+	    net_xml.create()
 
     def destroy(self):
         """
         Clear up created network.
         """
-        return virsh.net_destroy(self.name)
+        virsh.net_destroy(self.name, ignore_status=True, debug=True)
+        virsh.net_undefine(self.name, ignore_status=True, debug=True)
 
 
 def cpus_parser(cpulist):


### PR DESCRIPTION
This change allows the temporary network created be set to
persistent or transient by changing an argument.

Signed-off-by: Hao Liu <hliu@redhat.com>