### PR TITLE
virttest.qemu_virtio_port: Avoid infinity hang

### DIFF
--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -369,7 +369,7 @@ class GuestWorker(object):
             logging.warn("Workaround the stuck thread on guest")
             # Thread is stuck in read/write
             for send_pt in send_pts:
-                send_pt.sock.sendall(".")
+                send_pt.sock.send(".")
         elif match != 0:
             # Something else
             raise VirtioPortException("Unexpected fail\nMatch: %s\nData:\n%s"


### PR DESCRIPTION
The socket.sendall() sends the data in an infinite loop until they are
successfully sent. When virtio_console is really hanged and the buffer
is full this hangs the test for infinity. Using socket.send('.') usually
sends the data and proceeds to cleanup. Otherwise VM is destroyed later
in this cleanup function.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>