### PR TITLE
shared.unattended: Allow ssh root login on Ubuntu 14.04 Linux server

### DIFF
--- a/shared/unattended/Ubuntu-14-04-1.preseed
+++ b/shared/unattended/Ubuntu-14-04-1.preseed
@@ -64,4 +64,5 @@ echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
 echo "#!/bin/sh -e" > /target/etc/rc.local; \
 echo "/usr/sbin/update-grub" >> /target/etc/rc.local; \
 echo "exit 0" >> /target/etc/rc.local; \
-sed -i "s/ alias/ #alias/g" /target/root/.bashrc
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; \
+sed -i "s/^PermitRootLogin without-password/PermitRootLogin yes/g" /target/etc/ssh/sshd_config

--- a/shared/unattended/Ubuntu-14-04.preseed
+++ b/shared/unattended/Ubuntu-14-04.preseed
@@ -50,4 +50,5 @@ echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
 echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
 echo "respawn exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
 echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
-sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub; \
+sed -i "s/^PermitRootLogin without-password/PermitRootLogin yes/g" /target/etc/ssh/sshd_config


### PR DESCRIPTION
By default the root ssh login to Ubuntu 14.04 Linux
server is disable, need allow it.

Signed-off-by: Shuping Cui <scui@redhat.com>