### PR TITLE
virttest.shared.unattended: Remove dhclient command from SLES 12

### DIFF
--- a/shared/unattended/SLES-12.xml
+++ b/shared/unattended/SLES-12.xml
@@ -549,8 +549,7 @@ echo ttyS0 >> /etc/securetty]]>
       <script>
         <debug config:type="boolean">true</debug>
         <filename>config</filename>
-        <source><![CDATA[dhclient eth0
-chkconfig sshd on
+        <source><![CDATA[chkconfig sshd on
 sed -i -e 's/\(PasswordAuthentication\s\)no/\1yes/g'  /etc/ssh/sshd_config
 service sshd restart
 ]]></source>


### PR DESCRIPTION
...ES 12

The old command will only update the line from no to yes. But in SLES 12 it still
start with '#' and the login in following cases will failed.

ID: 1218472