### PR TITLE
virttest.utils_misc: Report out of memory error in verify_host_dmesg()

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2839,6 +2839,7 @@ def verify_host_dmesg(dmesg_log_file=None, trace_re=None):
     panic_re = [r"BUG:.*---\[ end trace .* \]---"]
     panic_re.append(r"----------\[ cut here.* BUG .*\[ end trace .* \]---")
     panic_re.append(r"general protection fault:.* RSP.*>")
+    panic_re.append(r"kernel: Out of memory: Kill process .*")
     panic_re = "|".join(panic_re)
     dmesg = utils.system_output("dmesg", timeout=30, ignore_status=True)
     if dmesg:


### PR DESCRIPTION
Find the out of memory log in host dmesg log.

Signed-off-by: Shuping Cui scui@redhat.com

ID: 1229090
