### PR TITLE
virttest.qemu_virtio_port: Avoid infinity hang

### DIFF
--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -369,7 +369,14 @@ class GuestWorker(object):
             logging.warn("Workaround the stuck thread on guest")
             # Thread is stuck in read/write
             for send_pt in send_pts:
-                send_pt.sock.sendall(".")
+                timeout = None
+                try:
+                    timeout = send_pt.sock.gettimeout()
+                    send_pt.sock.settimeout(1)
+                    send_pt.sock.send(".")
+                except socket.timeout:
+                    pass    # If still stuck VM gets destroyed below
+                send_pt.sock.settimeout(timeout)
         elif match != 0:
             # Something else
             raise VirtioPortException("Unexpected fail\nMatch: %s\nData:\n%s"


### PR DESCRIPTION
The socket.send can hang for infinity. Use timeout to ignore failed
write and re-try the virtconsole status afterwards. If sending the data
doesn't help VM gets destroyed.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>