### PR TITLE
virt-test: base.cfg: some updates for usb cfg.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -85,7 +85,6 @@ cdroms = cd1
 usbs = usb1
 # USB controller type, run following command to see supported controller.
 # `qemu-kvm -device \? 2>&1 | grep "usb.*bus PCI"`
-usb_type = ich9-usb-uhci1
 usb_type_usb1 = ich9-usb-uhci1
 # Max ports on a controller.
 usb_max_port = 2
@@ -96,7 +95,7 @@ usb_devices = tablet1
 # `qemu-kvm -device \? 2>&1 | grep "bus USB"`
 usb_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
-usb_controller_tablet1 = uhci
+usb_controller = uhci
 
 # Serial port support
 # You can assign more than one serial to guest with this parameter.


### PR DESCRIPTION
1. remove "usb_type = ich9-usb-uhci1" which is useless,
as "usb_type_usb1 = ich9-usb-uhci1" has defined the usb type.

2. set "usb_controller = uhci" which can add more devices.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1183906