### PR TITLE
virttest.qemu_monitor: Add vm.name for monitor log

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -91,7 +91,7 @@ def get_monitor_filename(vm, monitor_name):
     :param monitor_name: The monitor name.
     :return: The string of socket file name for qemu monitor.
     """
-    return "/tmp/monitor-%s-%s" % (monitor_name, vm.instance)
+    return "/tmp/monitor-%s-%s-%s" % (vm.name, monitor_name, vm.instance)
 
 
 def get_monitor_filenames(vm):
@@ -187,8 +187,8 @@ class Monitor:
         try:
             self._socket.connect(filename)
         except socket.error, details:
-            raise MonitorConnectError("Could not connect to monitor socket: %s"
-                                      % details)
+            raise MonitorConnectError("Could not connect to monitor (%s-%s) "
+                                      "socket: %s" % (name, vm.name, details))
 
     def __del__(self):
         # Automatically close the connection when the instance is garbage
@@ -278,8 +278,8 @@ class Monitor:
         :param extra_str: Extra string would be printed in log.
         """
         if self.debug_log or debug:
-            logging.debug("(monitor %s) Sending command '%s' %s",
-                          self.name, cmd, extra_str)
+            logging.debug("(monitor %s-%s) Sending command '%s' %s",
+                          self.name, self.vm.name, cmd, extra_str)
 
     def _log_lines(self, log_str):
         """


### PR DESCRIPTION
For booting up multiple vms, check monitor log is not really
easy, so add vm.name into it.

Signed-off-by: Shuping Cui <scui@redhat.com>