### PR TITLE
iscsi: avoid aggressive clearconfig

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -746,8 +746,8 @@ class IscsiLIO(_IscsiComm):
             del_cmd = "targetcli /iscsi delete %s" % self.target
             utils.system(del_cmd)
 
-        # Clear all configuration to avoid restoring
-        cmd = "targetcli clearconfig confirm=True"
+        # Save deleted configuration to avoid restoring
+        cmd = "targetcli / saveconfig"
         utils.system(cmd)
 
 


### PR DESCRIPTION
As multiple iscsi target could be created, use clearconfig to clear
entire local configuration will cause problem, so after each delete
use saveconfig will be safer.

Signed-off-by: Wayne Sun <gsun@redhat.com>