### PR TITLE
Disable ppc e1000

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -3,14 +3,19 @@
 # NICs
 variants:
     - rtl8139:
+        no ppc64 ppc64le
         nic_model = rtl8139
     - e1000:
+        no ppc64 ppc64le
         nic_model = e1000
     - e1000-82540em:
+        no ppc64 ppc64le
         nic_model = e1000-82540em
     - e1000-82544gc:
+        no ppc64 ppc64le
         nic_model = e1000-82544gc
     - e1000-82545em:
+        no ppc64 ppc64le
         nic_model = e1000-82545em
     - virtio_net:
         nic_model = virtio


### PR DESCRIPTION
e1000 & rtl8139 is not support in ppc 
this patch is to disable them on power platform

ID: 1247467