### PR TITLE
virttest/utils_libguestfs: No set copyonread explicitly

### DIFF
--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -531,7 +531,10 @@ class GuestfishPersistent(Guestfish):
         if copyonread:
             cmd += " copyonread:true"
         else:
-            cmd += " copyonread:false"
+            # The default is false for copyonread.
+            # If copyonread param is false,
+            # It's no need to set " copyonread:false" explicitly.
+            pass
 
         return self.inner_cmd(cmd)
 


### PR DESCRIPTION
copyonread is unavailable on old guestfish and
" copyonread:false" cause errors, such as following on RHEL6.7,

><fs> add-drive-opts /iso/g/images/rhel6X-64.qcow2 \
      readonly:true copyonread:false
add-drive-opts: unknown optional argument "copyonread:false"
><fs>

And the default is false for copyonread,
so it's no need to set " copyonread:false" explicitly.
Please refer to manual for more details.