### PR TITLE
[V3] Avocado integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,5 @@ libguestfs/cfg/virtio-win.cfg
 tools/github/*cache
 tmp
 .*.swp
+.idea
 RELEASE-VERSION

--- a/run
+++ b/run
@@ -70,7 +70,7 @@ def _handle_stdout(options):
     Depending on self.options.verbose, make proxy print to /dev/null, or
     original sys.stdout stream.
     """
-    if not options.verbose:
+    if not options.vt_verbose:
         _silence_stderr()
         # Replace stdout with our proxy pointing to /dev/null
         sys.stdout = StreamProxy(filename="/dev/null", stream=sys.stdout)
@@ -202,11 +202,11 @@ class VirtTestRunParser(optparse.OptionParser):
 
         debug = optparse.OptionGroup(self, 'Debug Options')
         debug.add_option("-v", "--verbose", action="store_true",
-                         dest="verbose", help=("Exhibit test "
-                                               "messages in the console "
-                                               "(used for debugging)"))
+                         dest="vt_verbose", help=("Exhibit test "
+                                                  "messages in the console "
+                                                  "(used for debugging)"))
         debug.add_option("--console-level", action="store",
-                         dest="console_level",
+                         dest="vt_console_level",
                          default="debug",
                          help=("Log level of test messages in the console. Only valid "
                                "with --verbose. "
@@ -214,128 +214,123 @@ class VirtTestRunParser(optparse.OptionParser):
                                ", ".join(SUPPORTED_LOG_LEVELS) +
                                ". Default: %default"))
         debug.add_option("--show-open-fd", action="store_true",
-                         dest="show_open_fd", help=("Show how many "
-                                                    "open fds at the end of "
-                                                    "each test "
-                                                    "(used for debugging)"))
+                         dest="vt_show_open_fd", help=("Show how many "
+                                                       "open fds at the end of "
+                                                       "each test "
+                                                       "(used for debugging)"))
 
         self.add_option_group(debug)
 
         general = optparse.OptionGroup(self, 'General Options')
         general.add_option("-b", "--bootstrap", action="store_true",
-                           dest="bootstrap", help=("Perform test suite setup "
-                                                   "procedures, such as "
-                                                   "downloading JeOS and check "
-                                                   "required programs and "
-                                                   "libs. Requires -t to be set"))
+                           dest="vt_bootstrap", help=("Perform test suite setup "
+                                                      "procedures, such as "
+                                                      "downloading JeOS and check "
+                                                      "required programs and "
+                                                      "libs. Requires -t to be set"))
         general.add_option("--update-config", action="store_true",
                            default=False,
-                           dest="update_config", help=("Forces configuration "
-                                                       "updates (all manual "
-                                                       "config file editing "
-                                                       "will be lost). "
-                                                       "Requires -t to be set"))
+                           dest="vt_update_config", help=("Forces configuration "
+                                                          "updates (all manual "
+                                                          "config file editing "
+                                                          "will be lost). "
+                                                          "Requires -t to be set"))
         general.add_option("--update-providers", action="store_true",
                            default=False,
-                           dest="update_providers", help=("Forces test "
-                                                          "providers to be "
-                                                          "updated (git repos "
-                                                          "will be pulled)"))
-        general.add_option("-t", "--type", action="store", dest="type",
+                           dest="vt_update_providers", help=("Forces test "
+                                                             "providers to be "
+                                                             "updated (git repos "
+                                                             "will be pulled)"))
+        general.add_option("-t", "--type", action="store", dest="vt_type",
                            help="Choose test type (%s)" %
                            ", ".join(SUPPORTED_TEST_TYPES))
-        general.add_option("--connect-uri", action="store", dest="uri",
+        general.add_option("--connect-uri", action="store", dest="vt_connect_uri",
                            help="Choose test connect uri for libvirt (E.g: %s)" %
-                           ", ".join(SUPPORTED_LIBVIRT_URIS))
-        general.add_option("-c", "--config", action="store", dest="config",
+                                ", ".join(SUPPORTED_LIBVIRT_URIS))
+        general.add_option("-c", "--config", action="store", dest="vt_config",
                            help=("Explicitly choose a cartesian config. "
                                  "When choosing this, some options will be "
                                  "ignored"))
         general.add_option("--no-downloads", action="store_true",
-                           dest="no_downloads", default=False,
+                           dest="vt_no_downloads", default=False,
                            help="Do not attempt to download JeOS images")
         general.add_option("--selinux-setup", action="store_true",
-                           dest="selinux_setup", default=False,
+                           dest="vt_selinux_setup", default=False,
                            help="Define default contexts of directory.")
         general.add_option("-k", "--keep-image", action="store_true",
-                           dest="keep_image",
+                           dest="vt_keep_image",
                            help=("Don't restore the JeOS image from pristine "
                                  "at the beginning of the test suite run "
                                  "(faster but unsafe)"))
         general.add_option("--keep-image-between-tests",
                            action="store_true", default=False,
-                           dest="keep_image_between_tests",
+                           dest="vt_keep_image_between_tests",
                            help=("Don't restore the JeOS image from pristine "
                                  "between tests (faster but unsafe)"))
-        general.add_option("-g", "--guest-os", action="store", dest="guest_os",
+        general.add_option("-g", "--guest-os", action="store", dest="vt_guest_os",
                            default=None,
                            help=("Select the guest OS to be used. "
                                  "If -c is provided, this will be ignored. "
                                  "Default: %s" % self.default_guest_os))
-        general.add_option("--arch", action="store", dest="arch",
+        general.add_option("--arch", action="store", dest="vt_arch",
                            default=None,
                            help=("Architecture under test. "
                                  "If -c is provided, this will be ignored. "
                                  "Default: any that supports the given machine type"))
-        general.add_option(
-            "--machine-type", action="store", dest="machine_type",
-            default=None,
-            help=("Machine type under test. "
-                  "If -c is provided, this will be ignored. "
-                  "Default: all for the chosen guests, %s if "
-                  "--guest-os not given." % virttest.defaults.DEFAULT_MACHINE_TYPE))
-        general.add_option("--tests", action="store", dest="tests",
+        general.add_option("--machine-type", action="store", dest="vt_machine_type",
+                           default=None,
+                           help=("Machine type under test. "
+                                 "If -c is provided, this will be ignored. "
+                                 "Default: all for the chosen guests, %s if "
+                                 "--guest-os not given." % virttest.defaults.DEFAULT_MACHINE_TYPE))
+        general.add_option("--tests", action="store", dest="vt_tests",
                            default="",
                            help=('List of space separated tests to be '
                                  'executed. '
                                  'If -c is provided, this will be ignored.'
                                  ' - example: --tests "boot reboot shutdown"'))
-        general.add_option("--list-tests", action="store_true", dest="list",
+        general.add_option("--list-tests", action="store_true", dest="vt_list_tests",
                            help="List tests available")
         general.add_option("--list-guests", action="store_true",
-                           dest="list_guests",
+                           dest="vt_list_guests",
                            help="List guests available")
-        general.add_option("--logs-dir", action="store", dest="logdir",
+        general.add_option("--logs-dir", action="store", dest="vt_log_dir",
                            help=("Path to the logs directory. "
                                  "Default path: %s" %
                                  os.path.join(data_dir.get_backing_data_dir(),
                                               'logs')))
-        general.add_option("--data-dir", action="store", dest="datadir",
+        general.add_option("--data-dir", action="store", dest="vt_data_dir",
                            help=("Path to a data dir. "
                                  "Default path: %s" %
                                  data_dir.get_backing_data_dir()))
         general.add_option("--keep-guest-running", action="store_true",
-                           dest="keep_guest_running", default=False,
+                           dest="vt_keep_guest_running", default=False,
                            help=("Don't shut down guests at the end of each "
                                  "test (faster but unsafe)"))
-        general.add_option("-m", "--mem", action="store", dest="mem",
+        general.add_option("-m", "--mem", action="store", dest="vt_mem",
                            default="1024",
                            help=("RAM dedicated to the main VM. Default:"
                                  "%default"))
-        general.add_option(
-            "--no", action="store", dest="no_filter", default="",
+        general.add_option("--no", action="store", dest="vt_no_filter", default="",
                            help=("List of space separated no filters to be "
                                  "passed to the config parser. If -c is "
                                  "provided, this will be ignored"))
         general.add_option("--type-specific", action="store_true",
-                           dest="only_type_specific", default=False,
+                           dest="vt_type_specific", default=False,
                            help=("Enable only type specific tests. Shared"
                                  " tests will not be tested."))
-
-        general.add_option("--run-dropin", action="store_true", dest="dropin",
+        general.add_option("--run-dropin", action="store_true", dest="vt_dropin",
                            default=False,
                            help=("Run tests present on the drop in dir on the "
                                  "host. Incompatible with --tests."))
-
-        general.add_option("--log-level", action="store", dest="log_level",
+        general.add_option("--log-level", action="store", dest="vt_log_level",
                            default="debug",
                            help=("Set log level for top level log file."
                                  " Supported levels: " +
                                  ", ".join(SUPPORTED_LOG_LEVELS) +
                                  ". Default: %default"))
-
         general.add_option("--no-cleanup", action="store_true",
-                           dest="no_cleanup",
+                           dest="vt_no_cleanup",
                            default=False,
                            help=("Don't clean up tmp files or VM processes at "
                                  "the end of a virt-test execution (useful "
@@ -344,13 +339,13 @@ class VirtTestRunParser(optparse.OptionParser):
         self.add_option_group(general)
 
         qemu = optparse.OptionGroup(self, 'Options specific to the qemu test')
-        qemu.add_option("--qemu-bin", action="store", dest="qemu",
+        qemu.add_option("--qemu-bin", action="store", dest="vt_qemu_bin",
                         default=None,
                         help=("Path to a custom qemu binary to be tested. "
                               "If -c is provided and this flag is omitted, "
                               "no attempt to set the qemu binaries will be made. "
                               "Default path: %s" % qemu_bin_path))
-        qemu.add_option("--qemu-dst-bin", action="store", dest="dst_qemu",
+        qemu.add_option("--qemu-dst-bin", action="store", dest="vt_dst_qemu_bin",
                         default=None,
                         help=("Path to a custom qemu binary to be tested for "
                               "the destination of a migration, overrides "
@@ -359,58 +354,59 @@ class VirtTestRunParser(optparse.OptionParser):
                               "no attempt to set the qemu binaries will be made. "
                               "Default path: %s" % qemu_bin_path))
         qemu.add_option("--use-malloc-perturb", action="store",
-                        dest="malloc_perturb", default="yes",
+                        dest="vt_malloc_perturb", default="yes",
                         help=("Use MALLOC_PERTURB_ env variable set to 1 "
                               "to help catch memory allocation problems on "
                               "qemu (yes or no). Default: %default"))
-        qemu.add_option("--accel", action="store", dest="accel", default="kvm",
+        qemu.add_option("--accel", action="store", dest="vt_accel", default="kvm",
                         help=("Accelerator used to run qemu (kvm or tcg). "
                               "Default: kvm"))
-        help_msg = "QEMU network option (%s). " % ", ".join(SUPPORTED_NET_TYPES)
+        help_msg = "QEMU network option (%s). " % ", ".join(
+            SUPPORTED_NET_TYPES)
         help_msg += "Default: %default"
-        qemu.add_option("--nettype", action="store", dest="nettype",
+        qemu.add_option("--nettype", action="store", dest="vt_nettype",
                         default=nettype_default, help=help_msg)
-        qemu.add_option("--netdst", action="store", dest="netdst",
+        qemu.add_option("--netdst", action="store", dest="vt_netdst",
                         default="virbr0",
                         help=("Bridge name to be used "
                               "(if you chose bridge as nettype). "
                               "Default: %default"))
-        qemu.add_option("--vhost", action="store", dest="vhost",
+        qemu.add_option("--vhost", action="store", dest="vt_vhost",
                         default="off",
                         help=("Whether to enable vhost for qemu "
                               "(on/off/force). Depends on nettype=bridge. "
                               "If -c is provided, this will be ignored. "
                               "Default: %default"))
-        qemu.add_option("--monitor", action="store", dest="monitor",
+        qemu.add_option("--monitor", action="store", dest="vt_monitor",
                         default='human',
                         help="Monitor type (human or qmp). Default: %default")
-        qemu.add_option("--smp", action="store", dest="smp",
+        qemu.add_option("--smp", action="store", dest="vt_smp",
                         default='2',
                         help=("Number of virtual cpus to use. "
                               "If -c is provided, this will be ignored. "
                               "Default: %default"))
-        qemu.add_option("--image-type", action="store", dest="image_type",
+        qemu.add_option("--image-type", action="store", dest="vt_image_type",
                         default="qcow2",
                         help=("Image format type to use "
                               "(any valid qemu format). "
                               "If -c is provided, this will be ignored. "
                               "Default: %default"))
-        qemu.add_option("--nic-model", action="store", dest="nic_model",
+        qemu.add_option("--nic-model", action="store", dest="vt_nic_model",
                         default="virtio_net",
                         help=("Guest network card model. "
                               "If -c is provided, this will be ignored. "
                               "(any valid qemu format). Default: %default"))
-        qemu.add_option("--disk-bus", action="store", dest="disk_bus",
+        qemu.add_option("--disk-bus", action="store", dest="vt_disk_bus",
                         default="virtio_blk",
                         help=("Guest main image disk bus. One of " +
                               " ".join(SUPPORTED_DISK_BUSES) +
                               ". If -c is provided, this will be ignored. "
                               "Default: %default"))
-        qemu.add_option("--qemu_sandbox", action="store", dest="qemu_sandbox",
+        qemu.add_option("--qemu_sandbox", action="store", dest="vt_qemu_sandbox",
                         default="on",
                         help=("Enable qemu sandboxing "
                               "(on/off). Default: %default"))
-        qemu.add_option("--defconfig", action="store", dest="defconfig",
+        qemu.add_option("--defconfig", action="store", dest="vt_defconfig",
                         default="yes",
                         help=("Prevent qemu from loading sysconfdir/qemu.conf "
                               "and sysconfdir/target-ARCH.conf at startup. "
@@ -418,7 +414,7 @@ class VirtTestRunParser(optparse.OptionParser):
         self.add_option_group(qemu)
 
         libvirt = optparse.OptionGroup(self, 'Options specific to the libvirt test')
-        libvirt.add_option("--install", action="store_true", dest="install_guest",
+        libvirt.add_option("--install", action="store_true", dest="vt_install_guest",
                            help=("Install the guest using import method before "
                                  "the tests are run."))
         libvirt.add_option("--remove", action="store_true", dest="remove_guest",
@@ -494,13 +490,13 @@ class VirtTestApp(object):
         """
         Puts the value of the qemu bin option in the cartesian parser command.
         """
-        if self.options.config and self.options.qemu is None:
+        if self.options.vt_config and self.options.vt_qemu_bin is None:
             logging.info("Config provided and no --qemu-bin set. Not trying "
                          "to automatically set qemu bin.")
         else:
             (qemu_bin_path, qemu_img_path, qemu_io_path,
-             qemu_dst_bin_path) = _find_default_qemu_paths(self.options.qemu,
-                                                           self.options.dst_qemu)
+             qemu_dst_bin_path) = _find_default_qemu_paths(self.options.vt_qemu_bin,
+                                                           self.options.vt_dst_qemu_bin)
             self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
             self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
@@ -512,156 +508,160 @@ class VirtTestApp(object):
         """
         Puts the value of the qemu bin option in the cartesian parser command.
         """
-        if self.options.config and self.options.qemu is None:
+        if self.options.vt_config and self.options.vt_qemu_bin is None:
             logging.info("Config provided and no --qemu-bin set. Not trying "
                          "to automatically set qemu bin.")
         else:
             (_, qemu_img_path,
-             _, _) = _find_default_qemu_paths(self.options.qemu,
-                                              self.options.dst_qemu)
+             _, _) = _find_default_qemu_paths(self.options.vt_qemu_bin,
+                                              self.options.vt_dst_qemu_bin)
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
 
     def _process_qemu_accel(self):
         """
         Puts the value of the qemu bin option in the cartesian parser command.
         """
-        if self.options.accel == 'tcg':
+        if self.options.vt_accel == 'tcg':
             self.cartesian_parser.assign("disable_kvm", "yes")
 
     def _process_bridge_mode(self):
-        if self.options.nettype not in SUPPORTED_NET_TYPES:
+        if self.options.vt_nettype not in SUPPORTED_NET_TYPES:
             _restore_stdout()
             print("Invalid --nettype option '%s'. Valid options are: (%s)" %
-                  (self.options.nettype, ", ".join(SUPPORTED_NET_TYPES)))
+                  (self.options.vt_nettype, ", ".join(SUPPORTED_NET_TYPES)))
             sys.exit(1)
-        if self.options.nettype == 'bridge':
+        if self.options.vt_nettype == 'bridge':
             if os.getuid() != 0:
                 _restore_stdout()
                 print("In order to use bridge, you need to be root, "
                       "aborting...")
                 sys.exit(1)
             self.cartesian_parser.assign("nettype", "bridge")
-            self.cartesian_parser.assign("netdst", self.options.netdst)
-        elif self.options.nettype == 'user':
+            self.cartesian_parser.assign("netdst", self.options.vt_netdst)
+        elif self.options.vt_nettype == 'user':
             self.cartesian_parser.assign("nettype", "user")
-        elif self.options.nettype == 'none':
+        elif self.options.vt_nettype == 'none':
             self.cartesian_parser.assign("nettype", "none")
 
     def _process_monitor(self):
-        if self.options.monitor == 'qmp':
+        if self.options.vt_monitor == 'qmp':
             self.cartesian_parser.assign("monitors", "qmp1")
             self.cartesian_parser.assign("monitor_type_qmp1", "qmp")
 
     def _process_smp(self):
-        if not self.options.config:
-            if self.options.smp == '1':
+        if not self.options.vt_config:
+            if self.options.vt_smp == '1':
                 self.cartesian_parser.only_filter("up")
-            elif self.options.smp == '2':
+            elif self.options.vt_smp == '2':
                 self.cartesian_parser.only_filter("smp2")
             else:
                 try:
                     self.cartesian_parser.only_filter("up")
-                    self.cartesian_parser.assign("smp", int(self.options.smp))
+                    self.cartesian_parser.assign(
+                        "smp", int(self.options.vt_smp))
                 except ValueError:
                     _restore_stdout()
                     print("Invalid option for smp: %s, aborting..." %
-                          self.options.smp)
+                          self.options.vt_smp)
                     sys.exit(1)
         else:
             logging.info("Config provided, ignoring --smp option")
 
     def _process_arch(self):
-        if self.options.arch is None:
+        if self.options.vt_arch is None:
             pass
-        elif not self.options.config:
-            self.cartesian_parser.only_filter(self.options.arch)
+        elif not self.options.vt_config:
+            self.cartesian_parser.only_filter(self.options.vt_arch)
         else:
             logging.info("Config provided, ignoring --arch option")
 
     def _process_machine_type(self):
-        if not self.options.config:
-            if self.options.machine_type is None:
+        if not self.options.vt_config:
+            if self.options.vt_machine_type is None:
                 # TODO: this is x86-specific, instead we can get the default
                 # arch from qemu binary and run on all supported machine types
-                if self.options.arch is None and self.options.guest_os is None:
+                if self.options.vt_arch is None and self.options.vt_guest_os is None:
                     import virttest.defaults
-                    self.cartesian_parser.only_filter(virttest.defaults.DEFAULT_MACHINE_TYPE)
+                    self.cartesian_parser.only_filter(
+                        virttest.defaults.DEFAULT_MACHINE_TYPE)
             else:
-                self.cartesian_parser.only_filter(self.options.machine_type)
+                self.cartesian_parser.only_filter(self.options.vt_machine_type)
         else:
             logging.info("Config provided, ignoring --machine-type option")
 
     def _process_image_type(self):
-        if not self.options.config:
-            if self.options.image_type in SUPPORTED_IMAGE_TYPES:
-                self.cartesian_parser.only_filter(self.options.image_type)
+        if not self.options.vt_config:
+            if self.options.vt_image_type in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(self.options.vt_image_type)
             else:
                 self.cartesian_parser.only_filter("raw")
                 # The actual param name is image_format.
                 self.cartesian_parser.assign("image_format",
-                                             self.options.image_type)
+                                             self.options.vt_image_type)
         else:
             logging.info("Config provided, ignoring --image-type option")
 
     def _process_nic_model(self):
-        if not self.options.config:
-            if self.options.nic_model in SUPPORTED_NIC_MODELS:
-                self.cartesian_parser.only_filter(self.options.nic_model)
+        if not self.options.vt_config:
+            if self.options.vt_nic_model in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(self.options.vt_nic_model)
             else:
                 self.cartesian_parser.only_filter("nic_custom")
                 self.cartesian_parser.assign(
-                    "nic_model", self.options.nic_model)
+                    "nic_model", self.options.vt_nic_model)
         else:
             logging.info("Config provided, ignoring --nic-model option")
 
     def _process_disk_buses(self):
-        if not self.options.config:
-            if self.options.disk_bus in SUPPORTED_DISK_BUSES:
-                self.cartesian_parser.only_filter(self.options.disk_bus)
+        if not self.options.vt_config:
+            if self.options.vt_disk_bus in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(self.options.vt_disk_bus)
             else:
                 _restore_stdout()
                 print("Option %s is not in the list %s, aborting..." %
-                      (self.options.disk_bus, SUPPORTED_DISK_BUSES))
+                      (self.options.vt_disk_bus, SUPPORTED_DISK_BUSES))
                 sys.exit(1)
         else:
             logging.info("Config provided, ignoring --disk-bus option")
 
     def _process_vhost(self):
-        if not self.options.config:
-            if self.options.nettype == "bridge":
-                if self.options.vhost == "on":
+        if not self.options.vt_config:
+            if self.options.vt_nettype == "bridge":
+                if self.options.vt_vhost == "on":
                     self.cartesian_parser.assign("vhost", "on")
-                elif self.options.vhost == "force":
+                elif self.options.vt_vhost == "force":
                     self.cartesian_parser.assign("netdev_extra_params",
                                                  '",vhostforce=on"')
                     self.cartesian_parser.assign("vhost", "on")
             else:
-                if self.options.vhost in ["on", "force"]:
+                if self.options.vt_vhost in ["on", "force"]:
                     _restore_stdout()
                     print("Nettype %s is incompatible with vhost %s, "
                           "aborting..." %
-                          (self.options.nettype, self.options.vhost))
+                          (self.options.vt_nettype, self.options.vt_vhost))
                     sys.exit(1)
         else:
             logging.info("Config provided, ignoring --vhost option")
 
     def _process_qemu_sandbox(self):
-        if not self.options.config:
-            if self.options.qemu_sandbox == "off":
+        if not self.options.vt_config:
+            if self.options.vt_qemu_sandbox == "off":
                 self.cartesian_parser.assign("qemu_sandbox", "off")
         else:
-            logging.info("Config provided, ignoring \"--sandbox <on|off>\" option")
+            logging.info(
+                "Config provided, ignoring \"--sandbox <on|off>\" option")
 
     def _process_qemu_defconfig(self):
-        if not self.options.config:
-            if self.options.defconfig == "no":
+        if not self.options.vt_config:
+            if self.options.vt_defconfig == "no":
                 self.cartesian_parser.assign("defconfig", "no")
         else:
-            logging.info("Config provided, ignoring \"--defconfig <yes|no>\" option")
+            logging.info(
+                "Config provided, ignoring \"--defconfig <yes|no>\" option")
 
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
-                                     self.options.malloc_perturb)
+                                     self.options.vt_malloc_perturb)
 
     def _process_qemu_specific_options(self):
         """
@@ -686,66 +686,67 @@ class VirtTestApp(object):
         """
         Calls for processing all options specific to lvsb test
         """
-        self.options.no_downloads = True
+        self.options.vt_no_downloads = True
 
     def _process_libvirt_specific_options(self):
         """
         Calls for processing all options specific to libvirt test.
         """
-        if self.options.uri:
+        if self.options.vt_connect_uri:
             driver_found = False
             for driver in SUPPORTED_LIBVIRT_DRIVERS:
-                if self.options.uri.count(driver):
+                if self.options.vt_connect_uri.count(driver):
                     driver_found = True
                     self.cartesian_parser.only_filter(driver)
             if not driver_found:
-                print("Not supported uri: %s." % self.options.uri)
+                print("Not supported uri: %s." % self.options.vt_connect_uri)
                 sys.exit(1)
         else:
             self.cartesian_parser.only_filter("qemu")
 
     def _process_guest_os(self):
-        if not self.options.config:
+        if not self.options.vt_config:
             from virttest import standalone_test
             if len(standalone_test.get_guest_name_list(self.options)) == 0:
                 _restore_stdout()
                 print("Guest name %s is not on the known guest os list "
                       "(see --list-guests), aborting..." %
-                      self.options.guest_os)
+                      self.options.vt_guest_os)
                 sys.exit(1)
             self.cartesian_parser.only_filter(
-                self.options.guest_os or self.option_parser.default_guest_os)
+                self.options.vt_guest_os or self.option_parser.default_guest_os)
         else:
             logging.info("Config provided, ignoring --guest-os option")
 
     def _process_list(self):
         from virttest import standalone_test
-        if self.options.list:
+        if self.options.vt_list_tests:
             standalone_test.print_test_list(self.options,
                                             self.cartesian_parser)
             sys.exit(0)
-        if self.options.list_guests:
+        if self.options.vt_list_guests:
             standalone_test.print_guest_list(self.options)
             sys.exit(0)
 
     def _process_tests(self):
-        if not self.options.config:
-            if self.options.type:
-                if self.options.tests and self.options.dropin:
+        if not self.options.vt_config:
+            if self.options.vt_type:
+                if self.options.vt_tests and self.options.vt_dropin:
                     print("Option --tests and --run-dropin can't be set at "
                           "the same time")
                     sys.exit(1)
-                elif self.options.tests:
-                    tests = self.options.tests.split(" ")
-                    if self.options.type == 'libvirt':
-                        if self.options.install_guest:
+                elif self.options.vt_tests:
+                    tests = self.options.vt_tests.split(" ")
+                    if self.options.vt_type == 'libvirt':
+                        if self.options.vt_install_guest:
                             tests.insert(0, LIBVIRT_INSTALL)
-                        if self.options.remove_guest:
+                        if self.options.vt_remove_guest:
                             tests.append(LIBVIRT_REMOVE)
                     self.cartesian_parser.only_filter(", ".join(tests))
-                elif self.options.dropin:
+                elif self.options.vt_dropin:
                     from virttest import data_dir
-                    dropin_tests = os.listdir(os.path.join(data_dir.get_root_dir(), "dropin"))
+                    dropin_tests = os.listdir(
+                        os.path.join(data_dir.get_root_dir(), "dropin"))
                     if len(dropin_tests) <= 1:
                         _restore_stdout()
                         print("No drop in tests detected, aborting. "
@@ -754,30 +755,30 @@ class VirtTestApp(object):
                         sys.exit(1)
                     self.cartesian_parser.only_filter("dropin")
                 else:
-                    if self.options.type == 'qemu':
+                    if self.options.vt_type == 'qemu':
                         self.cartesian_parser.only_filter(QEMU_DEFAULT_SET)
                         self.cartesian_parser.no_filter("with_reboot")
-                    elif self.options.type == 'libvirt':
+                    elif self.options.vt_type == 'libvirt':
                         self.cartesian_parser.only_filter(LIBVIRT_DEFAULT_SET)
-                    elif self.options.type == 'lvsb':
+                    elif self.options.vt_type == 'lvsb':
                         self.cartesian_parser.only_filter(LVSB_DEFAULT_SET)
-                    elif self.options.type == 'openvswitch':
+                    elif self.options.vt_type == 'openvswitch':
                         self.cartesian_parser.only_filter(OVS_DEFAULT_SET)
         else:
             logging.info("Config provided, ignoring --tests option")
 
     def _process_restart_vm(self):
-        if not self.options.config:
-            if not self.options.keep_guest_running:
+        if not self.options.vt_config:
+            if not self.options.vt_keep_guest_running:
                 self.cartesian_parser.assign("kill_vm", "yes")
 
     def _process_restore_image_between_tests(self):
-        if not self.options.config:
-            if not self.options.keep_image_between_tests:
+        if not self.options.vt_config:
+            if not self.options.vt_keep_image_between_tests:
                 self.cartesian_parser.assign("restore_image", "yes")
 
     def _process_mem(self):
-        self.cartesian_parser.assign("mem", self.options.mem)
+        self.cartesian_parser.assign("mem", self.options.vt_mem)
 
     def _process_tcpdump(self):
         """
@@ -795,14 +796,14 @@ class VirtTestApp(object):
             self.cartesian_parser.assign("run_tcpdump", "no")
 
     def _process_no_filter(self):
-        if not self.options.config:
-            if self.options.no_filter:
-                no_filter = ", ".join(self.options.no_filter.split(' '))
+        if not self.options.vt_config:
+            if self.options.vt_no_filter:
+                no_filter = ", ".join(self.options.vt_no_filter.split(' '))
                 self.cartesian_parser.no_filter(no_filter)
 
     def _process_only_type_specific(self):
-        if not self.options.config:
-            if self.options.only_type_specific:
+        if not self.options.vt_config:
+            if self.options.vt_type_specific:
                 self.cartesian_parser.only_filter("(subtest=type_specific)")
 
     def _process_general_options(self):
@@ -830,121 +831,125 @@ class VirtTestApp(object):
         from virttest import cartesian_config, standalone_test
         from virttest import data_dir, bootstrap, arch
 
-        if (not self.options.type) and (not self.options.config):
+        if (not self.options.vt_type) and (not self.options.vt_config):
             _restore_stdout()
             print("No type (-t) or config (-c) options specified, aborting...")
             sys.exit(1)
 
-        if self.options.update_config:
+        if self.options.vt_update_config:
             from autotest.client.shared import logging_manager
             from virttest import utils_misc
             _restore_stdout()
             logging_manager.configure_logging(utils_misc.VirtLoggingConfig(),
                                               verbose=True)
-            test_dir = data_dir.get_backend_dir(self.options.type)
+            test_dir = data_dir.get_backend_dir(self.options.vt_type)
             shared_dir = os.path.join(data_dir.get_root_dir(), "shared")
             bootstrap.create_config_files(test_dir, shared_dir,
                                           interactive=False,
                                           force_update=True)
-            bootstrap.create_subtests_cfg(self.options.type)
-            bootstrap.create_guest_os_cfg(self.options.type)
+            bootstrap.create_subtests_cfg(self.options.vt_type)
+            bootstrap.create_guest_os_cfg(self.options.vt_type)
             sys.exit(0)
 
-        if self.options.bootstrap:
+        if self.options.vt_bootstrap:
             _restore_stdout()
             check_modules = []
             online_docs_url = None
             interactive = True
-            if self.options.type == "qemu":
-                default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+            if self.options.vt_type == "qemu":
+                default_userspace_paths = [
+                    "/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
                 check_modules = arch.get_kvm_module_list()
                 online_docs_url = "https://github.com/autotest/virt-test/wiki/GetStarted"
-            elif self.options.type == "libvirt":
-                default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
-            elif self.options.type == "libguestfs":
+            elif self.options.vt_type == "libvirt":
+                default_userspace_paths = [
+                    "/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+            elif self.options.vt_type == "libguestfs":
                 default_userspace_paths = ["/usr/bin/libguestfs-test-tool"]
-            elif self.options.type == "lvsb":
+            elif self.options.vt_type == "lvsb":
                 default_userspace_paths = ["/usr/bin/virt-sandbox"]
-            elif self.options.type == "openvswitch":
-                default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+            elif self.options.vt_type == "openvswitch":
+                default_userspace_paths = [
+                    "/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
                 check_modules = ["openvswitch"]
                 online_docs_url = "https://github.com/autotest/autotest/wiki/OpenVSwitch"
-            elif self.options.type == "v2v":
+            elif self.options.vt_type == "v2v":
                 default_userspace_paths = ["/usr/bin/virt-v2v"]
 
-            if not self.options.config:
-                restore_image = not(self.options.no_downloads or
-                                    self.options.keep_image)
+            if not self.options.vt_config:
+                restore_image = not(self.options.vt_no_downloads or
+                                    self.options.vt_keep_image)
             else:
                 restore_image = False
 
-            test_dir = data_dir.get_backend_dir(self.options.type)
-            bootstrap.bootstrap(test_name=self.options.type, test_dir=test_dir,
+            test_dir = data_dir.get_backend_dir(self.options.vt_type)
+            bootstrap.bootstrap(test_name=self.options.vt_type, test_dir=test_dir,
                                 base_dir=data_dir.get_data_dir(),
                                 default_userspace_paths=default_userspace_paths,
                                 check_modules=check_modules,
                                 online_docs_url=online_docs_url,
                                 interactive=interactive,
-                                selinux=self.options.selinux_setup,
+                                selinux=self.options.vt_selinux_setup,
                                 restore_image=restore_image,
-                                verbose=self.options.verbose,
-                                update_providers=self.options.update_providers,
-                                guest_os=(self.options.guest_os or
+                                verbose=self.options.vt_verbose,
+                                update_providers=self.options.vt_update_providers,
+                                guest_os=(self.options.vt_guest_os or
                                           self.option_parser.default_guest_os))
             sys.exit(0)
 
-        if self.options.type:
-            if self.options.type not in SUPPORTED_TEST_TYPES:
+        if self.options.vt_type:
+            if self.options.vt_type not in SUPPORTED_TEST_TYPES:
                 _restore_stdout()
                 print("Invalid test type %s. Valid test types: %s. "
-                      "Aborting..." % (self.options.type,
+                      "Aborting..." % (self.options.vt_type,
                                        " ".join(SUPPORTED_TEST_TYPES)))
                 sys.exit(1)
 
-        if self.options.log_level not in SUPPORTED_LOG_LEVELS:
+        if self.options.vt_log_level not in SUPPORTED_LOG_LEVELS:
             _restore_stdout()
             print("Invalid log level '%s'. Valid log levels: %s. "
-                  "Aborting..." % (self.options.log_level,
+                  "Aborting..." % (self.options.vt_log_level,
                                    " ".join(SUPPORTED_LOG_LEVELS)))
             sys.exit(1)
-        num_level = getattr(logging, self.options.log_level.upper(), None)
-        self.options.log_level = num_level
+        num_level = getattr(logging, self.options.vt_log_level.upper(), None)
+        self.options.vt_log_level = num_level
 
-        if self.options.console_level not in SUPPORTED_LOG_LEVELS:
+        if self.options.vt_console_level not in SUPPORTED_LOG_LEVELS:
             _restore_stdout()
             print("Invalid console level '%s'. Valid console levels: %s. "
-                  "Aborting..." % (self.options.console_level,
+                  "Aborting..." % (self.options.vt_console_level,
                                    " ".join(SUPPORTED_LOG_LEVELS)))
             sys.exit(1)
         num_level_console = getattr(logging,
-                                    self.options.console_level.upper(),
+                                    self.options.vt_console_level.upper(),
                                     None)
-        self.options.console_level = num_level_console
+        self.options.vt_console_level = num_level_console
 
-        if self.options.datadir:
-            data_dir.set_backing_data_dir(self.options.datadir)
+        if self.options.vt_data_dir:
+            data_dir.set_backing_data_dir(self.options.vt_data_dir)
 
         standalone_test.create_config_files(self.options)
 
         self.cartesian_parser = cartesian_config.Parser(debug=False)
 
-        if self.options.config:
-            cfg = os.path.abspath(self.options.config)
+        if self.options.vt_config:
+            cfg = os.path.abspath(self.options.vt_config)
 
-        if not self.options.config:
-            cfg = data_dir.get_backend_cfg_path(self.options.type, 'tests.cfg')
+        if not self.options.vt_config:
+            cfg = data_dir.get_backend_cfg_path(
+                self.options.vt_type, 'tests.cfg')
 
         self.cartesian_parser.parse_file(cfg)
-        if self.options.type != 'lvsb':
+        if self.options.vt_type != 'lvsb':
             self._process_general_options()
 
-        if self.options.type == 'qemu':
+        if self.options.vt_type == 'qemu':
             self._process_qemu_specific_options()
-        elif self.options.type == 'lvsb':
+        elif self.options.vt_type == 'lvsb':
             self._process_lvsb_specific_options()
-        elif self.options.type == 'openvswitch':
+        elif self.options.vt_type == 'openvswitch':
             self._process_qemu_specific_options()
-        elif self.options.type == 'libvirt':
+        elif self.options.vt_type == 'libvirt':
             self._process_libvirt_specific_options()
         # List and tests have to be the last things to be processed
         self._process_list()
@@ -966,7 +971,7 @@ class VirtTestApp(object):
             self._process_options()
             standalone_test.reset_logging()
             standalone_test.configure_console_logging(
-                loglevel=self.options.console_level)
+                loglevel=self.options.vt_console_level)
             standalone_test.bootstrap_tests(self.options)
             ok = standalone_test.run_tests(self.cartesian_parser, self.options)
 
@@ -978,19 +983,19 @@ class VirtTestApp(object):
         except StopIteration:
             _restore_stdout()
             print("Empty config set generated ")
-            if self.options.type:
-                print("Tests chosen: '%s'" % self.options.tests)
+            if self.options.vt_type:
+                print("Tests chosen: '%s'" % self.options.vt_tests)
                 print("Check that you typed the tests "
                       "names correctly, and double "
                       "check that tests show "
                       "in --list-tests for guest '%s'" %
-                      (self.options.guest_os or
+                      (self.options.vt_guest_os or
                        self.option_parser.default_guest_os))
                 sys.exit(1)
 
-            if self.options.config:
+            if self.options.vt_config:
                 print("Please check your custom config file %s" %
-                      self.options.config)
+                      self.options.vt_config)
                 sys.exit(1)
 
         except Exception:

--- a/run
+++ b/run
@@ -853,30 +853,8 @@ class VirtTestApp(object):
 
         if self.options.vt_bootstrap:
             _restore_stdout()
-            check_modules = []
-            interactive = True
-            if self.options.vt_type == "qemu":
-                check_modules = arch.get_kvm_module_list()
-            elif self.options.vt_type == "openvswitch":
-                check_modules = ["openvswitch"]
-
-            if not self.options.vt_config:
-                restore_image = not(self.options.vt_no_downloads or
-                                    self.options.vt_keep_image)
-            else:
-                restore_image = False
-
-            test_dir = data_dir.get_backend_dir(self.options.vt_type)
-            bootstrap.bootstrap(test_name=self.options.vt_type, test_dir=test_dir,
-                                base_dir=data_dir.get_data_dir(),
-                                check_modules=check_modules,
-                                interactive=interactive,
-                                selinux=self.options.vt_selinux_setup,
-                                restore_image=restore_image,
-                                verbose=self.options.vt_verbose,
-                                update_providers=self.options.vt_update_providers,
-                                guest_os=(self.options.vt_guest_os or
-                                          self.option_parser.default_guest_os))
+            bootstrap.bootstrap(options=self.options,
+                                interactive=True)
             sys.exit(0)
 
         if self.options.vt_type:

--- a/run
+++ b/run
@@ -857,24 +857,9 @@ class VirtTestApp(object):
             online_docs_url = None
             interactive = True
             if self.options.vt_type == "qemu":
-                default_userspace_paths = [
-                    "/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
                 check_modules = arch.get_kvm_module_list()
-                online_docs_url = "https://github.com/autotest/virt-test/wiki/GetStarted"
-            elif self.options.vt_type == "libvirt":
-                default_userspace_paths = [
-                    "/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
-            elif self.options.vt_type == "libguestfs":
-                default_userspace_paths = ["/usr/bin/libguestfs-test-tool"]
-            elif self.options.vt_type == "lvsb":
-                default_userspace_paths = ["/usr/bin/virt-sandbox"]
             elif self.options.vt_type == "openvswitch":
-                default_userspace_paths = [
-                    "/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
                 check_modules = ["openvswitch"]
-                online_docs_url = "https://github.com/autotest/autotest/wiki/OpenVSwitch"
-            elif self.options.vt_type == "v2v":
-                default_userspace_paths = ["/usr/bin/virt-v2v"]
 
             if not self.options.vt_config:
                 restore_image = not(self.options.vt_no_downloads or
@@ -885,7 +870,6 @@ class VirtTestApp(object):
             test_dir = data_dir.get_backend_dir(self.options.vt_type)
             bootstrap.bootstrap(test_name=self.options.vt_type, test_dir=test_dir,
                                 base_dir=data_dir.get_data_dir(),
-                                default_userspace_paths=default_userspace_paths,
                                 check_modules=check_modules,
                                 online_docs_url=online_docs_url,
                                 interactive=interactive,

--- a/run
+++ b/run
@@ -854,7 +854,6 @@ class VirtTestApp(object):
         if self.options.vt_bootstrap:
             _restore_stdout()
             check_modules = []
-            online_docs_url = None
             interactive = True
             if self.options.vt_type == "qemu":
                 check_modules = arch.get_kvm_module_list()
@@ -871,7 +870,6 @@ class VirtTestApp(object):
             bootstrap.bootstrap(test_name=self.options.vt_type, test_dir=test_dir,
                                 base_dir=data_dir.get_data_dir(),
                                 check_modules=check_modules,
-                                online_docs_url=online_docs_url,
                                 interactive=interactive,
                                 selinux=self.options.vt_selinux_setup,
                                 restore_image=restore_image,

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -838,3 +838,20 @@ def bootstrap(options, interactive=False):
                  "more info", step)
     logging.info("")
     logging.info(online_docs_url)
+
+
+def setup(options):
+    """
+    Run pre tests setup (Uncompress test image(s), such as the JeOS image).
+
+    :param test_name: Test name, such as "qemu".
+    :param guest_os: Specify the guest image used for bootstrapping. By default
+            the JeOS image is used.
+    """
+    if not options.vt_keep_image:
+        test_name = options.vt_type
+        guest_os = options.vt_guest_os or defaults.DEFAULT_GUEST_OS
+        logging.info("Running pre tests setup for test type %s and guest OS %s", test_name, guest_os)
+        for os_info in get_guest_os_info_list(test_name, guest_os):
+            asset_info = asset.get_asset_info(os_info['asset'])
+            asset.uncompress_asset(asset_info, force=True)

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -2,6 +2,7 @@ import logging
 import os
 import glob
 import shutil
+import sys
 from autotest.client.shared import logging_manager, error
 from autotest.client import utils
 import utils_misc
@@ -748,7 +749,13 @@ def bootstrap(options, interactive=False):
     step += 1
     logging.info("%d - Checking the mandatory programs and headers", step)
     guest_os = options.vt_guest_os or defaults.DEFAULT_GUEST_OS
-    verify_mandatory_programs(options.vt_type, guest_os)
+    try:
+        verify_mandatory_programs(options.vt_type, guest_os)
+    except Exception, details:
+        logging.info(details)
+        logging.info('Install the missing programs and/or headers and '
+                     're-run boostrap')
+        sys.exit(1)
 
     logging.info("")
     step += 1

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -723,7 +723,7 @@ def verify_selinux(datadir, imagesdir, isosdir, tmpdir,
 
 
 def bootstrap(test_name, test_dir, base_dir,
-              check_modules, online_docs_url, restore_image=False,
+              check_modules, restore_image=False,
               interactive=True, selinux=False,
               verbose=False, update_providers=False,
               guest_os=defaults.DEFAULT_GUEST_OS, force_update=False):
@@ -735,8 +735,6 @@ def bootstrap(test_name, test_dir, base_dir,
     :param base_dir: Base directory used to hold images and isos.
     :param check_modules: Whether we want to verify if a given list of modules
             is loaded in the system.
-    :param online_docs_url: URL to an online documentation system, such as a
-            wiki page.
     :param restore_image: Whether to restore the image from the pristine.
     :param interactive: Whether to ask for confirmation.
     :param verbose: Verbose output.
@@ -834,10 +832,10 @@ def bootstrap(test_name, test_dir, base_dir,
             else:
                 logging.debug("Module %s loaded", module)
 
-    if online_docs_url:
-        logging.info("")
-        step += 1
-        logging.info("%d - If you wish, take a look at the online docs for "
-                     "more info", step)
-        logging.info("")
-        logging.info(online_docs_url)
+    online_docs_url = 'http://virt-test.readthedocs.org/'
+    logging.info("")
+    step += 1
+    logging.info("%d - If you wish, you may take a look at the online docs for "
+                 "more info", step)
+    logging.info("")
+    logging.info(online_docs_url)

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -19,7 +19,7 @@ recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',),
                                     ('fakeroot',), ('semanage',),
                                     ('getfattr',), ('restorecon',)],
                         'openvswitch': [],
-                        'lvsb': [('semanage',), ('getfattr',), ('restorecon',)],
+                        'lvsb': [('semanage',), ('getfattr',), ('restorecon',), ('virt-sandbox')],
                         'v2v': [],
                         'libguestfs': [('perl',)]}
 
@@ -721,7 +721,7 @@ def verify_selinux(datadir, imagesdir, isosdir, tmpdir,
                          len(changes))
 
 
-def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
+def bootstrap(test_name, test_dir, base_dir,
               check_modules, online_docs_url, restore_image=False,
               interactive=True, selinux=False,
               verbose=False, update_providers=False,
@@ -732,8 +732,6 @@ def bootstrap(test_name, test_dir, base_dir, default_userspace_paths,
     :param test_name: Test name, such as "qemu".
     :param test_dir: Path with the test directory.
     :param base_dir: Base directory used to hold images and isos.
-    :param default_userspace_paths: Important programs for a successful test
-            execution.
     :param check_modules: Whether we want to verify if a given list of modules
             is loaded in the system.
     :param online_docs_url: URL to an online documentation system, such as a

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -514,6 +514,7 @@ def create_config_files(test_dir, shared_dir, interactive, step=None,
                     logging.debug("Preserving existing %s file", dst_file)
             else:
                 logging.debug("Config file %s exists, not touching", dst_file)
+    return step
 
 
 def haz_defcon(datadir, imagesdir, isosdir, tmpdir):
@@ -785,7 +786,7 @@ def bootstrap(test_name, test_dir, base_dir,
 
     datadir = data_dir.get_data_dir()
     if test_name == 'libvirt':
-        create_config_files(test_dir, shared_dir, interactive, step, force_update)
+        step = create_config_files(test_dir, shared_dir, interactive, step, force_update)
         create_subtests_cfg(test_name)
         create_guest_os_cfg(test_name)
         # Don't bother checking if changes can't be made
@@ -807,7 +808,7 @@ def bootstrap(test_name, test_dir, base_dir,
                            data_dir.get_tmp_dir(),
                            interactive, selinux)
     else:  # Some other test
-        create_config_files(test_dir, shared_dir, interactive, step, force_update)
+        step = create_config_files(test_dir, shared_dir, interactive, step, force_update)
         create_subtests_cfg(test_name)
         create_guest_os_cfg(test_name)
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -95,11 +95,11 @@ def verify_recommended_programs(t_type):
             found = None
             try:
                 found = utils_misc.find_command(cmd)
-                logging.info(found)
+                logging.info('%s OK', found)
                 break
             except ValueError:
                 pass
-        if found is None:
+        if not found:
             if len(cmd_aliases) == 1:
                 logging.info("Recommended command %s missing. You may "
                              "want to install it if not building from "
@@ -115,7 +115,7 @@ def verify_mandatory_programs(t_type, guest_os):
     cmds = mandatory_programs[t_type]
     for cmd in cmds:
         try:
-            logging.info(utils_misc.find_command(cmd))
+            logging.info('%s OK', utils_misc.find_command(cmd))
         except ValueError:
             if cmd == '7za' and guest_os != defaults.DEFAULT_GUEST_OS:
                 logging.warn("Command 7za (required to uncompress JeOS) "
@@ -131,7 +131,7 @@ def verify_mandatory_programs(t_type, guest_os):
     for include in available_includes:
         include_basename = os.path.basename(include)
         if include_basename in includes:
-            logging.info(include)
+            logging.info('%s OK', include)
             includes.pop(includes.index(include_basename))
 
     if includes:

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -146,12 +146,12 @@ def verify_mandatory_programs(t_type, guest_os):
 
 
 def write_subtests_files(config_file_list, output_file_object, test_type=None):
-    '''
+    """
     Writes a collection of individual subtests config file to one output file
 
     Optionally, for tests that we know their type, write the 'virt_test_type'
     configuration automatically.
-    '''
+    """
     if test_type is not None:
         output_file_object.write("    - @type_specific:\n")
         output_file_object.write("        variants subtest:\n")
@@ -459,7 +459,7 @@ def create_config_files(test_dir, shared_dir, interactive, step=None,
     def is_file_tracked(fl):
         tracked_result = utils.run("git ls-files %s --error-unmatch" % fl,
                                    ignore_status=True, verbose=False)
-        return (tracked_result.exit_status == 0)
+        return tracked_result.exit_status == 0
 
     if step is None:
         step = 0

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -728,29 +728,13 @@ def bootstrap_tests(options):
 
     :param options: OptParse object with program command line options.
     """
-    if options.vt_type:
-        test_dir = data_dir.get_backend_dir(options.vt_type)
-    elif options.vt_config:
+    if options.vt_config:
         parent_config_dir = os.path.dirname(os.path.dirname(options.vt_config))
         parent_config_dir = os.path.dirname(parent_config_dir)
         options.vt_type = parent_config_dir
-        test_dir = os.path.abspath(parent_config_dir)
 
-    if options.vt_type == 'qemu':
-        check_modules = arch.get_kvm_module_list()
-    else:
-        check_modules = None
-
-    kwargs = {'test_name': options.vt_type,
-              'test_dir': test_dir,
-              'base_dir': data_dir.get_data_dir(),
-              'check_modules': check_modules,
-              'selinux': options.vt_selinux_setup,
-              'restore_image': not(options.vt_no_downloads or
-                                   options.vt_keep_image),
-              'interactive': False,
-              'update_providers': options.vt_update_providers,
-              'guest_os': options.vt_guest_os or defaults.DEFAULT_GUEST_OS}
+    kwargs = {'options': options,
+              'interactive': False}
 
     # Tolerance we have without printing a message for the user to wait (3 s)
     tolerance = 3

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -740,13 +740,11 @@ def bootstrap_tests(options):
         check_modules = arch.get_kvm_module_list()
     else:
         check_modules = None
-    online_docs_url = "https://github.com/autotest/virt-test/wiki"
 
     kwargs = {'test_name': options.vt_type,
               'test_dir': test_dir,
               'base_dir': data_dir.get_data_dir(),
               'check_modules': check_modules,
-              'online_docs_url': online_docs_url,
               'selinux': options.vt_selinux_setup,
               'restore_image': not(options.vt_no_downloads or
                                    options.vt_keep_image),

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -5,8 +5,10 @@ import sys
 import time
 import traceback
 import Queue
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 import aexpect
 import asset
 import utils_misc
@@ -28,6 +30,81 @@ global GUEST_NAME_LIST
 GUEST_NAME_LIST = None
 global TAG_INDEX
 TAG_INDEX = {}
+
+
+def _variant_only_file(filename):
+    """
+    Parse file containing flat list of items to append on an 'only' filter
+    """
+    result = []
+    if not os.path.isabs(filename):
+        fullpath = os.path.realpath(os.path.join(data_dir.get_root_dir(),
+                                                 filename))
+    else:
+        fullpath = filename
+
+    if fullpath is not None:
+        for line in open(fullpath).readlines():
+            line = line.strip()
+            if line.startswith('#') or len(line) < 3:
+                continue
+            result.append(line)
+
+    return ", ".join(result)
+
+
+SUPPORTED_LOG_LEVELS = ["debug", "info", "warning", "error", "critical"]
+
+SUPPORTED_TEST_TYPES = ['qemu', 'libvirt', 'libguestfs', 'openvswitch', 'v2v', 'lvsb']
+
+SUPPORTED_LIBVIRT_URIS = ['qemu:///system', 'lxc:///']
+SUPPORTED_LIBVIRT_DRIVERS = ['qemu', 'lxc', 'xen']
+
+SUPPORTED_IMAGE_TYPES = ['raw', 'qcow2', 'qed', 'vmdk']
+SUPPORTED_DISK_BUSES = ['ide', 'scsi', 'virtio_blk', 'virtio_scsi', 'lsi_scsi', 'ahci', 'usb2', 'xenblk']
+SUPPORTED_NIC_MODELS = ["virtio_net", "e1000", "rtl8139", "spapr-vlan"]
+SUPPORTED_NET_TYPES = ["bridge", "user", "none"]
+
+QEMU_DEFAULT_SET = "migrate..tcp, migrate..unix, migrate..exec, migrate..fd"
+LIBVIRT_DEFAULT_SET = _variant_only_file('backends/libvirt/cfg/default_tests')
+LVSB_DEFAULT_SET = "lvsb_date"
+OVS_DEFAULT_SET = "load_module, ovs_basic"
+
+LIBVIRT_INSTALL = "unattended_install.import.import.default_install.aio_native"
+LIBVIRT_REMOVE = "remove_guest.without_disk"
+
+
+def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
+    if options_qemu:
+        if not os.path.isfile(options_qemu):
+            raise RuntimeError("Invalid qemu binary provided (%s)" %
+                               options_qemu)
+        qemu_bin_path = options_qemu
+    else:
+        try:
+            qemu_bin_path = utils_misc.find_command('qemu-kvm')
+        except ValueError:
+            qemu_bin_path = utils_misc.find_command('kvm')
+
+    if options_dst_qemu is not None:
+        if not os.path.isfile(options_dst_qemu):
+            raise RuntimeError("Invalid dst qemu binary provided (%s)" %
+                               options_dst_qemu)
+        qemu_dst_bin_path = options_dst_qemu
+    else:
+        qemu_dst_bin_path = None
+
+    qemu_dirname = os.path.dirname(qemu_bin_path)
+    qemu_img_path = os.path.join(qemu_dirname, 'qemu-img')
+    qemu_io_path = os.path.join(qemu_dirname, 'qemu-io')
+
+    if not os.path.exists(qemu_img_path):
+        qemu_img_path = utils_misc.find_command('qemu-img')
+
+    if not os.path.exists(qemu_io_path):
+        qemu_io_path = utils_misc.find_command('qemu-io')
+
+    return [qemu_bin_path, qemu_img_path, qemu_io_path, qemu_dst_bin_path]
 
 
 class Test(object):

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -745,7 +745,6 @@ def bootstrap_tests(options):
     kwargs = {'test_name': options.vt_type,
               'test_dir': test_dir,
               'base_dir': data_dir.get_data_dir(),
-              'default_userspace_paths': None,
               'check_modules': check_modules,
               'online_docs_url': online_docs_url,
               'selinux': options.vt_selinux_setup,


### PR DESCRIPTION
The integration PR was cleaned up and updated. I'd like to get this into the consideration ASAP, please.

Changes from v2:
* Dropped some refactored code from the test runner that is no longer useful
* Heavy cleanup on the interface of `bootstrap.bootstrap()`
* Add new interface `bootstrap.setup()`, that only concerns itself with setting up tests and mandates that users run the bootstrap procedure first.

Changes from v1:
 * Dropped commits made obsolete by the latest version of the plugin

This contains some simple and not-so intrusive patches in order to support the virt test compatibility layer for avocado [1]. 

[1] See avocado-framework/avocado#582