### PR TITLE
Change the virsh blkdeviotune's options processing method.

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -3953,7 +3953,7 @@ def blkdeviotune(name, device=None, options=None,
     """
     cmd = "blkdeviotune %s" % name
     if options:
-        cmd += " --%s" % options
+        cmd += " %s" % options
     if device:
         cmd += " --device %s" % device
     if total_bytes_sec:


### PR DESCRIPTION
The old method for options in virsh blkdeviotune just fits
single option, but '--live --config' should be given at the same time.