### PR TITLE
virttest/libvirt_vm: fix bug for qemu-guest-agent

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2379,7 +2379,9 @@ class VM(virt_vm.BaseVM):
         if not self.is_alive():
             self.start()
 
-        self.install_package('qemu-guest-agent')
+        if channel:
+            # Only install qemu-guest-agent when adding agent
+            self.install_package('qemu-guest-agent')
 
         session = self.wait_for_login()
 


### PR DESCRIPTION
If qemu-guest-agent isn't supported, such as on RHEL5,
all of virsh_reboot cases skip.
There's no available qemu-guest-agent package, which
causes install_package('qemu-guest-agent') raise exception.

In fact,
Only if the parameter channel of prepare_guest_agent()
is True, It needs to install qemu-guest-agent.

So, this patch do some check before installing.