### PR TITLE
virt-test: base.cfg: set ehci as default usb controller in CML.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -85,10 +85,10 @@ cdroms = cd1
 usbs = usb1
 # USB controller type, run following command to see supported controller.
 # `qemu-kvm -device \? 2>&1 | grep "usb.*bus PCI"`
-usb_type = ich9-usb-uhci1
-usb_type_usb1 = ich9-usb-uhci1
+usb_type = ich9-usb-ehci1
+usb_type_usb1 = ich9-usb-ehci1
 # Max ports on a controller.
-usb_max_port = 2
+usb_max_port = 6
 
 # USB device object names (whitespace separated)
 usb_devices = tablet1
@@ -96,7 +96,8 @@ usb_devices = tablet1
 # `qemu-kvm -device \? 2>&1 | grep "bus USB"`
 usb_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
-usb_controller_tablet1 = uhci
+usb_controller = ehci
+usb_bus = usb1.0
 
 # Serial port support
 # You can assign more than one serial to guest with this parameter.


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1183906