### PR TITLE
virt: enable machine_type accepts extra parameters

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -884,6 +884,7 @@ class DevContainer(object):
             return devices
 
         machine_type = params.get('machine_type')
+        machine_type_extra_params = params.get('machine_type_extra_params')
         if machine_type:
             m_types = []
             for _ in self.__machine_types.splitlines()[1:]:
@@ -891,7 +892,9 @@ class DevContainer(object):
 
             if machine_type in m_types:
                 if (self.has_option('M') or self.has_option('machine')):
-                    cmd = "-M %s" % machine_type
+                    cmd = "-machine %s" % machine_type
+                    if machine_type_extra_params:
+                        cmd += ",%s" % machine_type_extra_params.strip(',')
                 else:
                     cmd = ""
                 if 'q35' in machine_type:   # Q35 + ICH9

--- a/virttest/qemu_devices_unittest.py
+++ b/virttest/qemu_devices_unittest.py
@@ -759,7 +759,7 @@ fdc
         self.assertNotEqual(qdev2, qdev, "Other qdev matches this one:\n%s\n%s"
                             % (qdev, qdev2))
         # cmdline
-        exp = ("-M pc -device HBA,id=hba1,addr=0a,bus=pci.0 -device dev "
+        exp = ("-machine pc -device HBA,id=hba1,addr=0a,bus=pci.0 -device dev "
                "-device dev -device dev")
         out = qdev.cmdline()
         self.assertEqual(out, exp, 'Corrupted qdev.cmdline() output:\n%s\n%s'
@@ -1115,7 +1115,7 @@ fdc
                                      parent_bus={'type': ('PCI', 'PCIE'),
                                                  'aobject': 'pci.0'}))
 
-        exp = ("-M pc -device ioh3420,id=root.1,bus=pci.0,addr=02 "
+        exp = ("-machine pc -device ioh3420,id=root.1,bus=pci.0,addr=02 "
                "-device x3130-upstream,id=pci_switch,bus=root.1,addr=00 "
                "-device pci-bridge,id=pci_bridge,bus=root.1,addr=01,"
                "chassis_nr=1 -device ahci,id=in_bridge,bus=pci_bridge,addr=01"


### PR DESCRIPTION
Some new feature like dump-guest-core in qemu asks for command line
like '-machine pc,dump-guest-core=on/off', so we need let machine
type accepts extra parameters, and "-M" can not accept extra parameter
in qemu side, use "-machine".

ID: 1226116

Signed-off-by: Shaolong Hu <shu@redhat.com>