### PR TITLE
virttest.utils_net: Add missing parameter for class TAPModuleError()

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -43,6 +43,7 @@ class TAPModuleError(NetError):
     def __init__(self, devname, action="open", details=None):
         NetError.__init__(self, devname)
         self.devname = devname
+        self.action = action
         self.details = details
 
     def __str__(self):


### PR DESCRIPTION
ID: 1241444