### PR TITLE
Added default value for the attribute "priority"

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1754,7 +1754,7 @@ def create_nwfilter_xml(params):
         for i in range(len(rule_dict.keys())):
             rulexml.rule_action = rule_dict[i].get('rule_action')
             rulexml.rule_direction = rule_dict[i].get('rule_direction')
-            rulexml.rule_priority = rule_dict[i].get('rule_priority')
+            rulexml.rule_priority = rule_dict[i].get('rule_priority', 0)
             rulexml.rule_statematch = rule_dict[i].get('rule_statematch')
             for j in RULE_ATTR:
                 if j in rule_dict[i].keys():


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Description: The attribute "priority" expects an Integer value to be assigned. When there is nothing provided, it will have the value as None and results in test failures. Hence, modified the default value to 0 instead of None