### PR TITLE
virttest.qemu_vm: remove default parameter 'driftfix' for pseries

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -21,6 +21,7 @@ variants:
         usb_type = pci-ohci
         usb_type_usb1 = pci-ohci
         usb_controller_tablet1 = ohci
+        del rtc_drift
     - @arm64:
         only aarch64
         auto_cpu_model = "no"

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -992,7 +992,7 @@ class VM(virt_vm.BaseVM):
             if devices.has_option("rtc"):
                 cmd = " -rtc base=%s" % params.get("rtc_base", "utc")
                 cmd += _add_option("clock", params.get("rtc_clock", "host"))
-                cmd += _add_option("driftfix", params.get("rtc_drift", "none"))
+                cmd += _add_option("driftfix", params.get("rtc_drift", None))
                 return cmd
             elif devices.has_option("rtc-td-hack"):
                 return " -rtc-td-hack"


### PR DESCRIPTION
ID: 1243289