### PR TITLE
utils_test: increase timeout on md5sum since it can take a while

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -699,7 +699,9 @@ def run_autotest(vm, session, control_path, timeout,
         hash_differs = False
         local_hash = utils.hash_file(local_path)
         basename = os.path.basename(local_path)
-        output = session.cmd_output("md5sum %s" % remote_path)
+        output = session.cmd_output("md5sum %s" % remote_path,
+                                    timeout=int(
+                                        params.get("md5sum_timeout", 240)))
         if "such file" in output:
             remote_hash = "0"
         elif output:


### PR DESCRIPTION
For some reason my autotest tarball was huge, so the md5sum
did not complete in the default timeout of 60 seconds

Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>