### PR TITLE
utils_test: add pbzip2 support to tar

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -31,6 +31,7 @@ import subprocess
 
 from autotest.client import utils, os_dep
 from autotest.client.shared import error
+from autotest.client.shared import base_packages
 from autotest.client.tools import scan_results
 from virttest import qemu_virtio_port
 from virttest import aexpect, utils_misc, virt_vm, data_dir, utils_net
@@ -733,8 +734,16 @@ def run_autotest(vm, session, control_path, timeout,
         dirname = os.path.dirname(remote_path)
         session.cmd("cd %s" % dirname)
         session.cmd("mkdir -p %s" % os.path.dirname(dest_dir))
-        e_cmd = "tar xjvmf %s -C %s" % (basename, os.path.dirname(dest_dir))
-        output = session.cmd(e_cmd, timeout=240)
+        has_pbzip2, pbzip2_path = session.cmd_status_output("which pbzip2")
+        has_lbzip2, lbzip2_path = session.cmd_status_output("which lbzip2")
+        if (has_pbzip2 == 0) and "pbzip2" in pbzip2_path:
+            tar_cmds = "--use-compress-program=pbzip2 -xvmf"
+        elif (has_lbzip2 == 0) and "lbzip2" in lbzip2_path:
+            tar_cmds = "--use-compress-program=lbzip2 -xvmf"
+        else:
+            tar_cmds = "xvjmf"
+        e_cmd = "tar %s %s -C %s" % (tar_cmds, basename, os.path.dirname(dest_dir))
+        output = session.cmd(e_cmd, timeout=120)
         autotest_dirname = ""
         for line in output.splitlines()[1:]:
             autotest_dirname = line.split("/")[0]
@@ -897,8 +906,12 @@ def run_autotest(vm, session, control_path, timeout,
     autotest_parentdir = os.path.dirname(autotest_path)
 
     # tar the contents of bindir/autotest
-    cmd = ("cd %s; tar cvjf %s %s/*" %
-           (autotest_parentdir, compressed_autotest_path, autotest_basename))
+    if base_packages.has_pbzip2():
+        tar_cmds = "--use-compress-program=pbzip2 -cvf"
+    else:
+        tar_cmds = "cvjf"
+    cmd = ("cd %s; tar %s %s %s/*" %
+           (autotest_parentdir, tar_cmds, compressed_autotest_path, autotest_basename))
     cmd += " --exclude=%s/results*" % autotest_basename
     cmd += " --exclude=%s/tmp" % autotest_basename
     cmd += " --exclude=%s/control*" % autotest_basename


### PR DESCRIPTION
If pbzip2 is detected, either with base_packages.has_pbzip2 or with
'which pbzip2' then use pbzip2 to compress.

Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>