### PR TITLE
virt-test: remove display configuration

### DIFF
--- a/backends/libguestfs/cfg/tests.cfg
+++ b/backends/libguestfs/cfg/tests.cfg
@@ -44,7 +44,6 @@ variants:
         only bridge
         no multi_host
         only (subtest=guestfs_list_operations)
-        only vnc
         #only (subtest=type_specific)
 
 
@@ -64,6 +63,5 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
 
 only libguestfs_runner

--- a/backends/libvirt/cfg/tests.cfg
+++ b/backends/libvirt/cfg/tests.cfg
@@ -21,6 +21,5 @@ variants:
         only smallpages
         only default_bios
         only bridge
-        only vnc
 
 only libvirt_quick

--- a/backends/openvswitch/cfg/tests.cfg
+++ b/backends/openvswitch/cfg/tests.cfg
@@ -18,7 +18,6 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
         #only ovs_basic.vlan_ping
 
 
@@ -36,6 +35,5 @@ variants:
         only (image_backend=filesystem)
         only default_bios
         only bridge
-        only vnc
 
 only openvswitch_runner

--- a/backends/qemu/cfg/tests.cfg
+++ b/backends/qemu/cfg/tests.cfg
@@ -11,6 +11,5 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
 
 only qemu_kvm_jeos_quick

--- a/backends/v2v/cfg/tests.cfg
+++ b/backends/v2v/cfg/tests.cfg
@@ -46,6 +46,5 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
  
 only v2v_all

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -358,22 +358,3 @@ variants:
     - network:
         nettype = network
 
-# Display
-variants:
-    - spice:
-        display = spice
-        vga = qxl
-    - @vnc:
-        display = vnc
-        Linux:
-            vga = cirrus
-        Windows:
-            vga = std
-            WinXP, Win2003:
-                vga = cirrus
-    - sdl:
-        display = sdl
-        vga = cirrus
-    - nographic:
-        display = nographic
-        vga =


### PR DESCRIPTION
display variants in commit 727ebae broken testing in ARM and PPC
testing, so remove this part of configuration.

Signed-off-by: Xu Tian <xutian@redhat.com>