### PR TITLE
v2v: Update the harness for new version virt-v2v testing

### DIFF
--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -16,6 +16,7 @@ def build_docs():
     Build virt-test HTML docs, reporting failures.
     """
     ignore_list = ['No python imaging library installed',
+                   'ovirtsdk module not present',
                    'Virsh executable not set or found on path',
                    "failed to import module u'virttest.passfd'",
                    "failed to import module u'virttest.step_editor'"]

--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -350,3 +350,47 @@ def have_similar_img(base_img, comp_img_path, threshold=10):
         if img_similar(base_img, img, threshold):
             return True
     return False
+
+
+def image_crop_save(image, new_image, box=None):
+    """
+    Crop an image and save it to a new image.
+
+    :param image: Full path of the original image
+    :param new_image: Full path of the cropped image
+    :param box: A 4-tuple defining the left, upper, right, and lower pixel coordinate.
+    :return: True if crop and save image succeed
+    """
+    img = Image.open(image)
+    if not box:
+        x, y = img.size
+        box = (x/4, y/4, x*3/4, y*3/4)
+    try:
+        img.crop(box).save(new_image)
+    except (KeyError, SystemError), e:
+        logging.error("Fail to crop image: %s", e)
+        return False
+    return True
+
+
+def image_histogram_compare(image_a, image_b, size=(0, 0)):
+    """
+    Compare the histogram of two images and return similar degree.
+
+    :param image_a: Full path of the first image
+    :param image_b: Full path of the second image
+    :param size: Convert image to size(width, height), and if size=(0, 0), the function will convert the big size image align with the small one.
+    """
+    img_a = Image.open(image_a)
+    img_b = Image.open(image_b)
+    if not any(size):
+        size = tuple(map(max, img_a.size, img_b.size))
+    img_a_h = img_a.resize(size).convert('RGB').histogram()
+    img_b_h = img_b.resize(size).convert('RGB').histogram()
+    s = 0
+    for i, j in zip(img_a_h, img_b_h):
+        if i == j:
+            s += 1
+        else:
+            s += 1 - float(abs(i - j))/max(i, j)
+    return s / len(img_a_h)

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -14,6 +14,7 @@ import signal
 import re
 import logging
 import commands
+import subprocess
 import fcntl
 import sys
 import inspect
@@ -1316,6 +1317,31 @@ def yum_install(pkg_list, session=None, timeout=300):
                           % pkg)
             return False
     return True
+
+
+def add_identities_into_ssh_agent():
+    """
+    Adds RSA or DSA identities to the authentication agent
+    """
+    ssh_env = subprocess.check_output(["ssh-agent"]).decode("utf-8")
+    logging.info("The current SSH ENV: %s", ssh_env)
+
+    re_auth_sock = re.compile('SSH_AUTH_SOCK=(?P<SSH_AUTH_SOCK>[^;]*);')
+    ssh_auth_sock = re.search(re_auth_sock, ssh_env).group("SSH_AUTH_SOCK")
+    logging.debug("The SSH_AUTH_SOCK: %s", ssh_auth_sock)
+
+    re_agent_pid = re.compile('SSH_AGENT_PID=(?P<SSH_AGENT_PID>[^;]*);')
+    ssh_agent_pid = re.search(re_agent_pid, ssh_env).group("SSH_AGENT_PID")
+    logging.debug("SSH_AGENT_PID: %s", ssh_agent_pid)
+
+    logging.debug("Update SSH envrionment variables")
+    os.environ['SSH_AUTH_SOCK'] = ssh_auth_sock
+    os.system("set SSH_AUTH_SOCK " + ssh_auth_sock)
+    os.environ['SSH_AGENT_PID'] = ssh_agent_pid
+    utils.run("set SSH_AGENT_PID " + ssh_agent_pid)
+
+    logging.info("Adds RSA or DSA identities to the authentication agent")
+    utils.run("ssh-add")
 
 
 class NumaInfo(object):

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -643,9 +643,10 @@ class BaseVM(object):
         if nic.nettype not in ['bridge', 'macvtap']:
             hostname = socket.gethostname()
             return socket.gethostbyname(hostname)
-        if not nic.has_key('mac') and self.params.get('vm_type') == 'libvirt':
-            # Look it up from xml
-            nic.mac = self.get_virsh_mac_address(index)
+        if not nic.has_key('mac'):
+            if self.params.get('vm_type') in ['libvirt', 'v2v']:
+                # Look it up from xml
+                nic.mac = self.get_virsh_mac_address(index)
         # else TODO: Look up mac from existing qemu-kvm process
         if not nic.has_key('mac'):
             raise VMMACAddressMissingError(index)


### PR DESCRIPTION
Finally, the rewrite virt-v2v is ready for testing, so this patch
including 7 files update to make sure v2v test can work normally.

ovirt: Update for new ovirt API and bugs fix
ppm_utils.py: Introduce two functions for image crop and compare
utils_env: Update the tcpdump start function
utils_misc: Add a new function to add identities into ssh agent
utils_v2v: According the new version virt-v2v, update utils functions
           and introduce a new VirshSession for SASL authentication(for
           ovirt node virsh session creation)
virsh: Update VirshSession for inheritance and add two new functions for
       mouse move and click.
virt_vm: Also get mac address from XML for v2v VM

Signed-off-by: Yanbing Du <ydu@redhat.com>