### PR TITLE
virt-test: guest-hw.cfg: set "cd_format=ide" for virtio_blk.

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -65,7 +65,9 @@ variants:
         drive_format=sd
     - virtio_blk:
         drive_format=virtio
-        cd_format=virtio
+        cd_format=ide
+        q35:
+            cd_format=ahci
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
         image_boot=yes


### PR DESCRIPTION
As virtio_blk does not have the interface for cdrom,
use "cd_format=ide" for virtio_blk.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1238539