### PR TITLE
shared.cfg.guest-hw: Add virtio_rng driver in win_virtio_update

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -262,7 +262,9 @@ variants image_backend:
 
 variants:
     - @no_virtio_rng:
+        no rng_bat
     - rng_random:
+        only rng_bat win_virtio_update.install_driver
         no Host_RHEL.5 Host_RHEL.6.0 Host_RHEL.6.1 Host_RHEL.6.2 Host_RHEL.3 Host_RHEL.6.4 Host_RHEL.6.5
         virtio_rngs += " rng0"
         #max-bytes_virtio-rng-pci =
@@ -271,6 +273,7 @@ variants:
         backend_type = passthrough
         filename_passthrough = /dev/random
     - rng_egd:
+        only rng_bat
         no Host_RHEL.5 Host_RHEL.6.0 Host_RHEL.6.1 Host_RHEL.6.2 Host_RHEL.3 Host_RHEL.6.4 Host_RHEL.6.5
         virtio_rngs += "rng0"
         #max-bytes_virtio-rng-pci =


### PR DESCRIPTION
This patch will install the virtio_rng driver in
win_virtio_update.install_driver testcase.

ID: 1192327