### PR TITLE
cfg.guest-os: Add RHEL.7.devel.ppc64le variant

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64le.cfg
@@ -1,0 +1,18 @@
+- ppc64le:
+    image_name = images/rhel7devel-ppc64le
+    vm_arch_name = ppc64le
+    os_variant = rhel7
+    no unattended_install..floppy_ks
+    no guest_s3, guest_s4
+    mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
+    netdev_peer_re = "(.*?): .*?\\\s(.*?):"
+    unattended_install:
+        cdrom_unattended = images/rhel7-ppc64/ks.iso
+        kernel = images/rhel7-ppc64le/vmlinuz
+        initrd = images/rhel7-ppc64le/initrd.img
+    unattended_install.cdrom:
+        boot_path = ppc/ppc64
+        cdrom_cd1 = isos/linux/RHEL-7-devel-ppc64le.iso
+    unattended_install..floppy_ks:
+        floppies = "fl"
+        floppy_name = images/rhel7-ppc64le/ks.vfd


### PR DESCRIPTION
Tested on the latest RHEL7.1 available image.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>