### PR TITLE
virttest/utils_netperf: fix no return False

### DIFF
--- a/virttest/utils_netperf.py
+++ b/virttest/utils_netperf.py
@@ -222,7 +222,7 @@ class Netperf(object):
             return bool(check_reg.findall(output))
         except Exception, err:
             logging.debug("Check process error: %s" % str(err))
-        False
+        return False
 
     def stop(self, target):
         if self.client == "nc":


### PR DESCRIPTION
fixed that No return False for function is_target_running.