### PR TITLE
Fix skip message for TestFail()

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -554,7 +554,7 @@ class IscsiLIO(_IscsiComm):
                     % (self.target, self.target.split(":")[0]))
         output = utils.system_output(acls_cmd)
         if "Created Node ACL" not in output:
-            raise error.TestFail("Failed to create ACL. (%s)", output)
+            raise error.TestFail("Failed to create ACL. (%s)" % output)
 
         comm_cmd = ("targetcli /iscsi/%s/tpg1/acls/%s:client/"
                     % (self.target, self.target.split(":")[0]))
@@ -562,13 +562,13 @@ class IscsiLIO(_IscsiComm):
         userid_cmd = "%s set auth userid=%s" % (comm_cmd, self.chap_user)
         output = utils.system_output(userid_cmd)
         if self.chap_user not in output:
-            raise error.TestFail("Failed to set user. (%s)", output)
+            raise error.TestFail("Failed to set user. (%s)" % output)
 
         # Set password
         passwd_cmd = "%s set auth password=%s" % (comm_cmd, self.chap_passwd)
         output = utils.system_output(passwd_cmd)
         if self.chap_passwd not in output:
-            raise error.TestFail("Failed to set password. (%s)", output)
+            raise error.TestFail("Failed to set password. (%s)" % output)
 
         # Save configuration
         utils.system("targetcli / saveconfig")
@@ -590,13 +590,13 @@ class IscsiLIO(_IscsiComm):
         userid_cmd = "%s set auth userid=%s" % (auth_cmd, self.chap_user)
         output = utils.system_output(userid_cmd)
         if self.chap_user not in output:
-            raise error.TestFail("Failed to set user. (%s)", output)
+            raise error.TestFail("Failed to set user. (%s)" % output)
 
         # Set password
         passwd_cmd = "%s set auth password=%s" % (auth_cmd, self.chap_passwd)
         output = utils.system_output(passwd_cmd)
         if self.chap_passwd not in output:
-            raise error.TestFail("Failed to set password. (%s)", output)
+            raise error.TestFail("Failed to set password. (%s)" % output)
 
         # Save configuration
         utils.system("targetcli / saveconfig")
@@ -645,15 +645,15 @@ class IscsiLIO(_IscsiComm):
                           (self.device, self.emulated_image))
             output = utils.system_output(device_cmd)
             if "Created fileio" not in output:
-                raise error.TestFail("Failed to create fileio %s. (%s)",
-                                     self.device, output)
+                raise error.TestFail("Failed to create fileio %s. (%s)"
+                                     % (self.device, output))
 
             # Create an IQN with a target named target_name
             target_cmd = "targetcli /iscsi/ create %s" % self.target
             output = utils.system_output(target_cmd)
             if "Created target" not in output:
-                raise error.TestFail("Failed to create target %s. (%s)",
-                                     self.target, output)
+                raise error.TestFail("Failed to create target %s. (%s)"
+                                     % (self.target, output))
 
             check_portal = "targetcli /iscsi/%s/tpg1/portals ls" % self.target
             portal_info = utils.system_output(check_portal)
@@ -665,8 +665,8 @@ class IscsiLIO(_IscsiComm):
                               % (self.target, "0.0.0.0"))
                 output = utils.system_output(portal_cmd)
                 if "Created network portal" not in output:
-                    raise error.TestFail("Failed to create portal. (%s)",
-                                         output)
+                    raise error.TestFail("Failed to create portal. (%s)"
+                                         % output)
             if ("ipv6" == utils_net.IPAddress(self.portal_ip).version and
                     self.portal_ip not in portal_info):
                 # Ipv6 portal address can't be created by default,
@@ -675,16 +675,15 @@ class IscsiLIO(_IscsiComm):
                               % (self.target, self.portal_ip))
                 output = utils.system_output(portal_cmd)
                 if "Created network portal" not in output:
-                    raise error.TestFail("Failed to create portal. (%s)",
-                                         output)
+                    raise error.TestFail("Failed to create portal. (%s)"
+                                         % output)
 
             # Create lun
             lun_cmd = "targetcli /iscsi/%s/tpg1/luns/ " % self.target
             dev_cmd = "create /backstores/fileio/%s" % self.device
             output = utils.system_output(lun_cmd + dev_cmd)
             if "Created LUN" not in output:
