### PR TITLE
virttest.virsh: Bug fix for event()/qemu_monitor_event()

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -4094,7 +4094,7 @@ def qemu_monitor_event(domain=None, event=None, event_timeout=None,
     if event:
         cmd += " --event %s" % event
     if event_timeout:
-        cmd += " --timeout %s" % event
+        cmd += " --timeout %s" % event_timeout
     return command(cmd, **dargs)
 
 
@@ -4137,5 +4137,5 @@ def event(domain=None, event=None, event_timeout=None, options="", **dargs):
     if event:
         cmd += " --event %s" % event
     if event_timeout:
-        cmd += " --timeout %s" % event
+        cmd += " --timeout %s" % event_timeout
     return command(cmd, **dargs)


### PR DESCRIPTION
In qemu_monitor_event() function, the parameter of timeout should be 
event_timeout, not event.
event() function has the same problem.