### PR TITLE
virttest.qemu_vm: add workaround for ppc console issue

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -15,8 +15,8 @@
         kernel_params += " nicdelay=60 "
         aarch64:
             kernel_params += " efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
-        ppc64:
-            kernel_params += " console=hvc0"
+        ppc64, ppc64le:
+            kernel_params += " console=hvc0,38400 console=tty0"
         x86_64, i386:
             kernel_params += " console=ttyS0,115200 console=tty0"
         boot_path = images/pxeboot

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -440,6 +440,9 @@ class VM(virt_vm.BaseVM):
                 cmd += " -device isa-serial"
             elif 'ppc' in arch.ARCH:
                 cmd += " -device spapr-vty"
+                # Workaround for console issue, details:
+                #   lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html
+                cmd += _add_option("reg", "0x30000000")
             cmd += _add_option("chardev", serial_id)
             return cmd
 


### PR DESCRIPTION
For old kernels (< 3.1), here is a console issue - if the very last
byte of the spapr-vty's "reg" property is not equal to zero, then it
will not appeared as 'hvc0' which is expected. So made a workaround
here to slove this problem. Details:
    http://lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html