### PR TITLE
using notepad.exe for copy insetead of cmd.exe

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -213,9 +213,9 @@
         list_volume_command = wmic volume get driveletter
         re_str = "([A-Z]:)"
         format_command = format /fs:%s %s /q /y
-        copy_to_command = copy C:\WINDOWS\system32\cmd.exe %s /y
-        copy_from_command = copy %s\cmd.exe c:\ /y
-        compare_command = fc /b c:\windows\system32\cmd.exe c:\cmd.exe
+        copy_to_command = copy C:\WINDOWS\system32\notepad.exe %s /y
+        copy_from_command = copy %s\notepad.exe c:\ /y
+        compare_command = fc /b c:\windows\system32\notepad.exe c:\notepad.exe
         check_result_key_word = no difference
     floppy_test:
         format_floppy_cmd = echo n|format A: /Q /V:test_floppy


### PR DESCRIPTION
When running multi_disk job ,we will hit "The process cannot access t he file because it is being used by another process" when trying to copy cmd.exe from D:\ to C:\

This patch is using notepad.exe to fix it.

ID: 1243345

Signed-off-by: Mike Cao <bcao@redhat.com>