### PR TITLE
shared.unattended: Add packages to RHEL-6-spice.ks and RHEL-7-spice.ks

### DIFF
--- a/shared/unattended/RHEL-6-spice.ks
+++ b/shared/unattended/RHEL-6-spice.ks
@@ -32,6 +32,7 @@ KVM_TEST_LOGGING
 @Smart Card Support
 gnome-utils
 python-imaging
+python-six
 NetworkManager
 ntpdate
 watchdog

--- a/shared/unattended/RHEL-7-spice.ks
+++ b/shared/unattended/RHEL-7-spice.ks
@@ -31,6 +31,8 @@ xconfig --startxonboot
 @smart-card
 gnome-utils
 python-imaging
+python-six
+pyparsing
 NetworkManager
 ntpdate
 dconf


### PR DESCRIPTION
For spice testing, some new packages are required in the guest VMs.
Adding the packages pyparsing and python-six

Reviewed-By: Swapna Krishnan <skrishna@redhat.com>