### PR TITLE
virttest: small enhancement for get_cpu_count

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -12,7 +12,7 @@
     mem_chk_cmd = dmidecode -t 17 | awk -F: '/Size/ {print $2}'
     mem_chk_re_str = [^\$]([0-9]+)
     mem_chk_cur_cmd = grep MemTotal /proc/meminfo
-    cpu_chk_cmd = ls /sys/devices/system/cpu | egrep -c "cpu[0-9]+$"
+    cpu_chk_cmd = grep -c processor /proc/cpuinfo
     # these config are used in utils_test.get_readable_cdroms()
     cdrom_get_cdrom_cmd = "ls /dev/cdrom*"
     cdrom_check_cdrom_pattern = "/dev/cdrom-\w+|/dev/cdrom\d*"

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1251,8 +1251,10 @@ class BaseVM(object):
         Get the cpu count of the VM.
         """
         session = self.wait_for_login()
+        cmd = self.params.get("cpu_chk_cmd")
         try:
-            return int(session.cmd(self.params.get("cpu_chk_cmd")))
+            out = session.cmd_output_safe(cmd)
+            return int(re.search("\d+", out, re.M).group())
         finally:
             session.close()
 


### PR DESCRIPTION
sometimes,  we got unprintable string in console output, convert a string to int will cause exception, so use regex to filter number string only.


Signed-off-by: Xu Tian <xutian@redhat.com>