### PR TITLE
virt-test: test_setup.py: Add class for enable multi queue in guest.

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/6.6.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.6.cfg
@@ -2,6 +2,7 @@
     no setup
     image_name = images/rhel66
     os_variant = rhel6
+    setup_mq = yes
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         unattended_file = unattended/RHEL-6-series.ks
         syslog_server_proto = udp

--- a/shared/cfg/guest-os/Linux/RHEL/7.0/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/x86_64.cfg
@@ -2,6 +2,7 @@
     grub_file = /boot/grub2/grub.cfg
     vm_arch_name = x86_64
     image_name += -64
+    setup_mq = yes
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_unattended = images/rhel70-64/ks.iso
         kernel = images/rhel70-64/vmlinuz

--- a/shared/cfg/guest-os/Linux/RHEL/7.1/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.1/x86_64.cfg
@@ -2,6 +2,7 @@
     grub_file = /boot/grub2/grub.cfg
     vm_arch_name = x86_64
     image_name += -64
+    setup_mq = yes
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_unattended = images/rhel71-64/ks.iso
         kernel = images/rhel71-64/vmlinuz

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -805,6 +805,17 @@ def preprocess(test, params, env):
     # Preprocess all VMs and images
     if params.get("not_preprocess", "no") == "no":
         process(test, params, env, preprocess_image, preprocess_vm)
+        # Enable multi queue in guest
+        mq = test_setup.MultiQueueConfig(params)
+        if params.get("nic_model") == "virtio":
+            if params.get("setup_mq") == "yes" and params.get("queues"):
+                queues = int(params.get("queues", 1))
+                if queues == 1:
+                    logging.info("No need enable MQ feature for single queue")
+                elif queues > 1:
+                    for vm_name in params.get("vms").split():
+                        vm = env.get_vm(vm_name)
+                        mq.setup(queues, vm_name, vm)
 
     # Start the screendump thread
     if params.get("take_regular_screendumps") == "yes":


### PR DESCRIPTION
Enable multi queue for those guest whose os are 7.* and 6.6+.

Signed-off-by: Cong Li <coli@redhat.com>