### PR TITLE
virttest.qemu_virtio_port: Avoid ThSendCheck thread hang

### DIFF
--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -521,6 +521,7 @@ class ThSendCheck(Thread):
         """
         Thread.__init__(self)
         self.port = port
+        self.port.sock.settimeout(1)
         self.queues = queues
         # FIXME: socket.send(data>>127998) without read blocks thread
         if blocklen > 102400:
@@ -587,6 +588,8 @@ class ThSendCheck(Thread):
                 while not self.exitevent.isSet() and self.idx < target:
                     try:
                         idx = self.port.sock.send(buf)
+                    except socket.timeout:
+                        continue
                     except Exception, inst:
                         # Broken pipe
                         if not hasattr(inst, 'errno') or inst.errno != 32:


### PR DESCRIPTION
ThSendCheck thread can hang when sending data to a full socket. Instead
of returning number of sent bytes python waits for infinity. Use
non-blocking send instead avoids this problem.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>