### PR TITLE
run: Fix crash when $AUTOTEST_PATH is not set

### DIFF
--- a/run
+++ b/run
@@ -99,8 +99,9 @@ def _import_autotest_modules():
     2) Import the libraries system wide. For this to work, the
        autotest-framework package for the given distro must be installed.
     """
-    autotest_dir = os.path.expanduser(os.environ.get('AUTOTEST_PATH'))
+    autotest_dir = os.environ.get('AUTOTEST_PATH')
     if autotest_dir is not None:
+        autotest_dir = os.path.expanduser(autotest_dir)
         autotest_dir = os.path.abspath(autotest_dir)
         client_dir = os.path.join(autotest_dir, 'client')
         setup_modules_path = os.path.join(client_dir, 'setup_modules.py')


### PR DESCRIPTION
Fix issue introduced by commit 6ddc6783f9cd73b4deba94cb45df5b8ff16acc1c:

    $ ./run -h
    Traceback (most recent call last):
      File "./run", line 976, in <module>
        app = VirtTestApp()
      File "./run", line 483, in __init__
        self.system_setup()
      File "./run", line 468, in system_setup
        _import_autotest_modules()
      File "./run", line 102, in _import_autotest_modules
        autotest_dir = os.path.expanduser(os.environ.get('AUTOTEST_PATH'))
      File "/usr/lib64/python2.7/posixpath.py", line 261, in expanduser
        if not path.startswith('~'):
    AttributeError: 'NoneType' object has no attribute 'startswith'