### PR TITLE
cfg.guest-hw: Don't use cd_format for ppc

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -69,6 +69,9 @@ variants:
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
         image_boot=yes
+        unattended_install..ppc64, unattended_install..ppc64le:
+            # ppc is unable to install from cdrom using virtio_blk
+            cd_format=
         arm64:
             # Direct usage of virtio-blk-device (using mmio transports) is used
             # on arm64.

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1168,6 +1168,7 @@ class DevContainer(object):
             use_device = False
         if not fmt:
             use_device = False
+            fmt = None  # fmt == '' generates problems further in the code
         if fmt == 'floppy' and not self.has_option("global"):
             use_device = False
 


### PR DESCRIPTION
The 5df445a8fafe71a82d91698f28381278d355a11a commit makes all tests to use cd_format of the selected type. This doesn't work on PPC64 install (tested on RHEL7.1). This patch adds uses default instead.

Additionally it handles the situation when `fmt == ''`. Without the fix it still uses drive with `format=""`, which obviously doesn't produce expected results.
