### PR TITLE
virsh: fix typo in domcapabilities command

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -4020,7 +4020,7 @@ def domcapabilities(virttype=None, emulatorbin=None, arch=None, machine=None,
     if virttype:
         cmd += " --virttype %s" % virttype
     if emulatorbin:
-        cmd += " --emulatorpin %s" % emulatorbin
+        cmd += " --emulatorbin %s" % emulatorbin
     if arch:
         cmd += " --arch %s" % arch
     if machine:


### PR DESCRIPTION
Fix typo of --emulatorbin option.

Signed-off-by: Wayne Sun <gsun@redhat.com>