### PR TITLE
cfg.machines: Don't disable screendump on PPC64

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -17,8 +17,6 @@ variants:
         machine_type = pseries
         # Currently only supports standard VGA
         vga = std
-        inactivity_watcher = none
-        take_regular_screendumps = no
         # No support for USB-uhci
         usb_type = pci-ohci
         usb_type_usb1 = pci-ohci


### PR DESCRIPTION
Vga output was enabled in 121294e4ccd182eb46c4023771d177f2b5f1d690 lets
remove the screendump/inactivity_watcher sections to use defaults
instead.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>