### PR TITLE
Fix two indetectable iscsi bug

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -455,7 +455,6 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
                     "restart_tgtd": restart_tgtd}
     _iscsi = iscsi.Iscsi.create_iSCSI(iscsi_params)
     if is_setup:
-        _iscsi.export_target()
         if is_login:
             _iscsi.login()
             # The device doesn't necessarily appear instantaneously, so give
@@ -473,6 +472,7 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
             _iscsi.cleanup()
             utils.run("rm -f %s" % emulated_path)
         else:
+            _iscsi.export_target()
             return emulated_target
     else:
         _iscsi.export_flag = True


### PR DESCRIPTION
First :
    utils_test/libvirt.py: fix call export_target() twice
    
    If the parameter 'is_login' is true,
    export_target() will be call two times.
    Error message as following,
    
    * Command:
      targetcli /backstores/fileio/ create device.disk-pool
      /mnt/extra_disk/osc /virt-test/tmp/disk-pool
      Exit status: 1
      Duration: 0.110117912292
    
      stderr:
      expected a character buffer object
    
    so move the first export_target() to else-block.

Second:
    virttest/iscsi.py: fix login failure
    
    If both iSCSI server and iSCSI client are on localhost,
    It's necessary to set up InitiatorName for localhost.
    Otherwize, login will fail.

