### PR TITLE
.travis.yml: Update autotest package to the newest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ virtualenv:
     system_site_packages: true
 
 before_script:
-    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
+    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu utopic main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-get update -q
     - sudo apt-get -y --force-yes install autotest
 


### PR DESCRIPTION
I ended up deleting the old packages, and haven't realized
that virt-test and tp-qemu still used them. Let's update
to the latest version available.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>