### PR TITLE
virttest: add option argument for virsh destroy

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1687,7 +1687,10 @@ class VM(virt_vm.BaseVM):
                             session.close()
             # Destroy VM directly, as 'ignore_status=True' by default, so destroy
             # a shutoff domain is also acceptable here.
-            virsh.destroy(self.name, uri=self.connect_uri)
+            destroy_opt = ''
+            if gracefully:
+                destroy_opt = '--graceful'
+            virsh.destroy(self.name, destroy_opt, uri=self.connect_uri)
 
         finally:
             self.cleanup_serial_console()

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1281,15 +1281,16 @@ def shutdown(name, options="", **dargs):
     return command("shutdown %s %s" % (name, options), **dargs)
 
 
-def destroy(name, **dargs):
+def destroy(name, options="", **dargs):
     """
     True on successful domain destruction
 
     :param name: VM name
+    :param options: options for virsh destroy
     :param dargs: standardized virsh function API keywords
     :return: CmdResult object
     """
-    return command("destroy %s" % (name), **dargs)
+    return command("destroy %s %s" % (name, options), **dargs)
 
 
 def define(xml_path, **dargs):


### PR DESCRIPTION
The gracefully paramter hadn't been considered.
This PR fix it.