### PR TITLE
Iscsi

### DIFF
--- a/virttest/iscsi_unittest.py
+++ b/virttest/iscsi_unittest.py
@@ -173,7 +173,7 @@ class iscsi_test(unittest.TestCase):
 
     def test_iscsi_get_device_name(self):
         self.setup_stubs_init()
-        iscsi_emulated = iscsi.Iscsi(self.iscsi_emulated_params)
+        iscsi_emulated = iscsi.Iscsi.create_iSCSI(self.iscsi_emulated_params)
         iscsi_emulated.emulated_id = "1"
         self.setup_stubs_login(iscsi_emulated)
         iscsi_emulated.login()
@@ -186,7 +186,7 @@ class iscsi_test(unittest.TestCase):
 
     def test_iscsi_login(self):
         self.setup_stubs_init()
-        iscsi_emulated = iscsi.Iscsi(self.iscsi_emulated_params)
+        iscsi_emulated = iscsi.Iscsi.create_iSCSI(self.iscsi_emulated_params)
         self.setup_stubs_logged_in()
         self.assertFalse(iscsi_emulated.logged_in())
         result = "tcp [15] 127.0.0.1:3260,1 %s" % iscsi_emulated.target
@@ -195,7 +195,7 @@ class iscsi_test(unittest.TestCase):
 
     def test_iscsi_visible(self):
         self.setup_stubs_init()
-        iscsi_emulated = iscsi.Iscsi(self.iscsi_emulated_params)
+        iscsi_emulated = iscsi.Iscsi.create_iSCSI(self.iscsi_emulated_params)
         self.setup_stubs_portal_visible(iscsi_emulated)
         self.assertFalse(iscsi_emulated.portal_visible())
         self.setup_stubs_portal_visible(iscsi_emulated, "127.0.0.1:3260,1 %s"
@@ -203,7 +203,7 @@ class iscsi_test(unittest.TestCase):
 
     def test_iscsi_target_id(self):
         self.setup_stubs_init()
-        iscsi_emulated = iscsi.Iscsi(self.iscsi_emulated_params)
+        iscsi_emulated = iscsi.Iscsi.create_iSCSI(self.iscsi_emulated_params)
         self.setup_stubs_get_target_id()
         self.assertNotEqual(iscsi_emulated.get_target_id(), "")
 

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -465,7 +465,7 @@ class Iscsidev(Rawdev):
             if params.get("emulated_file_remove", "no") == "yes":
                 self.emulated_file_remove = True
         params["iscsi_thread_id"] = self.image_name
-        self.iscsidevice = iscsi.Iscsi(params, root_dir=root_dir)
+        self.iscsidevice = iscsi.Iscsi.create_iSCSI(params, root_dir=root_dir)
         self.device_id = params.get("device_id")
         self.iscsi_init_timeout = int(params.get("iscsi_init_timeout", 10))
 

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -432,7 +432,7 @@ def setup_or_cleanup_nfs(is_setup, mount_dir="nfs-mount", is_mount=False,
 
 
 def setup_or_cleanup_iscsi(is_setup, is_login=True,
-                           emulated_image="emulated_iscsi", image_size="1G",
+                           emulated_image="emulated-iscsi", image_size="1G",
                            chap_user="", chap_passwd="", restart_tgtd="no"):
     """
     Set up(and login iscsi target) or clean up iscsi service on localhost.
@@ -445,20 +445,15 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
     :param chap_passwd: CHAP authentication password
     :return: iscsi device name or iscsi target
     """
-    try:
-        utils_misc.find_command("tgtadm")
-        utils_misc.find_command("iscsiadm")
-    except ValueError:
-        raise error.TestNAError("Missing command 'tgtadm' and/or 'iscsiadm'.")
-
     tmpdir = os.path.join(data_dir.get_root_dir(), 'tmp')
     emulated_path = os.path.join(tmpdir, emulated_image)
-    emulated_target = "iqn.2001-01.com.virttest:%s.target" % emulated_image
+    emulated_target = ("iqn.%s.com.virttest:%s.target" %
+                       (time.strftime("%Y-%m"), emulated_image))
     iscsi_params = {"emulated_image": emulated_path, "target": emulated_target,
                     "image_size": image_size, "iscsi_thread_id": "virt",
                     "chap_user": chap_user, "chap_passwd": chap_passwd,
                     "restart_tgtd": restart_tgtd}
-    _iscsi = iscsi.Iscsi(iscsi_params)
+    _iscsi = iscsi.Iscsi.create_iSCSI(iscsi_params)
     if is_setup:
         _iscsi.export_target()
         if is_login:


### PR DESCRIPTION
    virttest/iscsi: support LIO backend for iSCSI
    
    RHEL7 introduces the LIO iSCSI backend,
    which replaces the TGT backend used in RHEL6.
    
    The deamon tgtd has been deprecated in latest release,
    which will causes some cases failed.
    
    The patch aims to support both TGT and LIO backend.
