### PR TITLE
virttest.bootstrap: setup() -> Handle guest OS that have no asset

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -141,7 +141,7 @@ def get_all_assets():
     asset_data_list = []
     download_dir = data_dir.get_download_dir()
     for asset in glob.glob(os.path.join(download_dir, '*.ini')):
-        asset_name = os.path.basename(asset).split('.')[0]
+        asset_name = os.path.basename(asset)[:-4]
         asset_data_list.append(get_asset_info(asset_name))
     return asset_data_list
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -861,6 +861,11 @@ def setup(options):
         test_name = options.vt_type
         guest_os = options.vt_guest_os or defaults.DEFAULT_GUEST_OS
         logging.info("Running pre tests setup for test type %s and guest OS %s", test_name, guest_os)
-        for os_info in get_guest_os_info_list(test_name, guest_os):
-            asset_info = asset.get_asset_info(os_info['asset'])
-            asset.uncompress_asset(asset_info, force=True)
+        try:
+            for os_info in get_guest_os_info_list(test_name, guest_os):
+                asset_info = asset.get_asset_info(os_info['asset'])
+                asset.uncompress_asset(asset_info, force=True)
+        # Some guests will not have guest os info list available,
+        # So there will be no need for the uncompress phase.
+        except ValueError:
+            pass


### PR DESCRIPTION
Some guest OS naturally won't have assets associated with
them. Let's handle when that happens, in order to let people
run install tests on such guests.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>