### PR TITLE
Enable Mellanox Connectx PCI SR-IOV [initialization,assignment,cleanup] for IBM PowerKVM

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -3,14 +3,19 @@
 # NICs
 variants:
     - rtl8139:
+        no ppc64 ppc64le
         nic_model = rtl8139
     - e1000:
+        no ppc64 ppc64le
         nic_model = e1000
     - e1000-82540em:
+        no ppc64 ppc64le
         nic_model = e1000-82540em
     - e1000-82544gc:
+        no ppc64 ppc64le
         nic_model = e1000-82544gc
     - e1000-82545em:
+        no ppc64 ppc64le
         nic_model = e1000-82545em
     - virtio_net:
         nic_model = virtio
@@ -159,14 +164,23 @@ variants:
         # As of today (30-11-2009), we have 2 drivers for this type of hardware:
         # Intel® 82576 Gigabit Ethernet Controller - igb
         # Neterion® X3100™ - vxge
+        # As of today (26-08-2015), we have Mellanox Connectx-3EN and
+        # Connectx-Pro SRIOV support on Power KVM (ppc64le) 3.1 host using 
+        # mlx4_core as the device driver. so driver can be either igb/mlx4_core.
         driver = igb
         # vf_filter_re: Regex used to filter vf from lspci.
         vf_filter_re = "Virtual Function"
         # pf_filter_re: Regex used to filter pf from lspci. It will be used
         # when device_name could not filter the pf.
+        # In case of Power KVM 3.1 (ppc64le) platform pf_filter_re value for
+        # Mellanox SR-IOV support is as below
+        # pf_filter_re = "Mellanox Technologies MT27520 Family"
         pf_filter_re = "82576 Gigabit Network"
         # Driver option to specify the maximum number of virtual functions
         # (on vxge the option is , for example, is max_config_dev)
+        # (for mlx4_core the option is, for example, num_vfs and probe_vf
+        # driver_option = "num_vfs=7 probe_vf=7", to get VF PCIs probed on host
+        # we should be using probe_vf option)
         # the default below is for the igb driver
         driver_option = "max_vfs=7"
         mac_ip_filter = "inet (.\d+.\d+.\d+.\d+).*?ether (.\w+:\w+:\w+:\w+:\w+:\w+)"
@@ -175,6 +189,13 @@ variants:
         mac_changeable = "yes"
         unattended_install:
             mac_changeable = no
+        # Options for mlx4_core, which is driver for Mellanox SR-IOV cards on
+        # Power(ppc64le) servers:
+        # sr-iov.sr_iov_negative.negative_max_vfs:
+        #    driver_option = "num_vfs=-1"
+        # sr-iov.sr_iov_negative.more_than_max_vfs:
+        #    driver_option = "num_vfs=17"
+        # the default below is for the igb driver
         sr-iov.sr_iov_negative.negative_max_vfs:
             driver_option = "max_vfs=-1"
         sr-iov.sr_iov_negative.more_than_max_vfs:
@@ -357,4 +378,3 @@ variants:
         nettype = user
     - network:
         nettype = network
-


### PR DESCRIPTION
IBM PowerKVM v3.1 (ppc64le) will have support for SR-IOV on Mellanox Connect-x
PCI Cards. Currently virt-test test setup supports setup, assign and clean-up
of SR-IOV virtual functions on x86 environment. This patch will enable SR-IOV
test setup on IBM PowerKVM v3.1 (ppc64le). Existing SR-IOV sanity test cases
under qemu can now run on IBM PowerKVM environment. Sample parameter values
have also been updated in respective configuration file.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>