### PR TITLE
shared.scripts.virtio_console_guest: Fix variable name

### DIFF
--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -300,7 +300,7 @@ class VirtioGuestPosix(VirtioGuest):
                         print "FAIL: Symlink %s is not correct." % dev_ppath
                 except AttributeError:
                     print ("Bad data on file %s:\n%s. " %
-                           (open_db_file, "".join(file).strip()))
+                           (open_db_file, "".join(line_list).strip()))
                     print "FAIL: Bad data on file %s." % open_db_file
                     return
 


### PR DESCRIPTION
The variable name in AttributeError exception handling should be
line_list and not file.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>