### PR TITLE
USB type device passthrough using add_hostdev within virt test

### DIFF
--- a/virttest/libvirt_xml/devices/hostdev.py
+++ b/virttest/libvirt_xml/devices/hostdev.py
@@ -36,13 +36,35 @@ class Hostdev(base.TypedDeviceBase):
         new_one.untyped_address = new_address
         return new_one
 
+    def new_sourceusb_address(self, **dargs):
+        new_one = self.SourceAddress(virsh_instance=self.virsh)
+        new_vendoraddress = new_one.new_untyped_vendor(**dargs)
+        new_productaddress = new_one.new_untyped_product(**dargs)
+	new_usbaddress = new_one.new_untyped_usbaddress(**dargs)
+        new_one.untyped_vendor = new_vendoraddress
+	new_one.untyped_product = new_productaddress
+	new_one.untyped_usbaddress = new_usbaddress
+        return new_one 
+
     class SourceAddress(base.base.LibvirtXMLBase):
 
-        __slots__ = ('untyped_address',)
+        __slots__ = ('untyped_address','untyped_vendor','untyped_product','untyped_usbaddress',)
 
         def __init__(self, virsh_instance=base.base.virsh):
             accessors.XMLElementNest('untyped_address', self, parent_xpath='/',
                                      tag_name='address', subclass=self.UntypedAddress,
+                                     subclass_dargs={
+                                         'virsh_instance': virsh_instance})
+            accessors.XMLElementNest('untyped_vendor', self, parent_xpath='/',
+                                     tag_name='vendor', subclass=self.UntypedVendor,
+                                     subclass_dargs={
+                                         'virsh_instance': virsh_instance})
+            accessors.XMLElementNest('untyped_product', self, parent_xpath='/',
+                                     tag_name='product', subclass=self.UntypedProduct,
+                                     subclass_dargs={
+                                         'virsh_instance': virsh_instance})
+            accessors.XMLElementNest('untyped_usbaddress', self, parent_xpath='/',
+                                     tag_name='address', subclass=self.UntypedusbAddress,
                                      subclass_dargs={
                                          'virsh_instance': virsh_instance})
             super(self.__class__, self).__init__(virsh_instance=virsh_instance)
@@ -69,3 +91,59 @@ class Hostdev(base.TypedDeviceBase):
                                        tag_name='address', attribute='function')
                 super(self.__class__, self).__init__("address", virsh_instance=virsh_instance)
                 self.xml = "<address/>"
+
+        def new_untyped_usbaddress(self, **dargs):
+            new_one = self.UntypedusbAddress(virsh_instance=self.virsh)
+	    keys = dargs.keys()
+            setattr(new_one, keys[1], dargs.get('bus'))
+	    setattr(new_one, keys[0],dargs.get('device'))
+            return new_one
+
+        class UntypedusbAddress(base.UntypedDeviceBase):
+
+            __slots__ = ('bus', 'device')
+
+            def __init__(self, virsh_instance=base.base.virsh):
+                accessors.XMLAttribute('bus', self, parent_xpath='/',
+                                       tag_name='address', attribute='bus')
+                accessors.XMLAttribute('device', self, parent_xpath='/',
+                                       tag_name='address', attribute='device')
+
+                super(self.__class__, self).__init__("address", virsh_instance=virsh_instance)
+                self.xml = "<address/>"
+
+        def new_untyped_vendor(self, **dargs):
+            new_one = self.UntypedVendor(virsh_instance=self.virsh)
+	    keys = dargs.keys()
+            setattr(new_one,keys[2], dargs.get('vendor_id'))
+            return new_one
+
+        class UntypedVendor(base.UntypedDeviceBase):
+
+            __slots__ = ('id','vendor_id')
+
+            def __init__(self, virsh_instance=base.base.virsh):
+                accessors.XMLAttribute('vendor_id', self, parent_xpath='/',
+                                       tag_name='vendor', attribute='id')
+
+                super(self.__class__, self).__init__("vendor", virsh_instance=virsh_instance)
+                self.xml = "<vendor/>"
+
+
+        def new_untyped_product(self, **dargs):
+            new_one = self.UntypedProduct(virsh_instance=self.virsh)
+	    keys = dargs.keys()
+            setattr(new_one, keys[3], dargs.get('product_id'))
+            return new_one
+
+        class UntypedProduct(base.UntypedDeviceBase):
+
+            __slots__ = ('id','product_id')
+
+            def __init__(self, virsh_instance=base.base.virsh):
+                accessors.XMLAttribute('product_id', self, parent_xpath='/',
+                                       tag_name='product', attribute='id')
+
+                super(self.__class__, self).__init__("product", virsh_instance=virsh_instance)
+                self.xml = "<product/>"
+

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1250,7 +1250,10 @@ class VMXML(VMXMLBase):
         dev.managed = managed
         if boot_order:
             dev.boot_order = boot_order
-        dev.source_address = dev.new_source_address(**source_address)
+        if hostdev_type=='usb':
+            dev.source_address = dev.new_sourceusb_address(**source_address)
+        else:
+            dev.source_address = dev.new_source_address(**source_address)
         self.add_device(dev)
 
     @staticmethod


### PR DESCRIPTION
Currently hostdev addition supported adding only pci type device for 
passthrough. This commit has added capability to within virt test 
framework to generate a hostdev xml section for USB device passthrough. 
Guest VM xml add hostdev will now be able accept USB specific parameters 
and add respective xml clause to guest VM accordingly.