### PR TITLE
Fix the issue param 'timeout' to float type

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -500,7 +500,7 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None):
     :param text: Text to print while waiting, for debug purposes
     """
     start_time = time.time()
-    end_time = time.time() + timeout
+    end_time = time.time() + float(timeout)
 
     time.sleep(first)
 


### PR DESCRIPTION
The timeout passed is str type ,can will cause Type Error when i
execute a plus operation.
This patch is to modify timeout as float type.

BZ: 1241372

Signed-off-by: Mike Cao <bcao@redhat.com>