### PR TITLE
virttest/virsh: cleanup code

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1512,7 +1512,6 @@ def update_device(domainarg=None, filearg=None,
     :param dargs: standardized virsh function API keywords
     :return: CmdResult instance
     """
-    cmd = "update-device"
     return _adu_device("update-device", domainarg=domainarg, filearg=filearg,
                        domain_opt=domain_opt, file_opt=file_opt,
                        flagstr=flagstr, **dargs)


### PR DESCRIPTION
The commit d0d6610 introduced a new function named
_adu_device() and make it as the basis of
attach_device()/detach_device()/update_device().
But,
It forgot to remove unused statement in update_device().
cmd = "update-device".