### PR TITLE
Support to -nodefconfig into QEMU command line.

### DIFF
--- a/run
+++ b/run
@@ -410,6 +410,11 @@ class VirtTestRunParser(optparse.OptionParser):
                         default="on",
                         help=("Enable qemu sandboxing "
                               "(on/off). Default: %default"))
+        qemu.add_option("--defconfig", action="store", dest="defconfig",
+                        default="yes",
+                        help=("Prevent qemu from loading sysconfdir/qemu.conf "
+                              "and sysconfdir/target-ARCH.conf at startup. "
+                              "(yes/no). Default: %default"))
         self.add_option_group(qemu)
 
         libvirt = optparse.OptionGroup(self, 'Options specific to the libvirt test')
@@ -647,6 +652,13 @@ class VirtTestApp(object):
         else:
             logging.info("Config provided, ignoring \"--sandbox <on|off>\" option")
 
+    def _process_qemu_defconfig(self):
+        if not self.options.config:
+            if self.options.defconfig == "no":
+                self.cartesian_parser.assign("defconfig", "no")
+        else:
+            logging.info("Config provided, ignoring \"--defconfig <yes|no>\" option")
+
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
                                      self.options.malloc_perturb)
@@ -668,6 +680,7 @@ class VirtTestApp(object):
         self._process_vhost()
         self._process_malloc_perturb()
         self._process_qemu_sandbox()
+        self._process_qemu_defconfig()
 
     def _process_lvsb_specific_options(self):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1204,6 +1204,10 @@ class VM(virt_vm.BaseVM):
         if devices.has_option("nodefaults") and defaults != "yes":
             devices.insert(StrDev('nodefaults', cmdline=" -nodefaults"))
 
+        # nodefconfig please
+        if params.get("defconfig", "yes") == "no":
+            devices.insert(StrDev('nodefconfig', cmdline=" -nodefconfig"))
+
         vga = params.get("vga")
         if vga:
             if vga != 'none':


### PR DESCRIPTION
The -nodefconfig parameter prevents QEMU from loading the
sysconfdir/qemu.conf and sysconfdir/target-ARCH.conf files at startup.

This patch adds support to virt-test add this parameter if specified by
user while launching virt-test.

Signed-off-by: Paulo Vital <paulo.vital@profitbricks.com>