### PR TITLE
virt-test: qemu_vm.py: update the usage of option "qemu_sandbox".

### DIFF
--- a/run
+++ b/run
@@ -646,8 +646,9 @@ class VirtTestApp(object):
 
     def _process_qemu_sandbox(self):
         if not self.options.vt_config:
-            if self.options.vt_qemu_sandbox == "off":
-                self.cartesian_parser.assign("qemu_sandbox", "off")
+            if self.options.vt_qemu_sandbox:
+                self.cartesian_parser.assign("qemu_sandbox",
+                                             self.options.vt_qemu_sandbox)
         else:
             logging.info(
                 "Config provided, ignoring \"--sandbox <on|off>\" option")

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1205,10 +1205,12 @@ class VM(virt_vm.BaseVM):
         # Add the VM's name
         devices.insert(StrDev('vmname', cmdline=add_name(devices, name)))
 
-        if params.get("qemu_sandbox", "on") == "on":
-            devices.insert(StrDev('sandbox', cmdline=process_sandbox(devices, "add")))
-        elif params.get("sandbox", "off") == "off":
+        qemu_sandbox = params.get("qemu_sandbox")
+        if qemu_sandbox == "on":
+            devices.insert(StrDev('qemu_sandbox', cmdline=process_sandbox(devices, "add")))
+        elif qemu_sandbox == "off":
             devices.insert(StrDev('qemu_sandbox', cmdline=process_sandbox(devices, "rem")))
+        del qemu_sandbox
 
         devs = devices.machine_by_params(params)
         for dev in devs:


### PR DESCRIPTION
The usage of "--sanbox=on/off" is dropped, we use
"qemu_sandbox=on/off" instead now.
Need update all the usage to "qemu_sandbox".

Signed-off-by: Cong Li <coli@redhat.com>