### PR TITLE
virttest/virt_vm.py: Adjust timing to get mac list

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -634,9 +634,6 @@ class BaseVM(object):
         :raise VMAddressVerificationError: If the MAC-IP address mapping cannot
                 be verified (using arping)
         """
-        # Make sure the IP address is assigned to one or more macs
-        # for this guest
-        macs = self.virtnet.mac_list()
         nic = self.virtnet[index]
         self.ip_version = self.params.get("ip_version", "ipv4").lower()
         # TODO: Determine port redirection in use w/o checking nettype
@@ -652,6 +649,8 @@ class BaseVM(object):
         if self.ip_version == "ipv4":
             # Get the IP address from arp cache
             arp_ip = self.address_cache.get(nic.mac.lower())
+            # Make sure IP is assigned to one or more macs for this guest
+            macs = self.virtnet.mac_list()
             if not arp_ip:
                 arp_ip = self.address_cache.get(nic.mac.upper())
             if (not arp_ip or


### PR DESCRIPTION
The fef5c4c move mac_list() to the beginning of get_address(),
which leads to verification of arping result failed until
the timeout to zero.

The reason as following,
The self.virtnet of VM is created by VirtNet.__init__,
and the self.virtnet.mac isn't set any value.
So it's better to obtain the mac list after checking the
existence of this attribute by nic.has_key('mac').