### PR TITLE
virttest.qemu_storage: Support -b "" for qemu_disk_img_rebase

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -251,8 +251,11 @@ class QemuImg(storage.QemuImg):
         if rebase_mode == "unsafe":
             cmd += " -u"
         if self.base_tag:
-            cmd += " -b %s -F %s %s" % (self.base_image_filename,
-                                        self.base_format, self.image_filename)
+            if self.base_tag == "null":
+                cmd += " -b \"\" -F %s %s" % (self.base_format, self.image_filename)
+            else:
+                cmd += " -b %s -F %s %s" % (self.base_image_filename,
+                                            self.base_format, self.image_filename)
         else:
             raise error.TestError("Can not find the image parameters need"
                                   " for rebase.")


### PR DESCRIPTION
If backing_file is specified as "" (the empty string), then the
image is rebased onto no backing file

Signed-off-by: chendt.fnst <chendt.fnst@cn.fujitsu.com>