### PR TITLE
virt-test: unattended_install: keep the original image name when using iscsi.

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -578,6 +578,8 @@ def preprocess(test, params, env):
     base_dir = data_dir.get_data_dir()
     if params.get("storage_type") == "iscsi":
         iscsidev = qemu_storage.Iscsidev(params, base_dir, "iscsi")
+        image_name_origin = params["image_name"]
+        params["image_name_origin"] = image_name_origin
         params["image_name"] = iscsidev.setup()
         params["image_raw_device"] = "yes"
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -360,6 +360,8 @@ def run_image_copy(test, params, env):
 
     src = params.get('images_good')
     asset_name = '%s' % (os.path.split(params['image_name'])[1])
+    if params.get("storage_type") == "iscsi":
+        asset_name = '%s' % (os.path.split(params['image_name_origin'])[1])
     image = '%s.%s' % (params['image_name'], params['image_format'])
     dst_path = storage.get_image_filename(params, data_dir.get_data_dir())
     image_dir = os.path.dirname(dst_path)


### PR DESCRIPTION
For iscsi, the image_name is /dev/sdb, but it needs the original
image name when installation failed, which needs copy the corresponding
image from nfs, e.g. rhel71-64-virtio.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1223303