-                raise error.TestFail("Failed to create lun. (%s)",
-                                     output)
+                raise error.TestFail("Failed to create lun. (%s)" % output)
 
             # Set firewall if it's enabled
             output = utils.system_output("firewall-cmd --state",

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -290,17 +290,17 @@ class NFSClient(object):
         try:
             utils.system(umount_cmd, verbose=True)
         except error.CmdError:
-            raise error.TestFail("Failed to run: %s", umount_cmd)
+            raise error.TestFail("Failed to run: %s" % umount_cmd)
 
         if self.mkdir_mount_remote:
             rmdir_cmd = ssh_cmd + "'rm -rf %s'" % self.mount_dir
             try:
                 utils.system(rmdir_cmd, verbose=True)
             except error.CmdError:
-                raise error.TestFail("Failed to run: %s", rmdir_cmd)
+                raise error.TestFail("Failed to run: %s" % rmdir_cmd)
 
         if self.is_mounted():
-            raise error.TestFail("Failed to umount %s", self.mount_dir)
+            raise error.TestFail("Failed to umount %s" % self.mount_dir)
 
         # Recover SSH connection
         self.ssh_obj.auto_recover = True
@@ -319,7 +319,7 @@ class NFSClient(object):
             logging.debug("Prepare to create %s", self.mount_dir)
             s, o = commands.getstatusoutput(mkdir_cmd)
             if s != 0:
-                raise error.TestFail("Failed to run %s: %s", mkdir_cmd, o)
+                raise error.TestFail("Failed to run %s: %s" % (mkdir_cmd, o))
             self.mkdir_mount_remote = True
 
         self.mount_src = "%s:%s" % (self.nfs_server_ip, self.mount_src)
@@ -330,9 +330,9 @@ class NFSClient(object):
         try:
             utils.system(mount_cmd, verbose=True)
         except error.CmdError:
-            raise error.TestFail("Failed to run: %s", mount_cmd)
+            raise error.TestFail("Failed to run: %s" % mount_cmd)
 
         # Check if the sharing directory is mounted
         if not self.is_mounted():
-            raise error.TestFail("Failed to mount from %s to %s",
-                                 self.mount_src, self.mount_dir)
+            raise error.TestFail("Failed to mount from %s to %s"
+                                 % (self.mount_src, self.mount_dir))

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1856,8 +1856,8 @@ class IPv6Manager(propcan.PropCanBase):
         # flush local ip6tables rules
         result = utils.run(flush_cmd, ignore_status=True)
         if result.exit_status:
-            raise error.TestFail("%s on local host:%s",
-                                 test_fail_err, result.stderr)
+            raise error.TestFail("%s on local host:%s"
+                                 % (test_fail_err, result.stderr))
         else:
             logging.info("%s on the local host", flush_cmd_pass)
 
@@ -1866,7 +1866,7 @@ class IPv6Manager(propcan.PropCanBase):
             raise error.TestNAError(test_NA_err)
         # flush remote ip6tables rules
         if self.session.cmd_status(flush_cmd):
-            raise error.TestFail("%s on the remote host", test_fail_err)
+            raise error.TestFail("%s on the remote host" % test_fail_err)
         else:
             logging.info("%s on the remote host", flush_cmd_pass)
 
@@ -3088,7 +3088,7 @@ def check_listening_port_by_service(service, port, listen_addr='0.0.0.0',
         logging.error("Failed to run command '%s'", cmd)
 
     if not re.search(find_str, output, re.M):
-        raise error.TestFail("Failed to listen %s: %s", find_str, output)
+        raise error.TestFail("Failed to listen %s: %s" % (find_str, output))
     logging.info("The listening is active: %s", output)
 
 

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1034,7 +1034,7 @@ class PoolVolumeTest(object):
         if not pv.create_volume(vol_name, capacity, allocation, vol_format):
             raise error.TestFail("Prepare volume failed.")
         if not pv.volume_exists(vol_name):
-            raise error.TestFail("Can't find volume: %s", vol_name)
+            raise error.TestFail("Can't find volume: %s" % vol_name)
 
 
 ##########Migration Relative functions##############


### PR DESCRIPTION
In order to display message to users correctly,
The exception message has to use interpolation.
This PR refers to the commit beacb9d.

Signed-off-by: Wei,Jiangang <weijg.fnst@cn.fujitsu.com>