### PR TITLE
virttest/qemu_vm: fix bug related to try-except-else

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2578,6 +2578,14 @@ class VM(virt_vm.BaseVM):
         True. If QEMU is running in -no-shutdown mode, the QEMU process
         may be still alive.
         """
+        def _shutdown_by_sendline():
+            try:
+                session.sendline(self.params.get("shutdown_command"))
+                if self.wait_for_shutdown(timeout):
+                    return True
+            finally:
+                session.close()
+
         if self.params.get("shutdown_command"):
             # Try to destroy with shell command
             logging.debug("Shutting down VM %s (shell)", self.name)
@@ -2591,16 +2599,14 @@ class VM(virt_vm.BaseVM):
                     session = self.serial_login()
                 except (remote.LoginError, virt_vm.VMError), e:
                     logging.debug(e)
+                else:
+                    # Successfully get session by serial_login()
+                    _shutdown_by_sendline()
             except (remote.LoginError, virt_vm.VMError), e:
                 logging.debug(e)
             else:
-                try:
-                    # Send the shutdown command
-                    session.sendline(self.params.get("shutdown_command"))
-                    if self.wait_for_shutdown(timeout):
-                        return True
-                finally:
-                    session.close()
+                # There is no exception occurs
+                _shutdown_by_sendline()
 
     def _cleanup(self, free_mac_addresses):
         """


### PR DESCRIPTION
If IndexError is raised,
The else-block statements never be run at graceful_shutdown().

Explanation As following,
try:
     ...
except (IndexError), e:
     try:
            session = self.serial_login()
     except (remote.LoginError, virt_vm.VMError), e:
            logging.debug(e)
     >>>Although successfully get session by serial_login()
     >>>The following else-block never be run.
except (remote.LoginError, virt_vm.VMError), e:
     ...
else:
      >>>send shutdown command to VM if no error occurs.

This patch is dedicated to fix it.