### PR TITLE
virsh.py: Bigger timeout is needed on slower connection/systems

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -174,7 +174,7 @@ class VirshSession(aexpect.ShellSession):
         if ssh_remote_auth or self.uri:
             # Handle ssh / password prompts
             remote.handle_prompts(self, self.remote_user, self.remote_pwd,
-                                  prompt, debug=True)
+                                  prompt, timeout=60, debug=True)
 
         # fail if libvirtd is not running
         if self.cmd_status('list', timeout=60) != 0:


### PR DESCRIPTION
Bigger maximum timeout is needed on slower connection/systems